### PR TITLE
Improve plan-connection flow

### DIFF
--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -34,8 +34,10 @@ const uuid = require('uuid').v4;
 const gitHubTokenAuthUrl = `${config['habitat_api_url']}/v1/authenticate`;
 
 export const CLEAR_GITHUB_INSTALLATIONS = 'CLEAR_GITHUB_INSTALLATIONS';
+export const CLEAR_GITHUB_REPOSITORIES = 'CLEAR_GITHUB_REPOSITORIES';
 export const LOAD_GITHUB_SESSION_STATE = 'LOAD_GITHUB_SESSION_STATE';
 export const POPULATE_GITHUB_INSTALLATIONS = 'POPULATE_GITHUB_INSTALLATIONS';
+export const POPULATE_GITHUB_REPOSITORIES = 'POPULATE_GITHUB_REPOSITORIES';
 export const POPULATE_GITHUB_USER_DATA = 'POPULATE_GITHUB_USER_DATA';
 export const SET_GITHUB_AUTH_STATE = 'SET_GITHUB_AUTH_STATE';
 export const SET_GITHUB_AUTH_TOKEN = 'SET_GITHUB_AUTH_TOKEN';
@@ -85,16 +87,33 @@ export function authenticate(gitHubToken: string, bldrToken: string) {
   };
 }
 
