### PR TITLE
Introduce config flag to disable jobsrv communication

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -43,6 +43,8 @@ pub struct Config {
     pub non_core_builds_enabled: bool,
     /// Where to record log events for funnel metrics
     pub log_dir: String,
+    /// Whether jobsrv is present or not
+    pub jobsrv_enabled: bool,
 }
 
 impl Default for Config {
@@ -57,6 +59,7 @@ impl Default for Config {
             events_enabled: false,
             non_core_builds_enabled: true,
             log_dir: env::temp_dir().to_string_lossy().into_owned(),
+            jobsrv_enabled: true,
         }
     }
 }
@@ -133,6 +136,7 @@ mod tests {
         let content = r#"
         events_enabled = true
         non_core_builds_enabled = true
+        jobsrv_enabled = false
 
         [http]
         listen = "0:0:0:0:0:0:0:1"
@@ -167,6 +171,7 @@ mod tests {
 
         let config = Config::from_raw(&content).unwrap();
         assert_eq!(config.events_enabled, true);
+        assert_eq!(config.jobsrv_enabled, false);
         assert_eq!(config.non_core_builds_enabled, true);
         assert_eq!(&format!("{}", config.http.listen), "::1");
         assert_eq!(config.http.port, 9636);

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -38,7 +38,6 @@ extern crate openssl;
 extern crate params;
 extern crate persistent;
 extern crate protobuf;
-#[macro_use]
 extern crate router;
 extern crate segment_api_client;
 #[macro_use]

--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -156,15 +156,18 @@ pub fn get_profile(req: &mut Request) -> IronResult<Response> {
     }
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn job_group_promote(req: &mut Request) -> IronResult<Response> {
     job_group_promote_or_demote(req, true)
 
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn job_group_demote(req: &mut Request) -> IronResult<Response> {
     job_group_promote_or_demote(req, false)
 }
 
+// This route is only available if jobsrv_enabled is true
 fn job_group_promote_or_demote(req: &mut Request, promote: bool) -> IronResult<Response> {
     let group_id = match get_param(req, "id") {
         Some(id) => {
@@ -210,6 +213,7 @@ fn job_group_promote_or_demote(req: &mut Request, promote: bool) -> IronResult<R
     }
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn job_group_cancel(req: &mut Request) -> IronResult<Response> {
     let group_id = match get_param(req, "id") {
         Some(id) => {
@@ -316,6 +320,7 @@ pub fn validate_registry_credentials(req: &mut Request) -> IronResult<Response> 
     }
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn project_privacy_toggle(req: &mut Request) -> IronResult<Response> {
     let origin = match get_param(req, "origin") {
         Some(o) => o,
@@ -363,6 +368,7 @@ pub fn project_privacy_toggle(req: &mut Request) -> IronResult<Response> {
     }
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn rdeps_show(req: &mut Request) -> IronResult<Response> {
     let mut rdeps_get = JobGraphPackageReverseDependenciesGet::new();
     match get_param(req, "origin") {
@@ -387,6 +393,7 @@ pub fn rdeps_show(req: &mut Request) -> IronResult<Response> {
     }
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn job_show(req: &mut Request) -> IronResult<Response> {
     let mut request = JobGet::new();
     match get_param(req, "id") {
@@ -431,6 +438,7 @@ pub fn job_show(req: &mut Request) -> IronResult<Response> {
     }
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn job_log(req: &mut Request) -> IronResult<Response> {
     let start = req.get_ref::<Params>()
         .unwrap()
@@ -532,6 +540,7 @@ pub fn list_user_origins(req: &mut Request) -> IronResult<Response> {
 
 /// Create a new project as the authenticated user and associated to
 /// the given origin.
+// This route is only available if jobsrv_enabled is true
 pub fn project_create(req: &mut Request) -> IronResult<Response> {
     let mut request = OriginProjectCreate::new();
     let mut project = OriginProject::new();
@@ -638,6 +647,7 @@ pub fn project_create(req: &mut Request) -> IronResult<Response> {
 }
 
 /// Delete the given project
+// This route is only available if jobsrv_enabled is true
 pub fn project_delete(req: &mut Request) -> IronResult<Response> {
     let mut project_del = OriginProjectDelete::new();
 
@@ -670,6 +680,7 @@ pub fn project_delete(req: &mut Request) -> IronResult<Response> {
 }
 
 /// Update the given project
+// This route is only available if jobsrv_enabled is true
 pub fn project_update(req: &mut Request) -> IronResult<Response> {
     let origin = match get_param(req, "origin") {
         Some(o) => o,
@@ -772,6 +783,7 @@ pub fn project_update(req: &mut Request) -> IronResult<Response> {
 }
 
 /// Display the the given project's details
+// This route is only available if jobsrv_enabled is true
 pub fn project_show(req: &mut Request) -> IronResult<Response> {
     let mut project_get = OriginProjectGet::new();
 
@@ -805,6 +817,7 @@ pub fn project_show(req: &mut Request) -> IronResult<Response> {
 }
 
 /// Return names of all the projects in the given origin
+// This route is only available if jobsrv_enabled is true
 pub fn project_list(req: &mut Request) -> IronResult<Response> {
     let mut projects_get = OriginProjectListGet::new();
 
@@ -826,6 +839,7 @@ pub fn project_list(req: &mut Request) -> IronResult<Response> {
 }
 
 /// Retrieve the most recent 50 jobs for a project.
+// This route is only available if jobsrv_enabled is true
 pub fn project_jobs(req: &mut Request) -> IronResult<Response> {
     let mut jobs_get = ProjectJobsGet::new();
 
@@ -887,6 +901,7 @@ pub fn project_jobs(req: &mut Request) -> IronResult<Response> {
     }
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn create_project_integration(req: &mut Request) -> IronResult<Response> {
     let params = match validate_params(req, &["origin", "name", "integration"]) {
         Ok(p) => p,
@@ -937,6 +952,7 @@ pub fn create_project_integration(req: &mut Request) -> IronResult<Response> {
     }
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn delete_project_integration(req: &mut Request) -> IronResult<Response> {
     let params = match validate_params(req, &["origin", "name", "integration"]) {
         Ok(p) => p,
@@ -961,6 +977,7 @@ pub fn delete_project_integration(req: &mut Request) -> IronResult<Response> {
     }
 }
 
+// This route is only available if jobsrv_enabled is true
 pub fn get_project_integration(req: &mut Request) -> IronResult<Response> {
     let params = match validate_params(req, &["origin", "name", "integration"]) {
         Ok(p) => p,

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -48,6 +48,8 @@ pub struct Config {
     pub key_dir: PathBuf,
     /// A list of package platform and architecture combinations which can be uploaded and hosted
     pub targets: Vec<PackageTarget>,
+    /// Whether jobsrv is present or not
+    pub jobsrv_enabled: bool,
 }
 
 impl ConfigFile for Config {
@@ -71,6 +73,7 @@ impl Default for Config {
                 PackageTarget::new(Platform::Linux, Architecture::X86_64),
                 PackageTarget::new(Platform::Windows, Architecture::X86_64),
             ],
+            jobsrv_enabled: true,
         }
     }
 }
@@ -129,6 +132,7 @@ mod tests {
         events_enabled = true
         log_dir = "/hab/svc/hab-depot/var/log"
         key_dir = "/hab/svc/hab-depot/files"
+        jobsrv_enabled = false
 
         [[targets]]
         platform = "linux"
@@ -159,6 +163,7 @@ mod tests {
         assert_eq!(config.events_enabled, true);
         assert_eq!(config.log_dir, PathBuf::from("/hab/svc/hab-depot/var/log"));
         assert_eq!(config.key_dir, PathBuf::from("/hab/svc/hab-depot/files"));
+        assert_eq!(config.jobsrv_enabled, false);
         assert_eq!(&format!("{}", config.http.listen), "127.0.0.1");
         assert_eq!(config.http.port, 9000);
         assert_eq!(&format!("{}", config.routers[0]), "172.18.0.2:9001");

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -34,7 +34,6 @@ extern crate persistent;
 extern crate protobuf;
 extern crate regex;
 extern crate r2d2;
-#[macro_use]
 extern crate router;
 extern crate segment_api_client;
 extern crate serde;


### PR DESCRIPTION
This PR introduces a new config flag for both `builder-depot` and `builder-api` called `jobsrv_enabled`.  It's `true` by default, but when it's set to `false`, then no communication with `builder-jobsrv` will occur.

I switched our routes from the macro syntax to the normal function based syntax because it turns out it's difficult to have programmatic control over your routes inside a macro.  I should also note that some of our routes are ambiguous enough (and iron's router isn't capable enough) that some of our routes will get called incorrectly.  One concrete example of this is:

`/pkgs/origins/:origin/stats`

This retrieves package stats and it uses `builder-jobsrv` to do it.  When `jobsrv_enabled` is set to `false`, that route isn't present in the routing table.  However, if you go to, e.g.:

`/pkgs/origins/core/stats`

instead of getting a 404, like you should, you'll get an empty package list.  That's because this route still matches:

`/pkgs/:origin/:pkg/:version`

which calls `list_packages`.  This kind of nonsense will go away once we have the opportunity to write v2 of the API, but for now, this is how things are.

![tenor-107814571](https://user-images.githubusercontent.com/947/35820706-4f1a6a0a-0a5b-11e8-99c5-79fa43222039.gif)

Closes #137 
Signed-off-by: Josh Black <raskchanky@gmail.com>