### PR TITLE
Remove forced overflow-y: scroll

### DIFF
--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -140,7 +140,6 @@ main {
   bottom: 0;
   left: 0;
   background-color: $white;
-  overflow-y: scroll;
 
   .full &, .sign-in & {
     background: transparent;


### PR DESCRIPTION

This removes the scroll bar that shows up in the sign-in view

![](https://media3.giphy.com/media/OjmiOjUPzJSSI/200w.gif)
Signed-off-by: Elliott Davis elliott@excellent.io