### PR TITLE
Enable statsd metrics for github calls

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -12,6 +12,7 @@ export SSL_CERT_FILE
 export GITHUB_APP_ID
 export GITHUB_APP_URL
 export DEV_MODE
+export HAB_STATS_ADDR
 
 # Wrap a function with this one to ensure that it stops executing if any of its
 # commands return nonzero. If so, a highly-visible message is printed which

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -22,7 +22,6 @@ extern crate builder_http_gateway as http_gateway;
 extern crate constant_time_eq;
 extern crate github_api_client;
 extern crate habitat_builder_protocol as protocol;
-#[macro_use]
 extern crate habitat_core as hab_core;
 extern crate habitat_depot as depot;
 extern crate habitat_http_client as http_client;

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -18,13 +18,12 @@ use std::path::PathBuf;
 
 use depot;
 use github_api_client::GitHubClient;
-use hab_core::event::EventLogger;
 use http_gateway;
 use http_gateway::app::prelude::*;
 use hab_net::privilege::FeatureFlags;
 use iron;
 use mount::Mount;
-use persistent::{self, Read};
+use persistent;
 use segment_api_client::SegmentClient;
 use staticfile::Static;
 
@@ -45,9 +44,6 @@ impl HttpGateway for ApiSrv {
         ));
         chain.link(persistent::Read::<SegmentCli>::both(
             SegmentClient::new(config.segment.clone()),
-        ));
-        chain.link(Read::<EventLog>::both(
-            EventLogger::new(&config.log_dir, config.events_enabled),
         ));
         chain.link_after(Cors);
     }

--- a/components/builder-core/src/metrics.rs
+++ b/components/builder-core/src/metrics.rs
@@ -27,6 +27,10 @@ pub const STATS_ENV: &'static str = "HAB_STATS_ADDR";
 // Supported metrics
 #[derive(Debug, Clone)]
 pub enum Counter {
+    GithubApi,
+    GithubAuthenticate,
+    GithubEvent,
+    GithubInstallationToken,
     SearchPackages,
 }
 
@@ -122,10 +126,11 @@ fn receive(rz: SyncSender<()>, rx: Receiver<MetricTuple>) {
 fn statsd_client() -> Option<Client> {
     match env::var(STATS_ENV) {
         Ok(addr) => {
+            info!("Creating statsd client with addr: {}", addr);
             match Client::new(&addr, APP_NAME) {
                 Ok(c) => Some(c),
                 Err(e) => {
-                    debug!("Error creating statsd client: {:?}", e);
+                    error!("Error creating statsd client: {:?}", e);
                     None
                 }
             }
@@ -177,6 +182,10 @@ impl Gauge {
 impl Metric for Counter {
     fn id(&self) -> &'static str {
         match *self {
+            Counter::GithubApi => "github.api",
+            Counter::GithubAuthenticate => "github.authenticate",
+            Counter::GithubEvent => "github.event",
+            Counter::GithubInstallationToken => "github.installation-token",
             Counter::SearchPackages => "search-packages",
         }
     }

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -16,7 +16,6 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_builder_protocol as protocol;
-#[macro_use]
 extern crate habitat_core as hab_core;
 extern crate habitat_net as hab_net;
 extern crate builder_core as bldr_core;

--- a/components/builder-http-gateway/src/http/middleware.rs
+++ b/components/builder-http-gateway/src/http/middleware.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use base64;
-use bldr_core;
+use bldr_core::{self, metrics};
 use core::env;
 use github_api_client::{GitHubCfg, GitHubClient, HubError};
 use hab_net::{ErrCode, NetError};
@@ -279,6 +279,10 @@ pub fn session_create_github(req: &mut Request, token: &str) -> IronResult<Sessi
     let conn = req.extensions.get_mut::<XRouteClient>().expect(
         "no XRouteClient extension in request",
     );
+    debug!(
+        "GITHUB-CALL builder_http-gateway::middleware::session_create_github: Checking user with access token",
+    );
+    metrics::Counter::GithubApi.increment();
     match github.user(&token) {
         Ok(user) => {
             let mut request = SessionCreate::new();


### PR DESCRIPTION
This change enables use of statsd metrics - it adds some counters for tracking github API calls. There's also some misc cleanup (removes unused event handling), and adds some additional logging for the github APIs.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-190119237](https://user-images.githubusercontent.com/13542112/36939078-30b0ebe0-1ee0-11e8-8f5f-3d784153cb35.gif)
