### PR TITLE
Make srv components init hook respect datastore port binding

### DIFF
--- a/components/builder-jobsrv/habitat/hooks/init
+++ b/components/builder-jobsrv/habitat/hooks/init
@@ -3,8 +3,9 @@ set -e
 
 export PGPASSWORD="{{cfg.datastore.password}}"
 
-if [ $(psql -lw -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
-  createdb -w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
-fi
+PSQL_ARGS="-w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}"
+# shellcheck disable=SC2086
+# Create the DB or check that it exists
+createdb $PSQL_ARGS || psql -c ";" $PSQL_ARGS
 
 bldr-jobsrv migrate -c {{pkg.svc_config_path}}/config.toml

--- a/components/builder-originsrv/habitat/hooks/init
+++ b/components/builder-originsrv/habitat/hooks/init
@@ -3,8 +3,9 @@ set -e
 
 export PGPASSWORD="{{cfg.datastore.password}}"
 
-if [ $(psql -lw -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
-  createdb -w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
-fi
+PSQL_ARGS="-w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}"
+# shellcheck disable=SC2086
+# Create the DB or check that it exists
+createdb $PSQL_ARGS || psql -c ";" $PSQL_ARGS
 
 bldr-originsrv migrate -c {{pkg.svc_config_path}}/config.toml

--- a/components/builder-sessionsrv/habitat/hooks/init
+++ b/components/builder-sessionsrv/habitat/hooks/init
@@ -3,8 +3,9 @@ set -e
 
 export PGPASSWORD="{{cfg.datastore.password}}"
 
-if [ $(psql -lw -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
-  createdb -w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
-fi
+PSQL_ARGS="-w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}"
+# shellcheck disable=SC2086
+# Create the DB or check that it exists
+createdb $PSQL_ARGS || psql -c ";" $PSQL_ARGS
 
 bldr-sessionsrv migrate -c {{pkg.svc_config_path}}/config.toml


### PR DESCRIPTION
This makes jobsrv, originsrv and sessionsrv work when builder-datastore runs
on a port other than the psql default.

Fixes https://github.com/habitat-sh/builder/issues/175

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>