### PR TITLE
Change `core` origin to `habitat` in `do_builder_install` for builder dev

### DIFF
--- a/support/ci/builder-dev-plan.sh
+++ b/support/ci/builder-dev-plan.sh
@@ -23,9 +23,9 @@ do_clean() {
 }
 
 do_builder_install() {
-  rm "$(hab pkg path core/$pkg_name)/bin/$bin"
+  rm "$(hab pkg path habitat/$pkg_name)/bin/$bin"
   ln -sf "$CARGO_TARGET_DIR/$rustc_target/${builder_build_type#--}/$bin" \
-    "$(hab pkg path core/$pkg_name)/bin/$bin"
+    "$(hab pkg path habitat/$pkg_name)/bin/$bin"
 }
 
 do_install_wrapper() {


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/builder/issues/168

This appears to be a simple oversight from Just an oversight from a3d05cfa959e948d7a51b5965cbc947d9c1783a9

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>