### PR TITLE
Fix session flag for Builder session

### DIFF
--- a/components/builder-sessionsrv/src/server/handlers.rs
+++ b/components/builder-sessionsrv/src/server/handlers.rs
@@ -124,10 +124,10 @@ pub fn session_create(
     let mut msg = req.parse::<proto::SessionCreate>()?;
     debug!("session-create, {:?}", msg);
     let mut flags = FeatureFlags::default();
-    if env::var_os("HAB_FUNC_TEST").is_some() ||
-        msg.get_session_type() == proto::SessionType::Builder
-    {
+    if env::var_os("HAB_FUNC_TEST").is_some() {
         flags = FeatureFlags::empty();
+    } else if msg.get_session_type() == proto::SessionType::Builder {
+        flags = FeatureFlags::all();
     } else if msg.get_provider() == proto::OAuthProvider::GitHub {
         assign_permissions(msg.get_name(), &mut flags, state)
     }


### PR DESCRIPTION
This fixes up session creation for build workers - the correct privileges were not getting set.

Signed-off-by: Salim Alam <salam@chef.io>