### PR TITLE
Remove scheduler from bundle

### DIFF
--- a/terraform/scripts/create_bootstrap_bundle.sh
+++ b/terraform/scripts/create_bootstrap_bundle.sh
@@ -94,7 +94,6 @@ builder_packages=(habitat/builder-api
                   habitat/builder-jobsrv
                   habitat/builder-originsrv
                   habitat/builder-router
-                  habitat/builder-scheduler
                   habitat/builder-sessionsrv
                   habitat/builder-worker)
 


### PR DESCRIPTION
Minor change - removed deprecated package from bootstrap bundle

Signed-off-by: Salim Alam <salam@chef.io>
