### PR TITLE
Update cargo lock to fix dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "github-api-client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
+source = "git+https://github.com/habitat-sh/habitat.git#6e4a72e5cbfe60ec7f587a20379469791c584959"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "frank_jwt 2.5.1 (git+https://github.com/habitat-sh/frank_jwt?branch=habitat)",
@@ -672,7 +672,7 @@ dependencies = [
  "hyper-openssl 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -683,22 +683,6 @@ dependencies = [
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "habitat-builder-protocol"
-version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "habitat-builder-protocol"
@@ -976,7 +960,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#77171f0892d27e3bcb396f3bd451ad19d4dd2a76"
+source = "git+https://github.com/habitat-sh/core.git#95932c9058f248f915842e3874b29356b2ad4d9c"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -984,55 +968,20 @@ dependencies = [
  "ctrlc 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)",
+ "habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsodium-sys 0.0.16 (git+https://github.com/dnaq/sodiumoxide)",
+ "libsodium-sys 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sodiumoxide 0.0.16 (git+https://github.com/dnaq/sodiumoxide)",
- "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "users 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "habitat_core"
-version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
-dependencies = [
- "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ctrlc 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
- "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsodium-sys 0.0.16 (git+https://github.com/dnaq/sodiumoxide)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sodiumoxide 0.0.16 (git+https://github.com/dnaq/sodiumoxide)",
+ "sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1088,19 +1037,19 @@ dependencies = [
 [[package]]
 name = "habitat_depot_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
+source = "git+https://github.com/habitat-sh/habitat.git#6e4a72e5cbfe60ec7f587a20379469791c584959"
 dependencies = [
  "broadcast 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
- "habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)",
+ "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1111,15 +1060,15 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
+source = "git+https://github.com/habitat-sh/habitat.git#6e4a72e5cbfe60ec7f587a20379469791c584959"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1148,18 +1097,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder#6136c7991a0446027c6cf51036257c13d99cca63"
-dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "habitat_win_users"
-version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
+source = "git+https://github.com/habitat-sh/core.git#95932c9058f248f915842e3874b29356b2ad4d9c"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1401,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "libsodium-sys"
 version = "0.0.16"
-source = "git+https://github.com/dnaq/sodiumoxide#cbd6a17102f0d669447a188028f39ebb59e96f8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2170,7 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "segment-api-client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#6678d9a07aa29b4ccb2d375333a557c3a9533e4e"
+source = "git+https://github.com/habitat-sh/habitat.git#6e4a72e5cbfe60ec7f587a20379469791c584959"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2291,10 +2229,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sodiumoxide"
 version = "0.0.16"
-source = "git+https://github.com/dnaq/sodiumoxide#cbd6a17102f0d669447a188028f39ebb59e96f8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsodium-sys 0.0.16 (git+https://github.com/dnaq/sodiumoxide)",
+ "libsodium-sys 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2878,14 +2816,11 @@ dependencies = [
 "checksum git2 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ee5b4bb7cd2a44e6e5ee3a26ba6a9ca10d4ce2771cdc3839bbc54b47b7d1be84"
 "checksum github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)" = "<none>"
 "checksum habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)" = "<none>"
-"checksum habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum habitat_depot_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
-"checksum habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
-"checksum habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/habitat.git?branch=jb/remove-builder)" = "<none>"
+"checksum habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/core.git)" = "<none>"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"
 "checksum hmac 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a13f4163aa0c5ca1be584aace0e2212b2e41be5478218d4f657f5f778b2ae2a"
@@ -2912,7 +2847,7 @@ dependencies = [
 "checksum libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum libgit2-sys 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6eeae66e7b1c995de45cb4e65c5ab438a96a7b4077e448645d4048dc753ad357"
-"checksum libsodium-sys 0.0.16 (git+https://github.com/dnaq/sodiumoxide)" = "<none>"
+"checksum libsodium-sys 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fcbd1beeed8d44caa8a669ebaa697c313976e242c03cc9fb23d88bf1656f5542"
 "checksum libssh2-sys 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0db4ec23611747ef772db1c4d650f8bd762f07b461727ec998f953c614024b75"
 "checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
 "checksum linked-hash-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2aab0478615bb586559b0114d94dd8eca4fdbb73b443adcb0d00b61692b4bf"
@@ -3012,7 +2947,7 @@ dependencies = [
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
-"checksum sodiumoxide 0.0.16 (git+https://github.com/dnaq/sodiumoxide)" = "<none>"
+"checksum sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb5cb2f14f9a51352ad65e59257a0a9459d5a36a3615f3d53a974c82fdaaa00a"
 "checksum staticfile 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "babd3fa68bb7e3994ce181c5f21ff3ff5fffef7b18b8a10163b45e4dafc6fb86"
 "checksum statsd 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed7ee0d38d74a7e0a5e5d0503b663eeada0124caa1fc8b4940acbf9fa7563441"
 "checksum strcursor 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15439fa64cc809180c589577250af7d3a138f96ea6c267665d6afcc81a574060"


### PR DESCRIPTION
Update Cargo.lock (cargo update) to fix dependency failures - eg, for habitat_win_users

Note: Cargo update might have been more aggressive than we want and the openssl rev looks like it went backward, so this may not quite be what we want but it gets past the compile error.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-212604801](https://user-images.githubusercontent.com/13542112/35311215-4098e272-006a-11e8-980c-efd27729ea55.gif)
