### PR TITLE
Toggle Builder features in the UI

### DIFF
--- a/components/builder-api-proxy/config/habitat.conf.js
+++ b/components/builder-api-proxy/config/habitat.conf.js
@@ -22,5 +22,6 @@ habitatConfig({
     slack_url: "{{cfg.slack_url}}",
     youtube_url: "{{cfg.youtube_url}}",
     demo_app_url: "{{cfg.demo_app_url}}",
-    learn_url: "{{cfg.learn_url}}"
+    learn_url: "{{cfg.learn_url}}",
+    enable_builder: {{cfg.enable_builder}}
 });

--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -15,6 +15,7 @@ slack_url            = "http://slack.habitat.sh/"
 youtube_url          = "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI1Kq6ae8eVBl5S3IKk"
 demo_app_url         = "https://www.habitat.sh/demo"
 learn_url            = "https://www.habitat.sh/learn"
+enable_builder       = true
 
 [github]
 url          = "https://api.github.com"

--- a/components/builder-web/app/actions/features.ts
+++ b/components/builder-web/app/actions/features.ts
@@ -12,31 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { combineReducers } from 'redux';
-import app from './app';
-import gitHub from './gitHub';
-import builds from './builds';
-import features from './features';
-import notifications from './notifications';
-import origins from './origins';
-import packages from './packages';
-import projects from './projects';
-import router from './router';
-import session from './sessions';
-import users from './users';
-import ui from './ui';
+export const LOAD_FEATURES = 'LOAD_FEATURES';
 
