### PR TITLE
Retry failed log requests for running builds

### DIFF
--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -25,6 +25,10 @@ export {
   POPULATE_BUILD,
   POPULATE_BUILDS,
   STREAM_BUILD_LOG,
+  SET_BUILD_LOADING,
+  SET_BUILDS_LOADING,
+  SET_BUILD_LOG_LOADING,
+  SET_BUILD_LOG_NOT_FOUND,
   streamBuildLog,
   submitJob
 } from './builds';

--- a/components/builder-web/app/initial-state.ts
+++ b/components/builder-web/app/initial-state.ts
@@ -62,7 +62,19 @@ export default Record({
         is_complete: undefined,
         stream: undefined
       })(),
-      stream: false
+      stream: false,
+    })(),
+    ui: Record({
+      loading: false,
+      selected: Record({
+        info: Record({
+          loading: false
+        })(),
+        log: Record({
+          loading: false,
+          notFound: false
+        })()
+      })()
     })()
   })(),
   features: Record({

--- a/components/builder-web/app/package/build-detail/build-detail.component.html
+++ b/components/builder-web/app/package/build-detail/build-detail.component.html
@@ -5,9 +5,9 @@
       <span>Back to build jobs</span>
     </a>
   </section>
-  <div class="summary" *ngIf="buildState">
+  <div class="summary">
     <div class="status {{ statusClass }}">
-      <div>
+      <div *ngIf="buildState">
         <hab-icon [symbol]="statusIcon" [class]="statusClass" [title]="buildState | titlecase"></hab-icon>
         Build {{ buildState }}
       </div>
@@ -23,7 +23,7 @@
       </div>
     </div>
   </div>
-  <div class="controls" [ngStyle]="controlsStyles">
+  <div class="controls" [ngStyle]="controlsStyles" [hidden]="!showLog">
     <button type="button" class="jump-to-top" (click)="scrollToTop()">
       <hab-icon symbol="chevron-up"></hab-icon>
       <span>Jump to top</span>
@@ -34,6 +34,7 @@
     </button>
   </div>
   <div class="output-container {{ statusClass }}">
-    <pre class="output"></pre>
+    <pre class="output log" [hidden]="!showLog"></pre>
+    <pre class="output" [hidden]="!showPending">This job will begin in a moment.</pre>
   </div>
 </div>

--- a/components/builder-web/app/package/build-detail/build-detail.component.spec.ts
+++ b/components/builder-web/app/package/build-detail/build-detail.component.spec.ts
@@ -44,6 +44,7 @@ class MockAppStore {
       }
     };
   }
+  subscribe() { }
   dispatch() { }
 }
 

--- a/components/builder-web/app/reducers/builds.ts
+++ b/components/builder-web/app/reducers/builds.ts
@@ -21,55 +21,75 @@ export default function builds(state = initialState['builds'], action) {
 
     case actionTypes.CLEAR_BUILD:
       return state
-        .setIn(['selected', 'info'], Record({})());
+        .setIn(['selected', 'info'], Record({})())
+        .setIn(['ui', 'selected', 'info', 'loading'], false);
 
     case actionTypes.CLEAR_BUILD_LOG:
       state.get('selected').log.content.next([]);
 
-      return state.setIn(['selected', 'log'], {
-        start: undefined,
-        stop: undefined,
-        content: state.get('selected').log.content,
-        is_complete: undefined
-      });
+      return state
+        .setIn(['selected', 'log'], {
+          start: undefined,
+          stop: undefined,
+          content: state.get('selected').log.content,
+          is_complete: undefined
+        })
+        .setIn(['ui', 'selected', 'log', 'loading'], false);
 
     case actionTypes.CLEAR_BUILDS:
       return state
-        .setIn(['visible'], List());
+        .setIn(['visible'], List())
+        .setIn(['ui', 'loading'], false);
 
     case actionTypes.POPULATE_BUILD:
       return state.setIn(['selected', 'info'], action.payload);
 
     case actionTypes.POPULATE_BUILD_LOG:
-      let payload = action.payload;
-      let content = state.get('selected').log.content;
 
-      // It'll be common to get log requests for builds that haven't
-      // started yet (which will surface as errors), so in that case,
-      // we'll just hand back the current state.
       if (action.error) {
-        return state;
+        return state.setIn(['selected', 'log'], {
+          start: undefined,
+          stop: undefined,
+          content: state.get('selected').log.content,
+          is_complete: undefined
+        });
       }
+      else {
+        let payload = action.payload;
+        let content = state.get('selected').log.content;
 
-      if (payload.start === 0 && !payload.is_complete) {
-        content.next(payload.content || []);
-      }
-      else if (payload.content.length) {
-        content.next(payload.content);
-      }
+        if (payload.start === 0 && !payload.is_complete) {
+          content.next(payload.content || []);
+        }
+        else if (payload.content.length) {
+          content.next(payload.content);
+        }
 
-      return state.setIn(['selected', 'log'], {
-        start: payload.start,
-        stop: payload.stop,
-        content: content,
-        is_complete: payload.is_complete
-      });
+        return state.setIn(['selected', 'log'], {
+          start: payload.start,
+          stop: payload.stop,
+          content: content,
+          is_complete: payload.is_complete
+        });
+      }
 
     case actionTypes.POPULATE_BUILDS:
       return state.setIn(['visible'], List(action.payload));
 
     case actionTypes.STREAM_BUILD_LOG:
       return state.setIn(['selected', 'stream'], action.payload);
+
+    case actionTypes.SET_BUILD_LOADING:
+      return state.setIn(['ui', 'selected', 'info', 'loading'], action.payload);
+
+    case actionTypes.SET_BUILDS_LOADING:
+      return state.setIn(['ui', 'loading'], action.payload);
+
+    case actionTypes.SET_BUILD_LOG_LOADING:
+      return state.setIn(['ui', 'selected', 'log', 'loading'], action.payload);
+
+    case actionTypes.SET_BUILD_LOG_NOT_FOUND:
+      return state.setIn(['ui', 'selected', 'log', 'notFound'], action.payload);
 
     default:
       return state;

--- a/components/builder-web/app/shared/icon/icon.component.ts
+++ b/components/builder-web/app/shared/icon/icon.component.ts
@@ -31,7 +31,7 @@ export class IconComponent {
   get tooltip() {
     let tip;
 
-    if (this.title.trim() !== '') {
+    if (this.title && this.title.trim() !== '') {
       tip = this.title;
     }
 


### PR DESCRIPTION
Currently, when a user navigates to a running build job, there’s a chance the request for that job’s log output could 404 (e.g., before logging has begun), which leaves the user staring at an empty box that never gets updated. This change adds logic to retry every five seconds until the request succeeds (or the user navigates elsewhere).

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-55462236](https://user-images.githubusercontent.com/274700/36235203-17d44da4-11a4-11e8-800d-4f4c3bb7cb95.gif)
