### PR TITLE
Missed connection reply in token validation

### DIFF
--- a/components/builder-sessionsrv/src/server/handlers.rs
+++ b/components/builder-sessionsrv/src/server/handlers.rs
@@ -203,6 +203,7 @@ pub fn account_token_validate(
 
     // Builder tokens are never in the DB and are not revocable
     if account_id == bldr_core::access_token::BUILDER_ACCOUNT_ID {
+        conn.route_reply(req, &NetOk::new())?;
         return Ok(());
     }
 


### PR DESCRIPTION
1-liner fix to add a missing reply to token validation. Makes builds work again.

Signed-off-by: Salim Alam <salam@chef.io>