### PR TITLE
Check for PEM file before starting worker

### DIFF
--- a/components/builder-worker/habitat/hooks/run
+++ b/components/builder-worker/habitat/hooks/run
@@ -6,4 +6,11 @@ export RUST_BACKTRACE=1
 export HAB_STUDIO_BACKLINE_PKG=core/hab-backline
 pkg_svc_run="bldr-worker start -c {{pkg.svc_config_path}}/config.toml"
 
+# Wait for pem file before starting the service
+while ! [ -f {{pkg.svc_files_path}}/builder-github-app.pem ];
+do
+    echo "Waiting for builder-github-app.pem"
+    sleep 30
+done
+
 exec ${pkg_svc_run} 2>&1


### PR DESCRIPTION
Check for PEM file in the builder-worker run hook - if the PEM file does not exist, the worker can crash if a job is queued.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-170557511](https://user-images.githubusercontent.com/13542112/36120760-1397a3aa-0ff9-11e8-9e06-627cfe330027.gif)
