### PR TITLE
Restore search results

### DIFF
--- a/components/builder-web/.gitignore
+++ b/components/builder-web/.gitignore
@@ -11,3 +11,4 @@ npm-debug.log*
 /dist
 /typings
 results/
+!app/search/results

--- a/components/builder-web/app/search/results/_results.component.scss
+++ b/components/builder-web/app/search/results/_results.component.scss
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.results-component {
+  display: block;
+
+  .none {
+    font-size: $base-font-size;
+    font-weight: normal;
+  }
+
+  .list {
+    border: none;
+    box-shadow: none;
+  }
+
+  .item {
+    display: block;
+
+    .name {
+      font-size: 16px;
+    }
+  }
+}

--- a/components/builder-web/app/search/results/results.component.html
+++ b/components/builder-web/app/search/results/results.component.html
@@ -1,0 +1,13 @@
+<div class="results-component">
+  <ul class="nav-list">
+    <div class="none" *ngIf="noPackages">
+      <span>No packages found.</span>
+    </div>
+    <li class="item hover" *ngFor="let pkg of packages">
+      <a [routerLink]="routeFor(pkg)">
+        <span class="name">{{ packageString(pkg) }}</span>
+        <hab-icon symbol="chevron-right"></hab-icon>
+      </a>
+    </li>
+  </ul>
+</div>

--- a/components/builder-web/app/search/results/results.component.spec.ts
+++ b/components/builder-web/app/search/results/results.component.spec.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { List } from 'immutable';
+import { MockComponent } from 'ng2-mock-component';
+import { SearchResultsComponent } from './results.component';
+
+describe('SearchResultsComponent', () => {
+  let fixture: ComponentFixture<SearchResultsComponent>;
+  let component: SearchResultsComponent;
+  let element: DebugElement;
+
+  beforeEach(() => {
+
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule
+      ],
+      declarations: [
+        SearchResultsComponent,
+        MockComponent({ selector: 'hab-icon', inputs: ['symbol'] }),
+        MockComponent({ selector: 'hab-channels', inputs: ['channels'] }),
+        MockComponent({
+          selector: 'hab-build-status',
+          inputs: ['origin', 'name', 'version']
+        })
+      ]
+    });
+
+    fixture = TestBed.createComponent(SearchResultsComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+  });
+
+  beforeEach(() => {
+    component.packages = List([
+      {
+        origin: 'core',
+        project: 'nginx',
+        version: '1.0.2',
+        release: '20170101000002',
+        channels: ['stable', 'unstable']
+      },
+      {
+        origin: 'core',
+        project: 'nginx',
+        version: '1.0.1',
+        release: '20170101000001',
+        channels: ['unstable']
+      },
+      {
+        origin: 'core',
+        project: 'nginx',
+        version: '1.0.0',
+        release: '20170101000000',
+        channels: []
+      }
+    ]);
+    fixture.detectChanges();
+  });
+
+  it('renders a list of packages', () => {
+    expect(element.queryAll(By.css('.results-component li .name')).length).toBe(3);
+  });
+});

--- a/components/builder-web/app/search/results/results.component.ts
+++ b/components/builder-web/app/search/results/results.component.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, Input } from '@angular/core';
+import { List } from 'immutable';
+import { packageString } from '../../util';
+
+@Component({
+  selector: 'hab-search-results',
+  template: require('./results.component.html')
+})
+export class SearchResultsComponent {
+  @Input() errorMessage: string;
+  @Input() noPackages: boolean;
+  @Input() packages: List<Object>;
+
+  routeFor(pkg) {
+    return ['/pkgs', pkg.origin, pkg.name, 'latest'];
+  }
+
+  packageString(pkg) {
+    return packageString(pkg);
+  }
+}


### PR DESCRIPTION
Looks like this fell through the cracks with the repo split. This restores it and adds an exception to the .gitignore file.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-154395077](https://user-images.githubusercontent.com/274700/35417921-42afb236-01e4-11e8-9ee0-a1a892f5aa3d.gif)
