### PR TITLE
Fix terraform to work with habitat origin

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -758,13 +758,13 @@ resource "null_resource" "worker_studio_network" {
     //
     // TODO fn: This resouce will get deleted once the additional network interface is connected
     // at instance boot time. Until then (and this is a kludge), we'll stop the Supervisor with all
-    // of its services (including `core/builder-worker`), ensure that any attempted airlock
+    // of its services (including `habitat/builder-worker`), ensure that any attempted airlock
     // networking is not in place (via the `hab pkg exec` command), and finally restart the
     // Supervisor once the host networking has completed.
     inline = [
       "sudo mv /tmp/51-studio-init.cfg /etc/network/interfaces.d/51-studio-init.cfg",
       "sudo systemctl stop hab-sup",
-      "sudo hab pkg exec core/airlock airlock netns destroy --ns-dir /hab/svc/builder-worker/data/network/airlock-ns",
+      "sudo hab pkg exec habitat/airlock airlock netns destroy --ns-dir /hab/svc/builder-worker/data/network/airlock-ns",
       "sleep 60",
       "sudo systemctl restart networking.service",
       "sudo systemctl start hab-sup",

--- a/terraform/scripts/install_base_packages.sh
+++ b/terraform/scripts/install_base_packages.sh
@@ -123,13 +123,22 @@ log "Populating artifact cache"
 mkdir -p /hab/cache/artifacts
 cp ${tmpdir}/artifacts/* /hab/cache/artifacts
 
-for pkg in "${sup_packages[@]}" "${helper_packages[@]}" ${services_to_install[@]:-}
+for pkg in "${sup_packages[@]}" "${helper_packages[@]}"
 do
     pkg_name=${pkg##core/} # strip "core/" if it's there
     # Using a fake depot URL keeps us honest; this will fail loudly if
     # we need to go off the box to get *anything*
     HAB_BLDR_URL=http://not-a-real-depot.habitat.sh \
                  ${hab_bootstrap_bin} pkg install ${tmpdir}/artifacts/core-${pkg_name}-*.hart
+done
+
+for pkg in ${services_to_install[@]:-}
+do
+    pkg_name=${pkg##habitat/} # strip "core/" if it's there
+    # Using a fake depot URL keeps us honest; this will fail loudly if
+    # we need to go off the box to get *anything*
+    HAB_BLDR_URL=http://not-a-real-depot.habitat.sh \
+                 ${hab_bootstrap_bin} pkg install ${tmpdir}/artifacts/habitat-${pkg_name}-*.hart
 done
 
 # Now we ensure that the hab binary being used on the system is the


### PR DESCRIPTION
Fixes the Terraform script to work with the new habitat origin for builder services.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-41909469](https://user-images.githubusercontent.com/13542112/36010644-64cc59c2-0d07-11e8-92c7-5ba812d7641a.gif)
