### PR TITLE
Fix input icon alignment

### DIFF
--- a/components/builder-web/app/shared/checking-input/_checking-input.component.scss
+++ b/components/builder-web/app/shared/checking-input/_checking-input.component.scss
@@ -1,7 +1,7 @@
 .checking-input-component {
   margin: $default-margin 0;
 
-  .wrapper {
+  .input-wrapper {
     position: relative;
 
     input {

--- a/components/builder-web/app/shared/checking-input/checking-input.component.html
+++ b/components/builder-web/app/shared/checking-input/checking-input.component.html
@@ -1,5 +1,5 @@
 <div class="checking-input-component">
-  <div class="wrapper">
+  <div class="input-wrapper">
     <hab-icon [symbol]="symbolForState(control)" [class.spinning]="control.pending" [class.invalid]="control.dirty && !control.pending && !control.valid"
       [class.valid]="!control.pending && control.valid">
     </hab-icon>


### PR DESCRIPTION
Vertical alignment is off a bit because of a class name used elsewhere in the app. This makes the class name more specific to the input component.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-87054854](https://user-images.githubusercontent.com/274700/35464114-1b0703ea-02a9-11e8-8165-1342be5ed46a.gif)