-export default combineReducers({
-  app,
-  gitHub,
-  builds,
-  features,
-  notifications,
-  origins,
-  packages,
-  projects,
-  router,
-  session,
-  ui,
-  users
-});
+export function loadFeatures() {
+  return {
+    type: LOAD_FEATURES
+  };
+}

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -30,6 +30,11 @@ export {
 } from './builds';
 
 export {
+  LOAD_FEATURES,
+  loadFeatures
+} from './features';
+
+export {
   authenticate,
   CLEAR_GITHUB_INSTALLATIONS,
   fetchGitHubInstallations,

--- a/components/builder-web/app/app.component.ts
+++ b/components/builder-web/app/app.component.ts
@@ -17,7 +17,8 @@ import { AppStore } from './app.store';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { URLSearchParams } from '@angular/http';
 import { Router } from '@angular/router';
-import { identifyUser, removeNotification, exchangeGitHubAuthCode, routeChange, setPackagesSearchQuery, signOut, toggleUserNavMenu } from './actions/index';
+import { identifyUser, loadFeatures, removeNotification, exchangeGitHubAuthCode,
+  routeChange, setPackagesSearchQuery, signOut, toggleUserNavMenu } from './actions/index';
 
 @Component({
   selector: 'hab-app',
@@ -33,6 +34,8 @@ export class AppComponent implements OnInit, OnDestroy {
   private sub: Subscription;
 
   constructor(private router: Router, private store: AppStore) {
+    store.dispatch(loadFeatures());
+
     // Whenever the Angular route has an event, dispatch an event with the new
     // route data.
     this.sub = this.router.events.subscribe(event => {

--- a/components/builder-web/app/initial-state.ts
+++ b/components/builder-web/app/initial-state.ts
@@ -61,6 +61,9 @@ export default Record({
       stream: false
     })()
   })(),
+  features: Record({
+    builder: false
+  })(),
   notifications: Record({
     all: List(),
   })(),

--- a/components/builder-web/app/origin/origin-page/origin-page-routing.module.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page-routing.module.ts
@@ -20,6 +20,7 @@ import { OriginMembersTabComponent } from './origin-members-tab/origin-members-t
 import { OriginPackagesTabComponent } from './origin-packages-tab/origin-packages-tab.component';
 import { OriginSettingsTabComponent } from './origin-settings-tab/origin-settings-tab.component';
 import { OriginIntegrationsTabComponent } from './origin-integrations-tab/origin-integrations-tab.component';
+import { BuilderEnabledGuard } from '../../shared/guards/builder-enabled.guard';
 import { OriginMemberGuard } from '../../shared/guards/origin-member.guard';
 import { SignedInGuard } from '../../shared/guards/signed-in.guard';
 
@@ -49,12 +50,12 @@ const routes: Routes = [
       {
         path: 'settings',
         component: OriginSettingsTabComponent,
-        canActivate: [SignedInGuard, OriginMemberGuard],
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard],
       },
       {
         path: 'integrations',
         component: OriginIntegrationsTabComponent,
-        canActivate: [SignedInGuard, OriginMemberGuard]
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
       },
       {
         path: '**',

--- a/components/builder-web/app/origin/origin-page/origin-page.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-page.component.html
@@ -25,13 +25,13 @@
       routerLinkActive
       #settings="routerLinkActive"
       [active]="settings.isActive"
-      *ngIf="memberOfOrigin">Settings</a>
+      *ngIf="builderEnabled && memberOfOrigin">Settings</a>
     <a mat-tab-link
       routerLink="integrations"
       routerLinkActive
       #integrations="routerLinkActive"
       [active]="integrations.isActive"
-      *ngIf="memberOfOrigin">Integrations</a>
+      *ngIf="builderEnabled && memberOfOrigin">Integrations</a>
   </nav>
   <router-outlet></router-outlet>
 </div>

--- a/components/builder-web/app/origin/origin-page/origin-page.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page.component.ts
@@ -47,6 +47,10 @@ export class OriginPageComponent implements OnInit, OnDestroy {
     this.sub.unsubscribe();
   }
 
+  get builderEnabled() {
+    return this.store.getState().features.builder;
+  }
+
   get origin() {
     const current = this.store.getState().origins.current;
 

--- a/components/builder-web/app/package/package-routing.module.ts
+++ b/components/builder-web/app/package/package-routing.module.ts
@@ -21,6 +21,7 @@ import { PackageLatestComponent } from './package-latest/package-latest.componen
 import { PackageSettingsComponent } from './package-settings/package-settings.component';
 import { PackageReleaseComponent } from './package-release/package-release.component';
 import { PackageVersionsComponent } from './package-versions/package-versions.component';
+import { BuilderEnabledGuard } from '../shared/guards/builder-enabled.guard';
 import { OriginMemberGuard } from '../shared/guards/origin-member.guard';
 import { SignedInGuard } from '../shared/guards/signed-in.guard';
 
@@ -40,17 +41,17 @@ const routes: Routes = [
       {
         path: 'builds',
         component: PackageBuildsComponent,
-        canActivate: [SignedInGuard, OriginMemberGuard]
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
       },
       {
         path: 'builds/:id',
         component: PackageBuildComponent,
-        canActivate: [SignedInGuard, OriginMemberGuard]
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
       },
       {
         path: 'settings',
         component: PackageSettingsComponent,
-        canActivate: [SignedInGuard, OriginMemberGuard]
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
       },
       {
         path: ':version',

--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -5,16 +5,38 @@
   <h2>package</h2>
 </header>
 <nav class="tabs" mat-tab-nav-bar>
-  <a mat-tab-link routerLink="latest" routerLinkActive #latest="routerLinkActive" [active]="latest.isActive">
+  <a
+    mat-tab-link
+    routerLink="latest"
+    routerLinkActive
+    #latest="routerLinkActive"
+    [active]="latest.isActive">
     Latest
   </a>
-  <a mat-tab-link routerLink="./" [routerLinkActiveOptions]="{exact: true}" routerLinkActive #versions="routerLinkActive" [active]="versions.isActive">
+  <a mat-tab-link
+    routerLink="./"
+    [routerLinkActiveOptions]="{exact: true}"
+    routerLinkActive
+    #versions="routerLinkActive"
+    [active]="versions.isActive">
     Versions
   </a>
-  <a mat-tab-link *ngIf="isOriginMember" routerLink="builds" routerLinkActive #jobs="routerLinkActive" [active]="jobs.isActive">
+  <a
+    mat-tab-link
+    *ngIf="builderEnabled && isOriginMember"
+    routerLink="builds"
+    routerLinkActive
+    #jobs="routerLinkActive"
+    [active]="jobs.isActive">
     Build Jobs
   </a>
-  <a mat-tab-link *ngIf="isOriginMember" routerLink="settings" routerLinkActive #settings="routerLinkActive" [active]="settings.isActive">
+  <a
+    mat-tab-link
+    *ngIf="builderEnabled && isOriginMember"
+    routerLink="settings"
+    routerLinkActive
+    #settings="routerLinkActive"
+    [active]="settings.isActive">
     Settings
   </a>
 </nav>

--- a/components/builder-web/app/package/package/package.component.spec.ts
+++ b/components/builder-web/app/package/package/package.component.spec.ts
@@ -25,28 +25,13 @@ import { AppStore } from '../../app.store';
 import { PackageComponent } from './package.component';
 
 class MockAppStore {
-  dispatch() { }
+  static state;
 
   getState() {
-    return {
-      builds: {
-        visible: []
-      },
-      origins: {
-        mine: []
-      },
-      projects: {
-        ui: {
-          current: {
-            exists: true
-          }
-        }
-      },
-      session: {
-        token: 'some-token'
-      }
-    };
+    return MockAppStore.state;
   }
+
+  dispatch() { }
 }
 
 class MockRoute {
@@ -62,6 +47,30 @@ describe('PackageComponent', () => {
   let fixture: ComponentFixture<PackageComponent>;
   let component: PackageComponent;
   let element: DebugElement;
+
+  beforeEach(() => {
+    MockAppStore.state = {
+      builds: {
+        visible: []
+      },
+      features: {
+        builder: false
+      },
+      origins: {
+        mine: []
+      },
+      projects: {
+        ui: {
+          current: {
+            exists: true
+          }
+        }
+      },
+      session: {
+        token: 'some-token'
+      }
+    };
+  });
 
   beforeEach(() => {
 
@@ -92,9 +101,44 @@ describe('PackageComponent', () => {
     it('renders breadcrumbs and sidebar', () => {
       component.showSidebar = true;
       fixture.detectChanges();
-    
+
       expect(element.query(By.css('hab-package-breadcrumbs'))).not.toBeNull();
       expect(element.query(By.css('hab-package-sidebar'))).not.toBeNull();
+    });
+
+    describe('when Builder is disabled', () => {
+
+      beforeEach(() => {
+        MockAppStore.state.features.builder = false;
+      });
+
+      it ('suppresses the Build Jobs and Settings tabs', () => {
+        fixture.detectChanges();
+
+        expect(element.query(By.css('[routerlink="builds"]'))).toBeNull();
+        expect(element.query(By.css('[routerlink="settings"]'))).toBeNull();
+      });
+    });
+
+    describe('when Builder is enabled', () => {
+
+      beforeEach(() => {
+        MockAppStore.state.features.builder = true;
+      });
+
+      describe('and the user is an origin member', () => {
+
+        beforeEach(() => {
+          MockAppStore.state.origins.mine = [ { name: 'core' } ];
+        });
+
+        it('exposes the Build Jobs and Settings tabs', () => {
+          fixture.detectChanges();
+
+          expect(element.query(By.css('[routerlink="builds"]'))).not.toBeNull();
+          expect(element.query(By.css('[routerlink="settings"]'))).not.toBeNull();
+        });
+      });
     });
   });
 });

--- a/components/builder-web/app/package/package/package.component.ts
+++ b/components/builder-web/app/package/package/package.component.ts
@@ -75,8 +75,12 @@ export class PackageComponent implements OnInit, OnDestroy {
     });
   }
 
+  get builderEnabled() {
+    return this.store.getState().features.builder;
+  }
+
   get buildable(): boolean {
-    let hasProject = this.store.getState().projects.ui.current.exists;
+    const hasProject = this.store.getState().projects.ui.current.exists;
 
     if (this.isOriginMember && hasProject) {
       return true;

--- a/components/builder-web/app/reducers/features.ts
+++ b/components/builder-web/app/reducers/features.ts
@@ -12,31 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { combineReducers } from 'redux';
-import app from './app';
-import gitHub from './gitHub';
-import builds from './builds';
-import features from './features';
-import notifications from './notifications';
-import origins from './origins';
-import packages from './packages';
-import projects from './projects';
-import router from './router';
-import session from './sessions';
-import users from './users';
-import ui from './ui';
+import * as actionTypes from '../actions/index';
+import config from '../config';
+import initialState from '../initial-state';
 
-export default combineReducers({
-  app,
-  gitHub,
-  builds,
-  features,
-  notifications,
-  origins,
-  packages,
-  projects,
-  router,
-  session,
-  ui,
-  users
-});
+export default function builds(state = initialState['features'], action) {
+  switch (action.type) {
+
+    case actionTypes.LOAD_FEATURES:
+      return state.set('builder', !!config['enable_builder']);
+
+    default:
+      return state;
+  }
+}

--- a/components/builder-web/app/shared/guards/builder-enabled.guard.ts
+++ b/components/builder-web/app/shared/guards/builder-enabled.guard.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { AppStore } from '../../app.store';
+import { requestRoute } from '../../actions/index';
+
+@Injectable()
+export class BuilderEnabledGuard implements CanActivate {
+
+  constructor(private store: AppStore, private router: Router) { }
+
+  canActivate(route: ActivatedRouteSnapshot, routerState: RouterStateSnapshot): Promise<boolean> {
+    const state = this.store.getState();
+
+    return new Promise((resolve, reject) => {
+      if (state.features.builder) {
+        resolve(true);
+      }
+      else {
+        reject(() => this.redirect('/pkgs'));
+      }
+    })
+    .catch(next => next())
+    .then(() => true);
+  }
+
+  private redirect(path: string) {
+    this.store.dispatch(requestRoute([path]));
+  }
+}

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -22,6 +22,8 @@
     }
 
     .cta {
+      margin-right: $default-margin;
+
       .button {
         @include cta;
       }

--- a/components/builder-web/app/shared/shared.module.ts
+++ b/components/builder-web/app/shared/shared.module.ts
@@ -37,6 +37,7 @@ import { PlatformIconComponent } from './platform-icon/platform-icon.component';
 import { VisibilitySelectorComponent } from './visibility-selector/visibility-selector.component';
 import { KeysPipe } from './pipes/keys.pipe';
 import { SimpleConfirmDialog } from './dialog/simple-confirm/simple-confirm.dialog';
+import { BuilderEnabledGuard } from './guards/builder-enabled.guard';
 import { OriginMemberGuard } from './guards/origin-member.guard';
 import { SignedInGuard } from './guards/signed-in.guard';
 
@@ -96,6 +97,7 @@ import { SignedInGuard } from './guards/signed-in.guard';
     SimpleConfirmDialog,
   ],
   providers: [
+    BuilderEnabledGuard,
     OriginMemberGuard,
     SignedInGuard
   ]

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -1,54 +1,77 @@
 habitatConfig({
+
+    // Enable Builder-specific features
+    enable_builder: true,
+
+    // The URL for community information
+    community_url: "https://www.habitat.sh/community",
+
+    // The URL for the demo app
+    demo_app_url: "https://www.habitat.sh/demo",
+
+    // The URL for documentation
+    docs_url: "https://www.habitat.sh/docs",
+
+    // The environment in which we're running. If "production", enable production mode
+    environment: "production",
+
+    // The URL for events
+    events_url: "https://events.chef.io/events/categories/habitat/",
+
+    // The URL for feature requests
+    feature_requests_url: "https://portal.prodpad.com/24539",
+
+    // The URL for forums
+    forums_url: "https://forums.habitat.sh/",
+
     // The URL for the Habitat API service (including the API version.) If
-    // running the API services locally with `make bldr-run` or `make bldr-run-shell` from the root
-    // of the habitat repo, this will be localhost (if running Docker for Mac or
+    // running the API services locally with `start-builder` from the root
+    // of the builder repo, this will be localhost (if running Docker for Mac or
     // Linux) or the result of `$(docker-machine ip default)` if using Docker
     // in a virtual Machine.
     habitat_api_url: "http://localhost:9636",
-    // The URL for community information
-    community_url: "https://www.habitat.sh/community",
-    // The URL for documentation
-    docs_url: "https://www.habitat.sh/docs",
-    // The environment in which we're running. If "production", enable
-    // production mode
-    environment: "production",
-    // GitHub Client ID for GitHubApp
-    github_client_id: "Iv1.732260b62f84db15",
+
     // The API URL for GitHub
     github_api_url: "https://api.github.com",
-    // The Web URL for GitHub
-    github_web_url: "https://github.com",
-    // The Habitat Builder GitHub app
-    github_app_url: "https://github.com/apps/habitat-builder-dev",
+
     // The Habitat Builder GitHub app ID
     github_app_id: "5629",
-    // The GitHub redirect URI. Must exactly match the value of the User Authorization Callback URL in the GitHub app.
+
+    // The Habitat Builder GitHub app
+    github_app_url: "https://github.com/apps/habitat-builder-dev",
+
+    // GitHub Client ID for GitHubApp
+    github_client_id: "Iv1.732260b62f84db15",
+
+    // The GitHub redirect URI. Must exactly match the value of the User Authorization Callback
+    // URL in the GitHub app.
     github_redirect_uri: "http://localhost:3000/",
+
+    // The Web URL for GitHub
+    github_web_url: "https://github.com",
+
+    // The URL for the Learn Habitat
+    learn_url: "https://www.habitat.sh/learn",
+    // The URL for Slack
+
+    slack_url: "http://slack.habitat.sh/",
+
     // The URL for the Habitat source code
     source_code_url: "https://github.com/habitat-sh/habitat",
-    // The URL for tutorials
-    tutorials_url: "https://www.habitat.sh/tutorials",
-    // The URL for Slack
-    slack_url: "http://slack.habitat.sh/",
-    // The URL for YouTube
-    youtube_url: "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI1Kq6ae8eVBl5S3IKk",
-    // The URL for events
-    events_url: "https://events.chef.io/events/categories/habitat/",
-    // The URL for roadmap
-    roadmap_url: "https://ext.prodpad.com/ext/roadmap/d2938aed0d0ad1dd62669583e108357efd53b3a6",
-    // The URL for feature requests
-    feature_requests_url: "https://portal.prodpad.com/24539",
-    // The URL for forums
-    forums_url: "https://forums.habitat.sh/",
+
     // The URL for status
     status_url: "https://status.habitat.sh/",
-    // The URL for the demo app
-    demo_app_url: "https://www.habitat.sh/demo",
-    // The URL for the Learn Habitat
-    learn_url: "https://www.habitat.sh/learn",    
+
+    // The URL for tutorials
+    tutorials_url: "https://www.habitat.sh/tutorials",
+
     // The version of the software we're running. In production, this should
     // be automatically populated by Habitat
     version: "",
+
+    // The URL for YouTube
+    youtube_url: "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI1Kq6ae8eVBl5S3IKk",
+
     // The main website URL
     www_url: "https://www.habitat.sh"
 });


### PR DESCRIPTION
This change adds a configuration item, `enable_builder`, to the `builder-api-proxy` package that toggles Builder-specific functionality in the UI. When Builder is enabled, we expose:

* The Integrations and Settings tabs in the Origins section
* The Build Jobs and Settings tabs in the Packages section

When it’s disabled, we’ll also redirect requests to these Builder-specific views to prevent any broken-looking experiences.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-160263142](https://user-images.githubusercontent.com/274700/35467543-55d42122-02c4-11e8-9901-c8fb3919bac2.gif)

