### PR TITLE
Promote from package-detail views

### DIFF
--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -101,6 +101,7 @@ export {
 } from './origins';
 
 export {
+  CLEAR_CURRENT_PACKAGE_CHANNELS,
   CLEAR_LATEST_IN_CHANNEL,
   CLEAR_LATEST_PACKAGE,
   CLEAR_PACKAGE_VERSIONS,
@@ -109,10 +110,12 @@ export {
   fetchLatestInChannel,
   fetchLatestPackage,
   fetchPackage,
+  fetchPackageChannels,
   fetchPackageVersions,
   filterPackagesBy,
   getUniquePackages,
   POPULATE_DASHBOARD_RECENT,
+  SET_CURRENT_PACKAGE_CHANNELS,
   SET_CURRENT_PACKAGE_VERSIONS,
   SET_CURRENT_PACKAGE,
   SET_LATEST_IN_CHANNEL,

--- a/components/builder-web/app/client/depot-api.ts
+++ b/components/builder-web/app/client/depot-api.ts
@@ -176,6 +176,26 @@ export function get(params, nextRange: number = 0) {
   });
 }
 
+export function getPackageChannels(origin: string, name: string, version: string, release: string) {
+  const url = `${urlPrefix}/depot/pkgs/${origin}/${name}/${version}/${release}/channels`;
+
+  return new Promise((resolve, reject) => {
+    fetch(url, opts())
+      .then(response => handleUnauthorized(response, reject))
+      .then(response => {
+        if (response.status >= 400) {
+          reject(new Error(response.statusText));
+        }
+        else {
+          response.json().then(results => {
+            resolve(results);
+          });
+        }
+      })
+      .catch(error => handleError(error, reject));
+  });
+}
+
 export function getPackageVersions(origin: string, pkg: string) {
   const url = `${urlPrefix}/depot/pkgs/${origin}/${pkg}/versions`;
 

--- a/components/builder-web/app/initial-state.ts
+++ b/components/builder-web/app/initial-state.ts
@@ -103,6 +103,7 @@ export default Record({
   })(),
   packages: Record({
     current: Package(),
+    currentChannels: [],
     dashboard: Record({
       origin: undefined,
       recent: List()

--- a/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
@@ -9,8 +9,8 @@
       </hab-project-settings>
     </section>
     <section *ngIf="!selectingPlan">
-      <ul class="nav-list">
-        <li class="heading" *ngIf="projectsExist">
+      <ul class="nav-list" *ngIf="projectsExist">
+        <li class="heading">
           <h4>Connected Plans</h4>
         </li>
         <li class="item" *ngFor="let proj of projects">

--- a/components/builder-web/app/package/package-detail/package-detail.component.html
+++ b/components/builder-web/app/package/package-detail/package-detail.component.html
@@ -26,7 +26,15 @@
       <div>
         <dt>&nbsp;</dt>
         <dd>
-          <hab-channels [channels]="package.channels"></hab-channels>
+          <hab-channels [channels]="channels"></hab-channels>
+          <hab-package-promote
+            [origin]="package.ident.origin"
+            [name]="package.ident.name"
+            [version]="package.ident.version"
+            [release]="package.ident.release"
+            channel="stable"
+            *ngIf="promotable(package)">
+          </hab-package-promote>
         </dd>
       </div>
     </dl>

--- a/components/builder-web/app/package/package-detail/package-detail.component.spec.ts
+++ b/components/builder-web/app/package/package-detail/package-detail.component.spec.ts
@@ -13,15 +13,27 @@
 // limitations under the License.
 
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { Component, DebugElement } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
 import { Package } from '../../records/Package';
-import * as actions from '../../actions/index';
+import { AppStore } from '../../app.store';
 import { PackageDetailComponent } from './package-detail.component';
+
+class MockAppStore {
+  getState() {
+    return {
+      origins: {
+        mine: []
+      },
+      packages: {
+        currentChannels: []
+      }
+    };
+  }
+  dispatch() {}
+}
 
 class MockRoute {
   params = Observable.of({
@@ -43,8 +55,11 @@ describe('PackageDetailComponent', () => {
         MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] }),
         MockComponent({ selector: 'hab-channels', inputs: ['channels'] }),
         MockComponent({ selector: 'hab-package-list', inputs: ['currentPackage', 'packages'] }),
+        MockComponent({ selector: 'hab-package-promote', inputs: [ 'origin', 'name', 'version', 'release', 'channel' ] }),
         MockComponent({ selector: 'hab-copyable', inputs: ['text', 'style'] })
-      ]
+      ],
+      providers: [
+        { provide: AppStore, useClass: MockAppStore }]
     });
 
     fixture = TestBed.createComponent(PackageDetailComponent);

--- a/components/builder-web/app/package/package-detail/package-detail.component.ts
+++ b/components/builder-web/app/package/package-detail/package-detail.component.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { Component, Input } from '@angular/core';
+import { AppStore } from '../../app.store';
 import { releaseToDate } from '../../util';
 
 @Component({
@@ -20,10 +21,12 @@ import { releaseToDate } from '../../util';
   template: require('./package-detail.component.html')
 })
 export class PackageDetailComponent {
-  @Input() package: object;
+  @Input() package: any;
 
-  releaseToDate(release) {
-    return releaseToDate(release);
+  constructor(private store: AppStore) {}
+
+  get channels() {
+    return this.store.getState().packages.currentChannels;
   }
 
   get fullName() {
@@ -37,5 +40,21 @@ export class PackageDetailComponent {
     });
 
     return props.join('/');
+  }
+
+  get memberOfOrigin() {
+    return !!this.store.getState().origins.mine.find(
+      origin => origin['name'] === this.package.ident.origin
+    );
+  }
+
+  promotable(pkg) {
+    return this.memberOfOrigin &&
+      this.channels.length > 0 &&
+      this.channels.indexOf('stable') === -1;
+  }
+
+  releaseToDate(release) {
+    return releaseToDate(release);
   }
 }

--- a/components/builder-web/app/package/package-promote/_package-promote.component.scss
+++ b/components/builder-web/app/package/package-promote/_package-promote.component.scss
@@ -1,13 +1,20 @@
 .package-promote-component {
+  @include transition(border box-shadow);
   font-size: $smaller-font-size;
   font-weight: 600;
   border-radius: 11px;
   color: $hab-blue;
   padding: 2px 8px 4px 8px;
+  border: 1px solid transparent;
   cursor: pointer;
 
-  span {
+  > span {
     white-space: nowrap;
+
+    > hab-icon {
+      @include icon-size(14);
+      margin: 0;
+    }
   }
 
   &:hover {

--- a/components/builder-web/app/package/package-release/package-release.component.ts
+++ b/components/builder-web/app/package/package-release/package-release.component.ts
@@ -18,6 +18,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 import { AppStore } from '../../app.store';
 import { fetchPackage } from '../../actions/index';
+import { fetchPackageChannels } from '../../actions/packages';
 
 @Component({
   template: require('./package-release.component.html')
@@ -67,5 +68,8 @@ export class PackageReleaseComponent implements OnDestroy {
 
   private fetchRelease() {
     this.store.dispatch(fetchPackage({ ident: this.ident }));
+    this.store.dispatch(fetchPackageChannels(
+      this.ident.origin, this.ident.name, this.ident.version, this.ident.release
+    ));
   }
 }

--- a/components/builder-web/app/package/package/package.component.ts
+++ b/components/builder-web/app/package/package/package.component.ts
@@ -21,7 +21,7 @@ import { PackageLatestComponent } from '../package-latest/package-latest.compone
 import { PackageReleaseComponent } from '../package-release/package-release.component';
 import { PackageVersionsComponent } from '../package-versions/package-versions.component';
 import { AppStore } from '../../app.store';
-import { fetchBuilds, fetchIntegrations, fetchOrigin, fetchProject } from '../../actions/index';
+import { fetchBuilds, fetchIntegrations, fetchLatestInChannel, fetchOrigin, fetchProject } from '../../actions/index';
 
 @Component({
   template: require('./package.component.html')
@@ -122,8 +122,13 @@ export class PackageComponent implements OnInit, OnDestroy {
       }
     });
 
+    this.fetchLatestStable();
     this.fetchProject();
     this.fetchBuilds();
+  }
+
+  private fetchLatestStable() {
+    this.store.dispatch(fetchLatestInChannel(this.origin, this.name, 'stable'));
   }
 
   private fetchProject() {

--- a/components/builder-web/app/reducers/packages.ts
+++ b/components/builder-web/app/reducers/packages.ts
@@ -20,20 +20,21 @@ import { List } from 'immutable';
 
 export default function packages(state = initialState['packages'], action) {
   switch (action.type) {
+
+    case actionTypes.CLEAR_CURRENT_PACKAGE_CHANNELS:
+      return state.set('currentChannels', []);
+
     case actionTypes.CLEAR_PACKAGES:
-      return state.set('current', Package()).
-        set('nextRange', 0).
+      return state.set('nextRange', 0).
         set('visible', List()).
         set('totalCount', 0).
-        setIn(['ui', 'current', 'loading'], true).
-        setIn(['ui', 'current', 'exists'], false).
-        setIn(['ui', 'latest', 'loading'], true).
-        setIn(['ui', 'latest', 'exists'], false).
         setIn(['ui', 'visible', 'loading'], true).
         setIn(['ui', 'visible', 'exists'], false);
 
     case actionTypes.CLEAR_LATEST_PACKAGE:
-      return state.set('latest', Package());
+      return state.set('latest', Package()).
+        setIn(['ui', 'latest', 'loading'], true).
+        setIn(['ui', 'latest', 'exists'], false);
 
     case actionTypes.CLEAR_LATEST_IN_CHANNEL:
       return state.setIn(['latestInChannel', action.payload.channel], undefined).
@@ -50,8 +51,7 @@ export default function packages(state = initialState['packages'], action) {
     case actionTypes.SET_CURRENT_PACKAGE:
       if (action.error) {
         return state.set('current', Package()).
-          setIn(['ui', 'current', 'errorMessage'],
-          action.error.message).
+          setIn(['ui', 'current', 'errorMessage'], action.error.message).
           setIn(['ui', 'current', 'loading'], false).
           setIn(['ui', 'current', 'exists'], false);
       } else {
@@ -62,6 +62,9 @@ export default function packages(state = initialState['packages'], action) {
           setIn(['ui', 'current', 'exists'], true).
           setIn(['ui', 'current', 'loading'], false);
       }
+
+    case actionTypes.SET_CURRENT_PACKAGE_CHANNELS:
+      return state.set('currentChannels', action.payload);
 
     case actionTypes.SET_CURRENT_PACKAGE_VERSIONS:
       if (action.error) {

--- a/components/builder-web/assets/images/icons/all.svg
+++ b/components/builder-web/assets/images/icons/all.svg
@@ -181,7 +181,7 @@
     <g id="icon-star-circle">
       <!-- https://material.io/icons/#ic_stars -->
       <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z"/>
-    <g>
+    </g>
     <g id="icon-description">
       <!-- https://material.io/icons/#ic_description -->
       <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/>


### PR DESCRIPTION
This change adds the promote-to-stable button to the Latest and Release views.

Also fixes a couple of teeny bugs:

* Closes an unclosed tag in the SVG icon markup
* Hides the border of the connected-plans table when there aren't any

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes: #4465.

![tenor-133468580](https://user-images.githubusercontent.com/274700/35252904-742611a6-ff97-11e7-8de9-3ffca164e2b1.gif)
