### PR TITLE
Hab service logging to Sumologic

### DIFF
--- a/terraform/files/sumocollector.service
+++ b/terraform/files/sumocollector.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Send Habitat service logs to Sumologic syslog collector
+
+[Service]
+TimeoutStartSec=0
+ExecStart=/bin/sh -c '/bin/journalctl -fu hab-sup | /bin/ncat --udp localhost 1514'
+Restart=always
+RestartSec=5s
+[Install]
+WantedBy=multi-user.target

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -81,6 +81,19 @@ resource "null_resource" "api_provision" {
   }
 
   provisioner "file" {
+    source = "${path.module}/files/sumocollector.service"
+    destination = "/tmp/sumocollector.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/sumocollector.service /etc/systemd/system/sumocollector.service",
+      "sudo systemctl enable /etc/systemd/system/sumocollector.service",
+      "sudo systemctl start sumocollector.service"
+    ]
+  }
+
+  provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
   }
@@ -96,6 +109,7 @@ resource "null_resource" "api_provision" {
       "sudo systemctl enable hab-sup",
       "sudo hab svc load core/builder-api --group ${var.env} --bind router:builder-router.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
       "sudo hab svc load core/builder-api-proxy --group ${var.env} --bind http:builder-api.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load core/sumologic --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]
   }
 }
@@ -149,6 +163,19 @@ resource "aws_instance" "admin" {
   }
 
   provisioner "file" {
+    source = "${path.module}/files/sumocollector.service"
+    destination = "/tmp/sumocollector.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/sumocollector.service /etc/systemd/system/sumocollector.service",
+      "sudo systemctl enable /etc/systemd/system/sumocollector.service",
+      "sudo systemctl start sumocollector.service"
+    ]
+  }
+
+  provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
   }
@@ -164,6 +191,7 @@ resource "aws_instance" "admin" {
       "sudo systemctl enable hab-sup",
       "sudo hab svc load core/builder-admin --group ${var.env} --bind router:builder-router.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
       "sudo hab svc load core/builder-admin-proxy --group ${var.env} --bind http:builder-admin.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load core/sumologic --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]
   }
 
@@ -241,6 +269,19 @@ resource "null_resource" "datastore_provision" {
   }
 
   provisioner "file" {
+    source = "${path.module}/files/sumocollector.service"
+    destination = "/tmp/sumocollector.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/sumocollector.service /etc/systemd/system/sumocollector.service",
+      "sudo systemctl enable /etc/systemd/system/sumocollector.service",
+      "sudo systemctl start sumocollector.service"
+    ]
+  }
+
+  provisioner "file" {
     source = "${path.module}/files/postgres.yaml"
     destination = "/tmp/postgres.yaml"
   }
@@ -259,6 +300,11 @@ resource "null_resource" "datastore_provision" {
   }
 
   provisioner "file" {
+    content     = "${data.template_file.sumo_sources_syslog.rendered}"
+    destination = "/home/ubuntu/sumo_sources_syslog.json"
+  }
+
+  provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
   }
@@ -272,7 +318,8 @@ resource "null_resource" "datastore_provision" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab svc load core/builder-datastore --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}"
+      "sudo hab svc load core/builder-datastore --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load core/sumologic --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]
   }
 }
@@ -342,6 +389,19 @@ resource "aws_instance" "jobsrv" {
   }
 
   provisioner "file" {
+    source = "${path.module}/files/sumocollector.service"
+    destination = "/tmp/sumocollector.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/sumocollector.service /etc/systemd/system/sumocollector.service",
+      "sudo systemctl enable /etc/systemd/system/sumocollector.service",
+      "sudo systemctl start sumocollector.service"
+    ]
+  }
+
+  provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
   }
@@ -355,7 +415,8 @@ resource "aws_instance" "jobsrv" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab svc load core/builder-jobsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}"
+      "sudo hab svc load core/builder-jobsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load core/sumologic --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]
   }
 
@@ -419,6 +480,19 @@ resource "aws_instance" "originsrv" {
   }
 
   provisioner "file" {
+    source = "${path.module}/files/sumocollector.service"
+    destination = "/tmp/sumocollector.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/sumocollector.service /etc/systemd/system/sumocollector.service",
+      "sudo systemctl enable /etc/systemd/system/sumocollector.service",
+      "sudo systemctl start sumocollector.service"
+    ]
+  }
+
+  provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
   }
@@ -432,7 +506,8 @@ resource "aws_instance" "originsrv" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab svc load core/builder-originsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}"
+      "sudo hab svc load core/builder-originsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load core/sumologic --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]
   }
 
@@ -495,6 +570,19 @@ resource "aws_instance" "router" {
   }
 
   provisioner "file" {
+    source = "${path.module}/files/sumocollector.service"
+    destination = "/tmp/sumocollector.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/sumocollector.service /etc/systemd/system/sumocollector.service",
+      "sudo systemctl enable /etc/systemd/system/sumocollector.service",
+      "sudo systemctl start sumocollector.service"
+    ]
+  }
+
+  provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
   }
