### PR TITLE
Use Builder error codes

### DIFF
--- a/components/builder-web/app/actions/builds.ts
+++ b/components/builder-web/app/actions/builds.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as depotApi from '../client/depot-api';
-import { BuilderApiClient } from '../client/builder-api';
+import { BuilderApiClient, ErrorCode } from '../client/builder-api';
 import { addNotification } from './notifications';
 import { DANGER, SUCCESS } from './notifications';
 
@@ -133,7 +133,7 @@ export function fetchBuildLog(id: string, token: string, start = 0) {
         dispatch(setBuildLogNotFound(true));
         dispatch(populateBuildLog(null, error));
 
-        if (error.message === 'Not Found' && getState().builds.selected.stream) {
+        if (error.code === ErrorCode.NotFound  && getState().builds.selected.stream) {
           doAfter(5000, fetchBuild(id, token));
           doAfter(5000, fetchBuildLog(id, token));
         }

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -20,6 +20,10 @@ import { AppStore } from '../app.store';
 import { addNotification, signOut } from '../actions/index';
 import { WARNING } from '../actions/notifications';
 
+
+export enum ErrorCode {
+  NotFound = 4
+}
 export class BuilderApiClient {
   private headers;
   private urlPrefix: string = `${config['habitat_api_url']}/v1`;
@@ -315,7 +319,7 @@ export class BuilderApiClient {
           if (response.ok) {
             resolve(response.json());
           } else {
-            reject(new Error(response.statusText));
+            response.json().then(reject);
           }
         })
         .catch(error => this.handleError(error, reject));


### PR DESCRIPTION
This change adds an `ErrorCode` enum that maps to [Builder’s error codes](https://github.com/habitat-sh/builder/blob/d6ea4585efa49f2f1a11e70d2869675cc7b9acbe/components/builder-protocol/protocols/net.proto#L12), and makes use of the `NotFound` error to handle responses for log files that don’t yet exist.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-70723691](https://user-images.githubusercontent.com/274700/36281966-6642f714-1254-11e8-88c7-2d7868353136.gif)
