### PR TITLE
Revert "Remove forced overflow-y: scroll"

### DIFF
--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -140,6 +140,7 @@ main {
   bottom: 0;
   left: 0;
   background-color: $white;
+  overflow-y: scroll;
 
   .full &, .sign-in & {
     background: transparent;


### PR DESCRIPTION
This reverts commit 71d319c7c460bdc8b712f4abc63bcdaa83e6bcbf.

The `overflow-y: scroll` is necessary here for the overall site layout. (It is apparently also causing a display issue on Linux, which I'll file a separate issue for.)

![](https://i.giphy.com/media/xUOwFU9aegl1O99rfG/200w.gif)
