### PR TITLE
Unpin worker

### DIFF
--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_deps=(habitat/airlock core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
-  core/libarchive core/zlib core/hab-studio core/hab-pkg-export-docker core/docker/17.09.0 core/curl)
+  core/libarchive core/zlib core/hab-studio core/hab-pkg-export-docker core/docker core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
 pkg_binds=(


### PR DESCRIPTION
Unpin the worker since stable hab-pkg-export-docker is now updated to latest docker.

Signed-off-by: Salim Alam <salam@chef.io>