### PR TITLE
Add version bump to git rev count since it's off after the builder migration

### DIFF
--- a/components/builder-admin-proxy/plan.sh
+++ b/components/builder-admin-proxy/plan.sh
@@ -17,7 +17,9 @@ pkg_binds=(
 pkg_exposes=(port)
 
 pkg_version() {
-  git rev-list master --count
+  # TED: After migrating the builder repo we needed to add to
+  # the rev-count to keep version sorting working
+  echo "$(($(git rev-list master --count) + 5000))"
 }
 
 do_before() {

--- a/components/builder-api-proxy/plan.sh
+++ b/components/builder-api-proxy/plan.sh
@@ -17,7 +17,9 @@ pkg_binds=(
 pkg_exposes=(port)
 
 pkg_version() {
-  git rev-list master --count
+  # TED: After migrating the builder repo we needed to add to
+  # the rev-count to keep version sorting working
+  echo "$(($(git rev-list master --count) + 5000))"
 }
 
 do_before() {

--- a/support/ci/builder-base-plan.sh
+++ b/support/ci/builder-base-plan.sh
@@ -1,7 +1,9 @@
 builder_build_type="--release"
 
 pkg_version() {
-  git rev-list master --count
+  # TED: After migrating the builder repo we needed to add to
+  # the rev-count to keep version sorting working
+  echo "$(($(git rev-list master --count) + 5000))"
 }
 
 do_before() {


### PR DESCRIPTION

![tenor-77877388](https://user-images.githubusercontent.com/1130349/35344231-387a06c4-00f2-11e8-9789-f257789ed203.gif)

Signed-off-by: Travis Elliott Davis <edavis@chef.io>