### PR TITLE
Fix the height of the orgs and repos lists

### DIFF
--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -1,7 +1,7 @@
 .project-settings-component {
 
   .select-list {
-    max-height: 198px;
+    height: 198px;
     overflow: auto;
   }
 


### PR DESCRIPTION
This is a minor tweak that accounts for lists containing only one or two items, which lay out a bit strangely in the project creation view.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-165953687](https://user-images.githubusercontent.com/274700/35997245-c7cf71e2-0ccd-11e8-895e-b8ea6daf8194.gif)