### PR TITLE
Remove references to jb/remove-builder branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
  "bodyparser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_net 0.0.0",
@@ -173,7 +173,7 @@ dependencies = [
  "persistent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "github-api-client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder#6136c7991a0446027c6cf51036257c13d99cca63"
+source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "frank_jwt 2.5.1 (git+https://github.com/habitat-sh/frank_jwt?branch=habitat)",
@@ -672,7 +672,7 @@ dependencies = [
  "hyper-openssl 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -683,6 +683,22 @@ dependencies = [
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "habitat-builder-protocol"
+version = "0.0.0"
+source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "habitat-builder-protocol"
@@ -709,7 +725,7 @@ dependencies = [
  "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.181 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_net 0.0.0",
@@ -742,11 +758,11 @@ dependencies = [
  "clippy 0.0.181 (registry+https://github.com/rust-lang/crates.io-index)",
  "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_depot 0.0.0",
- "habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat_net 0.0.0",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -758,7 +774,7 @@ dependencies = [
  "persistent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -909,7 +925,7 @@ dependencies = [
  "diesel 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)",
  "habitat_builder_db 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -939,10 +955,10 @@ dependencies = [
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
- "habitat_depot_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "habitat_depot_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat_net 0.0.0",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -993,6 +1009,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "habitat_core"
+version = "0.0.0"
+source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
+dependencies = [
+ "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsodium-sys 0.0.16 (git+https://github.com/dnaq/sodiumoxide)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sodiumoxide 0.0.16 (git+https://github.com/dnaq/sodiumoxide)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "habitat_depot"
 version = "0.0.0"
 dependencies = [
@@ -1003,7 +1054,7 @@ dependencies = [
  "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.181 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_net 0.0.0",
@@ -1020,7 +1071,7 @@ dependencies = [
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1037,19 +1088,19 @@ dependencies = [
 [[package]]
 name = "habitat_depot_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder#6136c7991a0446027c6cf51036257c13d99cca63"
+source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
 dependencies = [
  "broadcast 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)",
- "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
- "habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1060,15 +1111,15 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder#6136c7991a0446027c6cf51036257c13d99cca63"
+source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
+ "habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.9.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1098,6 +1149,17 @@ dependencies = [
 name = "habitat_win_users"
 version = "0.0.0"
 source = "git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder#6136c7991a0446027c6cf51036257c13d99cca63"
+dependencies = [
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_win_users"
+version = "0.0.0"
+source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2108,7 +2170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "segment-api-client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder#6136c7991a0446027c6cf51036257c13d99cca63"
+source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2814,12 +2876,15 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum git2 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ee5b4bb7cd2a44e6e5ee3a26ba6a9ca10d4ce2771cdc3839bbc54b47b7d1be84"
-"checksum github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)" = "<none>"
+"checksum github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)" = "<none>"
 "checksum habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)" = "<none>"
-"checksum habitat_depot_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)" = "<none>"
-"checksum habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)" = "<none>"
+"checksum habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
+"checksum habitat_depot_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
+"checksum habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
+"checksum habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)" = "<none>"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"
@@ -2932,7 +2997,7 @@ dependencies = [
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a2ff3fc5223829be817806c6441279c676e454cc7da608faf03b0ccc09d3889"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
-"checksum segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)" = "<none>"
+"checksum segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum sequence_trie 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "32157204e5c9d3c04007bd7e56e96e987635ce0e8e23c085b1e403861b76c351"

--- a/components/builder-admin/Cargo.toml
+++ b/components/builder-admin/Cargo.toml
@@ -37,7 +37,6 @@ urlencoded = { version = "*", git = "https://github.com/iron/urlencoded" }
 
 [dependencies.github-api-client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -47,11 +47,9 @@ branch = "release/v0.8"
 
 [dependencies.github-api-client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.segment-api-client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"
@@ -64,7 +62,6 @@ path = "../builder-depot"
 
 [dependencies.habitat_http_client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.habitat_net]
 path = "../net"

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -45,11 +45,9 @@ path = "../builder-core"
 
 [dependencies.github-api-client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.segment-api-client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/builder-http-gateway/Cargo.toml
+++ b/components/builder-http-gateway/Cargo.toml
@@ -38,11 +38,9 @@ branch = "release/v0.8"
 
 [dependencies.github-api-client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.segment-api-client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -36,7 +36,6 @@ features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.github-api-client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -40,7 +40,6 @@ branch = "release/v0.8"
 
 [dependencies.github-api-client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"
@@ -53,4 +52,3 @@ path = "../net"
 
 [dependencies.habitat_depot_client]
 git = "https://github.com/habitat-sh/habitat.git"
-branch = "jb/remove-builder"


### PR DESCRIPTION
Merge this _after_ https://github.com/habitat-sh/habitat/pull/4452 merges to point git refs to the `master` branch.

![tenor-238446606](https://user-images.githubusercontent.com/947/35296182-14c1ed72-0030-11e8-8448-9a5f2da5ca44.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>