### PR TITLE
Tweak scrollbar visibility

### DIFF
--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -140,7 +140,7 @@ main {
   bottom: 0;
   left: 0;
   background-color: $white;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   .full &, .sign-in & {
     background: transparent;

--- a/components/builder-web/app/shared/copyable/_copyable.component.scss
+++ b/components/builder-web/app/shared/copyable/_copyable.component.scss
@@ -9,6 +9,7 @@ hab-copyable {
   $button-height: 36px;
 
   &.input {
+    overflow-x: hidden;
 
     span {
       display: block;
@@ -16,7 +17,7 @@ hab-copyable {
       padding: 6px 8px;
       border: $default-border;
       border-radius: $default-radius 0 0 $default-radius;
-      overflow-x: auto;
+      overflow-x: scroll;
       margin-right: $button-width;
       white-space: nowrap;
       height: $button-height;


### PR DESCRIPTION
This change hides the horizontal scrollbars in the copyable component, and fixes a visible scrollbar on the sign-in screen.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/63I6FXZTXks2A/200w.gif)