-export function fetchGitHubInstallations() {
+export function fetchGitHubInstallations(username: string) {
   const token = Browser.getCookie('gitHubAuthToken');
 
   return dispatch => {
     const client = new GitHubApiClient(token);
     dispatch(clearGitHubInstallations());
 
-    client.getUserInstallations()
+    client.getUserInstallations(username)
       .then((results) => {
         dispatch(populateGitHubInstallations(results));
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  };
+}
+
+export function fetchGitHubRepositories(installationID: number) {
+  const token = Browser.getCookie('gitHubAuthToken');
+
+  return dispatch => {
+    const client = new GitHubApiClient(token);
+    dispatch(clearGitHubRepositories());
+
+    client.getAllUserInstallationRepositories(installationID)
+      .then((results) => {
+        dispatch(populateGitHubRepositories(results));
       })
       .catch((error) => {
         console.error(error);
@@ -121,6 +140,20 @@ function clearGitHubInstallations() {
 function populateGitHubInstallations(payload) {
   return {
     type: POPULATE_GITHUB_INSTALLATIONS,
+    payload,
+  };
+}
+
+
+function clearGitHubRepositories() {
+  return {
+    type: CLEAR_GITHUB_REPOSITORIES
+  };
+}
+
+function populateGitHubRepositories(payload) {
+  return {
+    type: POPULATE_GITHUB_REPOSITORIES,
     payload,
   };
 }

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -37,10 +37,13 @@ export {
 export {
   authenticate,
   CLEAR_GITHUB_INSTALLATIONS,
+  CLEAR_GITHUB_REPOSITORIES,
   fetchGitHubInstallations,
+  fetchGitHubRepositories,
   LOAD_GITHUB_SESSION_STATE,
   loadGitHubSessionState,
   POPULATE_GITHUB_INSTALLATIONS,
+  POPULATE_GITHUB_REPOSITORIES,
   POPULATE_GITHUB_USER_DATA,
   removeSession,
   exchangeGitHubAuthCode,

--- a/components/builder-web/app/initial-state.ts
+++ b/components/builder-web/app/initial-state.ts
@@ -30,9 +30,13 @@ export default Record({
     authState: undefined,
     authToken: undefined,
     installations: List(),
+    repositories: List(),
     username: undefined,
     ui: Record({
       installations: Record({
+        loading: false
+      })(),
+    repositories: Record({
         loading: false
       })()
     })()

--- a/components/builder-web/app/reducers/gitHub.ts
+++ b/components/builder-web/app/reducers/gitHub.ts
@@ -15,7 +15,6 @@
 import { fromJS, List } from 'immutable';
 import initialState from '../initial-state';
 import * as actionTypes from '../actions/index';
-import config from '../config';
 
 export default function gitHub(state = initialState['gitHub'], action) {
   switch (action.type) {
@@ -24,17 +23,21 @@ export default function gitHub(state = initialState['gitHub'], action) {
       return state.set('installations', List()).
         setIn(['ui', 'installations', 'loading'], true);
 
+    case actionTypes.CLEAR_GITHUB_REPOSITORIES:
+        return state.set('repositories', List()).
+          setIn(['ui', 'repositories', 'loading'], true);
+
     case actionTypes.LOAD_GITHUB_SESSION_STATE:
       return state.set('authState', action.payload.gitHubAuthState).
         set('authToken', action.payload.gitHubAuthToken);
 
     case actionTypes.POPULATE_GITHUB_INSTALLATIONS:
-      const filtered = action.payload.filter((i) => {
-        return i.app_id.toString() === config['github_app_id'];
-      });
-
-      return state.set('installations', fromJS(filtered)).
+      return state.set('installations', fromJS(action.payload)).
         setIn(['ui', 'installations', 'loading'], false);
+
+    case actionTypes.POPULATE_GITHUB_REPOSITORIES:
+      return state.set('repositories', fromJS(action.payload)).
+        setIn(['ui', 'repositories', 'loading'], false);
 
     case actionTypes.SET_GITHUB_AUTH_STATE:
       return state.set('authState', action.payload);

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -1,5 +1,27 @@
 .project-settings-component {
 
+  .select-list {
+    max-height: 198px;
+    overflow: auto;
+  }
+
+  .installation-selector {
+    h3 {
+      margin-top: 0;
+    }
+  }
+
+  @include tablet-up {
+    .installation-selector {
+      display: flex;
+
+      > div {
+        flex: 1;
+        margin-right: $default-margin;
+      }
+    }
+  }
+
   .note {
     margin-bottom: $default-margin;
     padding: $default-padding;
@@ -131,7 +153,7 @@
       border-radius: $default-radius;
       color: $white;
       padding: 4px 14px;
-      margin-bottom: 28px;
+      margin-bottom: $default-margin;
 
       li {
         display: inline-block;
@@ -174,7 +196,7 @@
     }
 
     .controls {
-      margin: 24px 0;
+      margin: $default-margin 0;
 
       a {
         cursor: pointer;

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -65,13 +65,10 @@
         <li [class.active]="selectedInstallation">Set path to Habitat plan file</li>
       </ol>
       <div class="installation" *ngIf="!selectedInstallation">
-        <h3>
-          GitHub Org / Repo
-        </h3>
-        <div *ngIf="loading">
+        <div *ngIf="loadingInstallations">
           <hab-icon symbol="loading" class="spinning"></hab-icon>
         </div>
-        <div *ngIf="!loading">
+        <div *ngIf="!loadingInstallations">
           <p *ngIf="installations.size === 0">
             It looks like you haven't yet installed the Habitat Builder app.
             <a href="{{ config['github_app_url'] }}" target="_blank">Install it on GitHub</a>, then come back here and
@@ -80,13 +77,37 @@
           </p>
           <div *ngIf="installations.size > 0">
             <p>
-              Enter the name of the GitHub organization and repository that
-              <strong>contains your Habitat plan file</strong>.
+              Choose the GitHub organization and repository that
+              <strong>contain your Habitat plan file</strong>.
             </p>
-            <hab-checking-input id="repo_path" name="repo_path" availableMessage="found." notAvailableMessage="not found. Please verify you've entered the name correctly and that the Habitat Builder GitHub app has been installed."
-              displayName="GitHub installation" [form]="form" [pattern]="false" [maxLength]="false" [isAvailable]="doesRepoExist"
-              [value]="selectedRepo" placeholder="{{username}}/example-app">
-            </hab-checking-input>
+            <div class="installation-selector">
+              <div>
+                <h3>Organization</h3>
+                <ul class="select-list installations">
+                  <li class="item" *ngFor="let install of installations"
+                    [class.active]="activeInstallation === install"
+                    (click)="pickInstallation(install)">
+                    {{ install.get('account').get('login') }}
+                  </li>
+                </ul>
+              </div>
+              <div>
+                <h3>Repository</h3>
+                <div *ngIf="!activeInstallation && !loadingRepositories">
+                  Choose an organization.
+                </div>
+                <div *ngIf="loadingRepositories">
+                  <hab-icon symbol="loading" class="spinning"></hab-icon>
+                </div>
+                <ul class="select-list repositories" *ngIf="activeInstallation && !loadingRepositories">
+                  <li class="item" *ngFor="let repo of repositories"
+                    [class.active]="activeRepo === repo"
+                    (click)="pickRepo(repo)">
+                    {{ repo.get('name') }}
+                  </li>
+                </ul>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -113,7 +134,7 @@
         </hab-docker-export-settings>
       </div>
       <div class="controls">
-        <button *ngIf="!selectedInstallation" mat-raised-button color="primary" class="button" (click)="selectRepo()" [disabled]="!validRepo">
+        <button *ngIf="!selectedInstallation" mat-raised-button color="primary" class="button" (click)="next()" [disabled]="!repoSelected">
           Next &raquo;
         </button>
         <button *ngIf="selectedInstallation" mat-raised-button color="primary" class="button" (click)="saveConnection()" [disabled]="!validProject">

--- a/components/builder-web/stylesheets/base/_lists.scss
+++ b/components/builder-web/stylesheets/base/_lists.scss
@@ -134,6 +134,18 @@
   }
 }
 
+.select-list {
+  @extend .toggle-list;
+
+  .item {
+
+    &.active {
+      background-color: $light-blue;
+      color: $dark-gray;
+    }
+  }
+}
+
 .action-list {
   @extend .list;
 


### PR DESCRIPTION
This change modifies the plan-connection UX to allow for click-based selection of organization and repositories. Doing so also allows us to cut way down on the number of API calls we make to GitHub.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes #149.

![tenor-221152835](https://user-images.githubusercontent.com/274700/35941631-c64b297c-0c07-11e8-98a1-f70ef74e13df.gif)
