### PR TITLE
Increase the repositories-per-page query

### DIFF
--- a/components/builder-web/app/client/github-api.ts
+++ b/components/builder-web/app/client/github-api.ts
@@ -172,7 +172,7 @@ export class GitHubApiClient {
 
   private getUserInstallationRepositories(installationId: string, page: number) {
     return new Promise((resolve, reject) => {
-      fetch(`${config['github_api_url']}/user/installations/${installationId}/repositories?access_token=${this.token}&page=${page}`, {
+      fetch(`${config['github_api_url']}/user/installations/${installationId}/repositories?access_token=${this.token}&page=${page}&per_page=100`, {
         method: 'GET',
         headers: {
           'Accept': [


### PR DESCRIPTION
Currently we query the GitHub API to determine the user’s list of connectable repositories. This increases that query’s per-page count from 30 (the default) to 100, which should reduce the overall number of requests we have to make to assemble the list (and thus help with rate-limiting issues).

Signed-off-by: Christian Nunciato <chris@nunciato.org>