### PR TITLE
Add openssl to builder-api-proxy

### DIFF
--- a/components/builder-api-proxy/plan.sh
+++ b/components/builder-api-proxy/plan.sh
@@ -4,7 +4,16 @@ pkg_description="HTTP Proxy service fronting the Habitat Builder API service"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/nginx core/curl core/coreutils)
-pkg_build_deps=(core/node8 core/gcc core/git core/tar core/phantomjs core/python2 core/make)
+pkg_build_deps=(
+  core/node8
+  core/gcc
+  core/git
+  core/tar
+  core/phantomjs
+  core/python2
+  core/make
+  core/openssl
+)
 pkg_svc_user="root"
 pkg_svc_run="nginx -c ${pkg_svc_config_path}/nginx.conf"
 pkg_exports=(


### PR DESCRIPTION
Because we rely on the openssl executable for the build process.

Signed-off-by: Christian Nunciato <chris@nunciato.org>