### PR TITLE
Improve side-scrolling

### DIFF
--- a/components/builder-web/app/shared/copyable/_copyable.component.scss
+++ b/components/builder-web/app/shared/copyable/_copyable.component.scss
@@ -17,7 +17,8 @@ hab-copyable {
       padding: 6px 8px;
       border: $default-border;
       border-radius: $default-radius 0 0 $default-radius;
-      overflow-x: scroll;
+      overflow-x: auto;
+      overflow-y: hidden;
       margin-right: $button-width;
       white-space: nowrap;
       height: $button-height;


### PR DESCRIPTION
This is a minor CSS fix that helps to improve the appearance of our side-scrolling input boxes on Linux.

Signed-off-by: Christian Nunciato <chris@nunciato.org>