@@ -508,7 +596,8 @@ resource "aws_instance" "router" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab svc load core/builder-router --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}"
+      "sudo hab svc load core/builder-router --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load core/sumologic --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]
   }
 
@@ -572,6 +661,19 @@ resource "aws_instance" "sessionsrv" {
   }
 
   provisioner "file" {
+    source = "${path.module}/files/sumocollector.service"
+    destination = "/tmp/sumocollector.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/sumocollector.service /etc/systemd/system/sumocollector.service",
+      "sudo systemctl enable /etc/systemd/system/sumocollector.service",
+      "sudo systemctl start sumocollector.service"
+    ]
+  }
+
+  provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
   }
@@ -585,7 +687,8 @@ resource "aws_instance" "sessionsrv" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab svc load core/builder-sessionsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}"
+      "sudo hab svc load core/builder-sessionsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load core/sumologic --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]
   }
 
@@ -652,6 +755,19 @@ resource "aws_instance" "worker" {
       "sudo sed -i \"$ a tags: env:${var.env}, role:worker\" /etc/dd-agent/datadog.conf",
       "sudo cp /tmp/builder.logrotate /etc/logrotate.d/builder",
       "sudo /etc/init.d/datadog-agent stop"
+    ]
+  }
+
+  provisioner "file" {
+    source = "${path.module}/files/sumocollector.service"
+    destination = "/tmp/sumocollector.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/sumocollector.service /etc/systemd/system/sumocollector.service",
+      "sudo systemctl enable /etc/systemd/system/sumocollector.service",
+      "sudo systemctl start sumocollector.service"
     ]
   }
 
@@ -775,6 +891,15 @@ data "template_file" "sumo_sources_worker" {
     name = "${var.env}"
     category = "${var.env}/worker"
     path = "/tmp/builder-worker.log"
+  }
+}
+
+data "template_file" "sumo_sources_syslog" {
+  template = "${file("${path.module}/templates/sumo_sources_syslog.json")}"
+
+  vars {
+    name = "${var.env}-Syslog"
+    category = "${var.env}/syslog"
   }
 }
 

--- a/terraform/scripts/create_bootstrap_bundle.sh
+++ b/terraform/scripts/create_bootstrap_bundle.sh
@@ -102,7 +102,8 @@ builder_packages=(core/builder-api
 
 # Helper packages. Not all need to to be installed on the same machine,
 # but all need to be present in our bundle.
-helper_packages=(core/sumologic)
+helper_packages=(core/sumologic
+                 core/nmap)
 
 # This is where we ultimately put all the things in S3.
 s3_bucket="habitat-builder-bootstrap"

--- a/terraform/scripts/install_base_packages.sh
+++ b/terraform/scripts/install_base_packages.sh
@@ -60,6 +60,9 @@ sup_packages=(hab-launcher
               hab-sup
               hab-butterfly)
 
+# Helper for syslog logging
+helper_packages=(nmap)
+
 ########################################################################
 # Download bootstrap archive from S3
 
@@ -120,7 +123,7 @@ log "Populating artifact cache"
 mkdir -p /hab/cache/artifacts
 cp ${tmpdir}/artifacts/* /hab/cache/artifacts
 
-for pkg in "${sup_packages[@]}" ${services_to_install[@]:-}
+for pkg in "${sup_packages[@]}" "${helper_packages[@]}" ${services_to_install[@]:-}
 do
     pkg_name=${pkg##core/} # strip "core/" if it's there
     # Using a fake depot URL keeps us honest; this will fail loudly if
@@ -139,3 +142,5 @@ done
 # lnger are worrying about Habitat versions 0.33.2 and older. (2017-09-29)
 ${hab_bootstrap_bin} pkg binlink core/hab hab --force \
   || ${hab_bootstrap_bin} pkg binlink core/hab hab
+${hab_bootstrap_bin} pkg binlink core/nmap ncat --force \
+  || ${hab_bootstrap_bin} pkg binlink core/nmap ncat

--- a/terraform/templates/sumo_sources_syslog.json
+++ b/terraform/templates/sumo_sources_syslog.json
@@ -1,0 +1,15 @@
+{
+  "api.version":"v1",
+  "source":{
+    "name":"${name}",
+    "category":"${category}",
+    "automaticDateParsing":true,
+    "forceTimeZone":false,
+    "timeZone":"Etc/UTC",
+    "filters":[],
+    "cutoffTimestamp":1507273200000,
+    "sourceType":"Syslog",
+    "protocol":"UDP",
+    "port":1514
+  }
+}


### PR DESCRIPTION
This change adds logging of the service output to Sumologic. It sets up a new systemd service that forwards journalctl logs to a Sumologic syslog collector, which then forwards it off to the Sumologic service.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-1773504](https://user-images.githubusercontent.com/13542112/35713791-2794e742-077e-11e8-9d2b-eb9893230c09.gif)
