### PR TITLE
[builder-worker] Temporarily remove `--tag-latest` when running Docker exporter

### DIFF
--- a/components/builder-worker/src/runner/docker.rs
+++ b/components/builder-worker/src/runner/docker.rs
@@ -98,9 +98,16 @@ impl<'a> DockerExporter<'a> {
         cmd.arg(&self.bldr_url);
         cmd.arg("--url");
         cmd.arg(&self.bldr_url);
-        if self.spec.latest_tag {
-            cmd.arg("--tag-latest");
-        }
+        // TODO fn: Due to the flag regrssion in 0.53.0, this flag does not exist and triggers an
+        // export failure. For the moment we will remove this flag which may result in some
+        // `:latest` tags not being pushed to remote repositories.
+        //
+        // As soon as the next stable release has shipped, the commenting out in this commit should
+        // be reverted.
+        //
+        // if self.spec.latest_tag {
+        //     cmd.arg("--tag-latest");
+        // }
         if self.spec.version_tag {
             cmd.arg("--tag-version");
         }


### PR DESCRIPTION
This is a stop-gap measure for the current stable release of
`core/hab-pkg-export-docker` which does not have a `--tag-latest` flag.

This commit should be reverted when habitat-sh/habitat#4617 is shipped
in the next stable release (which restores the latest flags).

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>