### PR TITLE
Briefly delay the call to fetch origins

### DIFF
--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -127,7 +127,6 @@ export function createOrigin(body: object, token: string, isFirstOrigin = false,
 
     new BuilderApiClient(token).createOrigin(body).then(origin => {
       dispatch(setCurrentOriginCreatingFlag(false));
-      dispatch(fetchMyOrigins(token));
 
       if (isFirstOrigin || origin['default']) {
         dispatch(setCurrentOrigin(origin));
@@ -141,6 +140,14 @@ export function createOrigin(body: object, token: string, isFirstOrigin = false,
 
       dispatch(generateOriginKeys(origin['name'], token));
       callback(origin);
+
+      // We delay this call briefly to allow for data to propagate.
+      // Once this is resolved: https://github.com/habitat-sh/builder/issues/142
+      // we should be able to remove the setTimeout and just make the
+      // call immediately on successful create.
+      setTimeout(() => {
+        dispatch(fetchMyOrigins(token));
+      }, 1000);
     }).catch(error => {
       dispatch(setCurrentOriginCreatingFlag(false));
       dispatch(addNotification({


### PR DESCRIPTION
Currently, when a new origin is created, we make an immediate call to retrieve all origins, but the list that’s returned often leaves out the new origin because of a data-propagation issue. This temporary fix adds a one-second delay to leave enough time for that propagation to happen.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-5558424](https://user-images.githubusercontent.com/274700/35946503-db80d484-0c18-11e8-986c-8daecc848bc4.gif)
