### PR TITLE
Fix non-existent-user invitation message

### DIFF
--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -15,11 +15,9 @@
 import 'whatwg-fetch';
 import config from '../config';
 import { parseKey } from '../util';
-import { GitHubApiClient } from './github-api';
 import { AppStore } from '../app.store';
 import { addNotification, signOut } from '../actions/index';
 import { WARNING } from '../actions/notifications';
-
 
 export enum ErrorCode {
   NotFound = 4
@@ -533,12 +531,9 @@ export class BuilderApiClient {
           if (response.ok) {
             resolve(true);
           } else if (response.status === 404) {
-            new GitHubApiClient(this.token).getUser(username).then(ghResponse => {
-              let msg = 'This is a valid GitHub user but they have not signed into Builder yet. Once they sign in, you can invite them to your origin.';
-              reject(new Error(msg));
-            }).catch(error => reject(error));
+            reject(new Error(`We were unable to locate a Builder user named ${username}. Please ensure the user has signed into Builder at least once before, then send the invitation again.`));
           } else if (response.status === 409) {
-            reject(new Error(`An invitation already exists for '${username}'`));
+            reject(new Error(`An invitation already exists for ${username}.`));
           } else {
             reject(new Error(response.statusText));
           }


### PR DESCRIPTION
Currently, when an invitation is extended to a user who hasn’t signed into Builder before, the error message we surface is simply `Unauthorized`, which is not helpful. This just changes that messages to make it clearer what needs to be done.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-63173793](https://user-images.githubusercontent.com/274700/36454150-9ecd966c-164f-11e8-9abb-1785c68ca017.gif)

