### PR TITLE
Improve github failure logging

### DIFF
--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -121,6 +121,7 @@ pub fn repo_file_content(req: &mut Request) -> IronResult<Response> {
         match github.app_installation_token(install_id) {
             Ok(token) => token,
             Err(err) => {
+                warn!("unable to generate github app token, {}", err);
                 return Ok(Response::with((status::BadGateway, err.to_string())));
             }
         }
@@ -137,7 +138,10 @@ pub fn repo_file_content(req: &mut Request) -> IronResult<Response> {
     match github.contents(&token, repo_id, path) {
         Ok(None) => Ok(Response::with(status::NotFound)),
         Ok(search) => Ok(render_json(status::Ok, &search)),
-        Err(err) => Ok(Response::with((status::BadGateway, err.to_string()))),
+        Err(err) => {
+            warn!("unable to fetch github contents, {}", err);
+            Ok(Response::with((status::BadGateway, err.to_string())))
+        }
     }
 }
 
@@ -161,13 +165,17 @@ pub fn search_code(req: &mut Request) -> IronResult<Response> {
         match github.app_installation_token(install_id) {
             Ok(token) => token,
             Err(err) => {
+                warn!("unable to generate github app token, {}", err);
                 return Ok(Response::with((status::BadGateway, err.to_string())));
             }
         }
     };
     match github.search_code(&token, query) {
         Ok(search) => Ok(render_json(status::Ok, &search)),
-        Err(err) => Ok(Response::with((status::BadGateway, err.to_string()))),
+        Err(err) => {
+            warn!("unable to search github code, {}", err);
+            Ok(Response::with((status::BadGateway, err.to_string())))
+        }
     }
 }
 
@@ -189,6 +197,7 @@ fn handle_push(req: &mut Request, body: &str) -> IronResult<Response> {
     let token = match github.app_installation_token(hook.installation.id) {
         Ok(token) => token,
         Err(err) => {
+            warn!("unable to generate github app token, {}", err);
             return Ok(Response::with((status::BadGateway, err.to_string())));
         }
     };

--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -637,7 +637,7 @@ pub fn project_create(req: &mut Request) -> IronResult<Response> {
             let token = match github.app_installation_token(body.installation_id) {
                 Ok(token) => token,
                 Err(err) => {
-                    debug!("Error authenticating github app installation, {}", err);
+                    warn!("Error authenticating github app installation, {}", err);
                     return Ok(Response::with(status::Forbidden));
                 }
             };
@@ -651,7 +651,7 @@ pub fn project_create(req: &mut Request) -> IronResult<Response> {
                 Ok(Some(repo)) => project.set_vcs_data(repo.clone_url),
                 Ok(None) => return Ok(Response::with((status::NotFound, "rg:pc:2"))),
                 Err(e) => {
-                    debug!("Error finding github repo. e = {:?}", e);
+                    warn!("Error finding github repo. e = {:?}", e);
                     return Ok(Response::with((status::UnprocessableEntity, "rg:pc:1")));
                 }
             }
@@ -689,7 +689,7 @@ pub fn project_create(req: &mut Request) -> IronResult<Response> {
         }
         Ok(None) => return Ok(Response::with((status::NotFound, "rg:pc:5"))),
         Err(e) => {
-            debug!("Error fetching contents from GH. e = {:?}", e);
+            warn!("Error fetching contents from GH. e = {:?}", e);
             return Ok(Response::with((status::UnprocessableEntity, "rg:pc:2")));
         }
     }
@@ -790,7 +790,7 @@ pub fn project_update(req: &mut Request) -> IronResult<Response> {
             let token = match github.app_installation_token(body.installation_id) {
                 Ok(token) => token,
                 Err(err) => {
-                    debug!("Error authenticating github app installation, {}", err);
+                    warn!("Error authenticating github app installation, {}", err);
                     return Ok(Response::with(status::Forbidden));
                 }
             };
@@ -801,7 +801,7 @@ pub fn project_update(req: &mut Request) -> IronResult<Response> {
                 Ok(Some(repo)) => project.set_vcs_data(repo.clone_url),
                 Ok(None) => return Ok(Response::with((status::NotFound, "rg:pu:2"))),
                 Err(e) => {
-                    debug!("Error finding GH repo. e = {:?}", e);
+                    warn!("Error finding GH repo. e = {:?}", e);
                     return Ok(Response::with((status::UnprocessableEntity, "rg:pu:1")));
                 }
             }
@@ -836,7 +836,7 @@ pub fn project_update(req: &mut Request) -> IronResult<Response> {
         }
         Ok(None) => return Ok(Response::with((status::NotFound, "rg:pu:6"))),
         Err(e) => {
-            debug!("Erroring fetching contents from GH. e = {:?}", e);
+            warn!("Erroring fetching contents from GH. e = {:?}", e);
             return Ok(Response::with((status::UnprocessableEntity, "rg:pu:5")));
         }
     }

--- a/components/builder-sessionsrv/src/server/handlers.rs
+++ b/components/builder-sessionsrv/src/server/handlers.rs
@@ -351,7 +351,7 @@ fn assign_permissions(name: &str, flags: &mut FeatureFlags, state: &ServerState)
                     }
                 }
                 Ok(None) => (),
-                Err(err) => warn!("Failed to check team membership, {}", err),
+                Err(err) => warn!("Failed to check github team membership, {}", err),
             }
             for team in state.permissions.early_access_teams.iter() {
                 match state.github.check_team_membership(&token, *team, name) {
@@ -363,7 +363,7 @@ fn assign_permissions(name: &str, flags: &mut FeatureFlags, state: &ServerState)
                         }
                     }
                     Ok(None) => (),
-                    Err(err) => warn!("Failed to check team membership, {}", err),
+                    Err(err) => warn!("Failed to check github team membership, {}", err),
                 }
             }
             for team in state.permissions.build_worker_teams.iter() {
@@ -376,7 +376,7 @@ fn assign_permissions(name: &str, flags: &mut FeatureFlags, state: &ServerState)
                         }
                     }
                     Ok(None) => (),
-                    Err(err) => warn!("Failed to check team membership, {}", err),
+                    Err(err) => warn!("Failed to check github team membership, {}", err),
                 }
             }
         }

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -216,7 +216,7 @@ impl Runner {
                 self.workspace.job.get_project().get_name(),
                 err
             );
-            debug!("{}", msg);
+            warn!("{}", msg);
             self.logger.log(&msg);
 
             log_pipe.pipe_buffer(msg.as_bytes())?;


### PR DESCRIPTION
This change improves the github related error logging by adding and/or converting debug logs to warnings that can be collected via the syslog.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-28641516](https://user-images.githubusercontent.com/13542112/36130434-a9dd506c-1021-11e8-8d85-67d9df8a0202.gif)
