### PR TITLE
Bump moment.js to 2.21.0

### DIFF
--- a/components/builder-web/package-lock.json
+++ b/components/builder-web/package-lock.json
@@ -1744,7 +1744,7 @@
       "integrity": "sha1-TZmZeKHSC7RgjnzUNNdBZSJVF0s=",
       "dev": true,
       "requires": {
-        "moment": "2.19.1"
+        "moment": "2.21.0"
       }
     },
     "console-browserify": {
@@ -6045,9 +6045,9 @@
       }
     },
     "moment": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
-      "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "ms": {
       "version": "2.0.0",

--- a/components/builder-web/package.json
+++ b/components/builder-web/package.json
@@ -56,7 +56,7 @@
     "js-cookie": "^2.1.4",
     "lodash": "^4.17.4",
     "marked": "^0.3.9",
-    "moment": "^2.18.1",
+    "moment": "^2.21.0",
     "parse-link-header": "^0.4.1",
     "redux": "^3.6.0",
     "redux-reset": "^0.3.0",


### PR DESCRIPTION
This updates the moment.js library to its latest version.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/tn8zWeNYA73G0/200w.gif)