### PR TITLE
Add GitHub client crate from habitat repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
  "bodyparser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",
  "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_net 0.0.0",
@@ -638,7 +638,6 @@ dependencies = [
 [[package]]
 name = "github-api-client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#8bd1b4326e46eb550a590d5543061093913225f2"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "frank_jwt 2.5.1 (git+https://github.com/habitat-sh/frank_jwt?branch=habitat)",
@@ -702,7 +701,7 @@ dependencies = [
  "clippy 0.0.187 (registry+https://github.com/rust-lang/crates.io-index)",
  "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_depot 0.0.0",
@@ -871,7 +870,7 @@ dependencies = [
  "diesel 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",
  "habitat_builder_db 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -901,7 +900,7 @@ dependencies = [
  "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_depot_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
@@ -965,7 +964,7 @@ dependencies = [
  "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.187 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_net 0.0.0",
@@ -2811,7 +2810,6 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
 "checksum git2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4813cd7ad02e53275e6e51aaaf21c30f9ef500b579ad7a54a92f6091a7ac296"
-"checksum github-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/builder.git)" = "<none>"
 "checksum habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "components/builder-router",
   "components/builder-sessionsrv",
   "components/builder-worker",
+  "components/github-api-client",
   "components/net",
   "components/op"
 ]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UNAME_S := $(shell uname -s)
 BIN = airlock
-LIB = builder-db builder-core net
+LIB = builder-db builder-core github-api-client net
 SRV = builder-api builder-depot builder-router builder-jobsrv builder-sessionsrv builder-originsrv builder-worker
 ALL = $(BIN) $(LIB) $(SRV)
 VERSION := $(shell cat VERSION)

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -46,7 +46,7 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [dependencies.github-api-client]
-git = "https://github.com/habitat-sh/habitat.git"
+path = "../github-api-client"
 
 [dependencies.segment-api-client]
 git = "https://github.com/habitat-sh/habitat.git"

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -44,7 +44,7 @@ features = [ "suggestions", "color", "unstable" ]
 path = "../builder-core"
 
 [dependencies.github-api-client]
-git = "https://github.com/habitat-sh/habitat.git"
+path = "../github-api-client"
 
 [dependencies.segment-api-client]
 git = "https://github.com/habitat-sh/habitat.git"

--- a/components/builder-http-gateway/Cargo.toml
+++ b/components/builder-http-gateway/Cargo.toml
@@ -37,7 +37,7 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [dependencies.github-api-client]
-git = "https://github.com/habitat-sh/habitat.git"
+path = "../github-api-client"
 
 [dependencies.segment-api-client]
 git = "https://github.com/habitat-sh/habitat.git"

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -36,7 +36,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.github-api-client]
-git = "https://github.com/habitat-sh/habitat.git"
+path = "../github-api-client"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -39,7 +39,7 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [dependencies.github-api-client]
-git = "https://github.com/habitat-sh/habitat.git"
+path = "../github-api-client"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/github-api-client/Cargo.toml
+++ b/components/github-api-client/Cargo.toml
@@ -17,4 +17,4 @@ serde_json = "*"
 time = "*"
 
 [dependencies.habitat_http_client]
-path = "../http-client"
+git = "https://github.com/habitat-sh/habitat.git"

--- a/components/github-api-client/Cargo.toml
+++ b/components/github-api-client/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "github-api-client"
+version = "0.0.0"
+authors = ["Jamie Winsor <reset@habitat.sh>", "Josh Black <raskchanky@gmail.com>"]
+workspace = "../../"
+
+[dependencies]
+base64 = "*"
+frank_jwt = { git = "https://github.com/habitat-sh/frank_jwt", branch = "habitat" }
+hyper = "0.10"
+hyper-openssl = "0.2"
+log = "*"
+regex = "*"
+serde = "*"
+serde_derive = "*"
+serde_json = "*"
+time = "*"
+
+[dependencies.habitat_http_client]
+path = "../http-client"

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -1,0 +1,353 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::time::{UNIX_EPOCH, Duration, SystemTime};
+
+use hab_http::ApiClient;
+use hyper::{self, Url};
+use hyper::client::IntoUrl;
+use hyper::status::StatusCode;
+use hyper::header::{Authorization, Accept, Bearer, UserAgent, qitem};
+use hyper::mime::{Mime, TopLevel, SubLevel};
+use jwt;
+use serde_json;
+
+use config::GitHubCfg;
+use error::{HubError, HubResult};
+use types::*;
+
+const USER_AGENT: &'static str = "Habitat-Builder";
+
+#[derive(Clone)]
+pub struct GitHubClient {
+    pub url: String,
+    pub web_url: String,
+    pub client_id: String,
+    pub client_secret: String,
+    app_id: u32,
+    app_private_key: String,
+    pub webhook_secret: String,
+}
+
+impl GitHubClient {
+    pub fn new(config: GitHubCfg) -> Self {
+        GitHubClient {
+            url: config.url,
+            web_url: config.web_url,
+            client_id: config.client_id,
+            client_secret: config.client_secret,
+            app_id: config.app_id,
+            app_private_key: config.app_private_key,
+            webhook_secret: config.webhook_secret,
+        }
+    }
+
+    pub fn app(&self) -> HubResult<App> {
+        let app_token = generate_app_token(&self.app_private_key, &self.app_id);
+        let url = Url::parse(&format!("{}/app", self.url)).map_err(
+            HubError::HttpClientParse,
+        )?;
+        let mut rep = http_get(url, Some(app_token))?;
+        let mut body = String::new();
+        rep.read_to_string(&mut body)?;
+        debug!("GitHub response body, {}", body);
+        if rep.status != StatusCode::Ok {
+            let err: HashMap<String, String> = serde_json::from_str(&body)?;
+            return Err(HubError::ApiError(rep.status, err));
+        }
+        let contents = serde_json::from_str::<App>(&body)?;
+        Ok(contents)
+    }
+
+    pub fn app_installation_token(&self, install_id: u32) -> HubResult<String> {
+        let app_token = generate_app_token(&self.app_private_key, &self.app_id);
+        let url = Url::parse(&format!(
+            "{}/installations/{}/access_tokens",
+            self.url,
+            install_id
+        )).map_err(HubError::HttpClientParse)?;
+        let mut rep = http_post(url, Some(app_token))?;
+        let mut body = String::new();
+        rep.read_to_string(&mut body)?;
+        debug!("GitHub response body, {}", body);
+        match serde_json::from_str::<AppInstallationToken>(&body) {
+            Ok(msg) => Ok(msg.token),
+            Err(_) => {
+                let err = serde_json::from_str::<AppAuthErr>(&body)?;
+                Err(HubError::AppAuth(err))
+            }
+        }
+    }
+
+    pub fn authenticate(&self, code: &str) -> HubResult<String> {
+        let url = Url::parse(&format!(
+            "{}/login/oauth/access_token?client_id={}&client_secret={}&code={}",
+            self.web_url,
+            self.client_id,
+            self.client_secret,
+            code
+        )).map_err(HubError::HttpClientParse)?;
+        let mut rep = http_post(url, None::<String>)?;
+        if rep.status.is_success() {
+            let mut body = String::new();
+            rep.read_to_string(&mut body)?;
+            debug!("GitHub response body, {}", body);
+            match serde_json::from_str::<AuthOk>(&body) {
+                Ok(msg) => Ok(msg.access_token),
+                Err(_) => {
+                    let err = serde_json::from_str::<AuthErr>(&body)?;
+                    Err(HubError::Auth(err))
+                }
+            }
+        } else {
+            Err(HubError::HttpResponse(rep.status))
+        }
+    }
+
+    pub fn check_team_membership(
+        &self,
+        token: &str,
+        team: u32,
+        user: &str,
+    ) -> HubResult<Option<TeamMembership>> {
+        let url = Url::parse(&format!("{}/teams/{}/memberships/{}", self.url, team, user))
+            .map_err(HubError::HttpClientParse)?;
+        let mut rep = http_get(url, Some(token))?;
+        let mut body = String::new();
+        rep.read_to_string(&mut body)?;
+        debug!("GitHub response body, {}", body);
+        match rep.status {
+            StatusCode::NotFound => return Ok(None),
+            StatusCode::Ok => (),
+            status => {
+                let err: HashMap<String, String> = serde_json::from_str(&body)?;
+                return Err(HubError::ApiError(status, err));
+            }
+        }
+        let membership = serde_json::from_str(&body)?;
+        Ok(Some(membership))
+    }
+
+    /// Returns the contents of a file or directory in a repository.
+    pub fn contents(&self, token: &str, repo: u32, path: &str) -> HubResult<Option<Contents>> {
+        let url = Url::parse(&format!(
+            "{}/repositories/{}/contents/{}",
+            self.url,
+            repo,
+            path
+        )).map_err(HubError::HttpClientParse)?;
+        let mut rep = http_get(url, Some(token))?;
+        let mut body = String::new();
+        rep.read_to_string(&mut body)?;
+        debug!("GitHub response body, {}", body);
+        match rep.status {
+            StatusCode::NotFound => return Ok(None),
+            StatusCode::Ok => (),
+            status => {
+                let err: HashMap<String, String> = serde_json::from_str(&body)?;
+                return Err(HubError::ApiError(status, err));
+            }
+        }
+        let mut contents: Contents = serde_json::from_str(&body)?;
+        // We need to strip line feeds as the Github API has started to return
+        // base64 content with line feeds.
+        if contents.encoding == "base64" {
+            contents.content = contents.content.replace("\n", "");
+        }
+        Ok(Some(contents))
+    }
+
+    pub fn repo(&self, token: &str, repo: u32) -> HubResult<Option<Repository>> {
+        let url = Url::parse(&format!("{}/repositories/{}", self.url, repo)).unwrap();
+        let mut rep = http_get(url, Some(token))?;
+        let mut body = String::new();
+        rep.read_to_string(&mut body)?;
+        debug!("GitHub response body, {}", body);
+        match rep.status {
+            StatusCode::NotFound => return Ok(None),
+            StatusCode::Ok => (),
+            status => {
+                let err: HashMap<String, String> = serde_json::from_str(&body)?;
+                return Err(HubError::ApiError(status, err));
+            }
+        }
+        let value = serde_json::from_str(&body)?;
+        Ok(Some(value))
+    }
+
+    pub fn user(&self, token: &str) -> HubResult<User> {
+        let url = Url::parse(&format!("{}/user", self.url)).unwrap();
+        let mut rep = http_get(url, Some(token))?;
+        let mut body = String::new();
+        rep.read_to_string(&mut body)?;
+        debug!("GitHub response body, {}", body);
+        if rep.status != StatusCode::Ok {
+            let err: HashMap<String, String> = serde_json::from_str(&body)?;
+            return Err(HubError::ApiError(rep.status, err));
+        }
+        let user = serde_json::from_str(&body)?;
+        Ok(user)
+    }
+
+    // The main purpose of this is just to verify HTTP communication with GH.
+    // There's nothing special about this endpoint, only that it doesn't require
+    // auth and the response body seemed small. We don't even care what the
+    // response is. For our purposes, just receiving a response is enough.
+    pub fn meta(&self) -> HubResult<()> {
+        let url = Url::parse(&format!("{}/meta", self.url)).unwrap();
+        let mut rep = http_get(url, None::<String>)?;
+        let mut body = String::new();
+        rep.read_to_string(&mut body)?;
+        debug!("GitHub response body, {}", body);
+
+        if rep.status != StatusCode::Ok {
+            let err: HashMap<String, String> = serde_json::from_str(&body)?;
+            return Err(HubError::ApiError(rep.status, err));
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct RepositoryList {
+    pub total_count: u32,
+    pub repositories: Vec<Repository>,
+}
+
+fn generate_app_token<T, U>(key_path: T, app_id: U) -> String
+where
+    T: ToString,
+    U: ToString,
+{
+    let mut payload = jwt::Payload::new();
+    let header = jwt::Header::new(jwt::Algorithm::RS256);
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    let expiration = now + Duration::from_secs(10 * 10);
+    payload.insert("iat".to_string(), now.as_secs().to_string());
+    payload.insert("exp".to_string(), expiration.as_secs().to_string());
+    payload.insert("iss".to_string(), app_id.to_string());
+    jwt::encode(header, key_path.to_string(), payload)
+}
+
+fn http_get<T, U>(url: T, token: Option<U>) -> HubResult<hyper::client::response::Response>
+where
+    T: IntoUrl,
+    U: ToString,
+{
+    let u = url.into_url().map_err(HubError::HttpClientParse)?;
+    let endpoint = format!("{}://{}", u.scheme(), u.host_str().unwrap());
+    let mut path = u.path();
+
+    // ApiClient expects path to not have a leading slash, so if we detect one here (which is
+    // almost always the case), then strip it off before passing it on. Failure to do so results in
+    // URLs that look like https://api.github.com//meta, which obviously 404s.
+    if path.starts_with("/") && path.len() > 1 {
+        path = path.get(1..).unwrap();
+    }
+
+    let client = http_client(endpoint.as_str())?;
+    let req = client.get_with_custom_url(path, |url| if u.query().is_some() {
+        url.set_query(Some(u.query().unwrap()))
+    });
+
+    let req = req.header(Accept(vec![
+        qitem(
+            Mime(TopLevel::Application, SubLevel::Json, vec![])
+        ),
+        qitem("application/vnd.github.v3+json".parse().unwrap()),
+        qitem(
+            "application/vnd.github.machine-man-preview+json"
+                .parse()
+                .unwrap()
+        ),
+    ])).header(UserAgent(USER_AGENT.to_string()));
+    let req = match token {
+        Some(token) => req.header(Authorization(Bearer { token: token.to_string() })),
+        None => req,
+    };
+    req.send().map_err(HubError::HttpClient)
+}
+
+fn http_post<T, U>(url: T, token: Option<U>) -> HubResult<hyper::client::response::Response>
+where
+    T: IntoUrl,
+    U: ToString,
+{
+    let u = url.into_url().map_err(HubError::HttpClientParse)?;
+    let endpoint = format!("{}://{}", u.scheme(), u.host_str().unwrap());
+    let mut path = u.path();
+
+    if path.starts_with("/") && path.len() > 1 {
+        path = path.get(1..).unwrap();
+    }
+
+    let client = http_client(endpoint.as_str())?;
+    let req = client.post_with_custom_url(path, |url| if u.query().is_some() {
+        url.set_query(Some(u.query().unwrap()))
+    });
+
+    let req = req.header(Accept(vec![
+        qitem(
+            Mime(TopLevel::Application, SubLevel::Json, vec![])
+        ),
+        qitem("application/vnd.github.v3+json".parse().unwrap()),
+        qitem(
+            "application/vnd.github.machine-man-preview+json"
+                .parse()
+                .unwrap()
+        ),
+    ])).header(UserAgent(USER_AGENT.to_string()));
+    let req = match token {
+        Some(token) => req.header(Authorization(Bearer { token: token.to_string() })),
+        None => req,
+    };
+    req.send().map_err(HubError::HttpClient)
+}
+
+fn http_client<T>(url: T) -> HubResult<ApiClient>
+where
+    T: IntoUrl,
+{
+    ApiClient::new(url, "hab", "0.53.0", None).map_err(HubError::ApiClient)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use super::*;
+    use config;
+
+    #[test]
+    fn use_a_proxy_from_the_env() {
+        let proxy = env::var_os("HTTPS_PROXY");
+
+        if proxy.is_some() {
+            let p = proxy.unwrap();
+            let pp = p.to_string_lossy();
+
+            if !pp.is_empty() {
+                let cfg = config::GitHubCfg::default();
+                let client = GitHubClient::new(cfg);
+                assert_eq!(client.meta().unwrap(), ());
+            } else {
+                assert!(true);
+            }
+        } else {
+            assert!(true);
+        }
+    }
+}

--- a/components/github-api-client/src/config.rs
+++ b/components/github-api-client/src/config.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// URL to GitHub API endpoint
+pub const DEFAULT_GITHUB_URL: &'static str = "https://api.github.com";
+/// URL to GitHub Web endpoint
+pub const DEFAULT_GITHUB_WEB_URL: &'static str = "https://github.com";
+/// Default Client ID providing a value in development environments only.
+///
+/// See https://developer.github.com/apps
+pub const DEV_GITHUB_CLIENT_ID: &'static str = "Iv1.732260b62f84db15";
+/// Default Client Secret providing a value in development environments only.
+///
+/// See https://developer.github.com/apps
+pub const DEV_GITHUB_CLIENT_SECRET: &'static str = "fc7654ed8c65ccfe014cd339a55e3538f935027a";
+/// Default github application id created in the habitat-sh org
+pub const DEFAULT_GITHUB_APP_ID: u32 = 5629;
+/// Webhook secret token
+pub const DEV_GITHUB_WEBHOOK_SECRET: &'static str = "58d4afaf5e5617ab0f8c39e505605e78a054d003";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct GitHubCfg {
+    /// URL to GitHub API
+    pub url: String,
+    /// URL to GitHub Web
+    pub web_url: String,
+    /// Path to GitHub App private key
+    pub app_private_key: String,
+    /// Client identifier used for GitHub API requests
+    pub client_id: String,
+    /// Client secret used for GitHub API requests
+    pub client_secret: String,
+    /// App Id used for builder integration
+    pub app_id: u32,
+    /// Secret key for validating payloads sent by a GitHub WebHook
+    pub webhook_secret: String,
+}
+
+impl Default for GitHubCfg {
+    fn default() -> Self {
+        GitHubCfg {
+            url: DEFAULT_GITHUB_URL.to_string(),
+            web_url: DEFAULT_GITHUB_WEB_URL.to_string(),
+            app_private_key: "/src/.secrets/builder-github-app.pem".to_string(),
+            client_id: DEV_GITHUB_CLIENT_ID.to_string(),
+            client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),
+            app_id: DEFAULT_GITHUB_APP_ID,
+            webhook_secret: DEV_GITHUB_WEBHOOK_SECRET.to_string(),
+        }
+    }
+}

--- a/components/github-api-client/src/error.rs
+++ b/components/github-api-client/src/error.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::error;
+use std::fmt;
+use std::io;
+
+use base64;
+use hyper;
+use serde_json;
+use hab_http;
+
+use types;
+
+pub type HubResult<T> = Result<T, HubError>;
+
+#[derive(Debug)]
+pub enum HubError {
+    ApiClient(hab_http::Error),
+    ApiError(hyper::status::StatusCode, HashMap<String, String>),
+    AppAuth(types::AppAuthErr),
+    Auth(types::AuthErr),
+    ContentDecode(base64::DecodeError),
+    HttpClient(hyper::Error),
+    HttpClientParse(hyper::error::ParseError),
+    HttpResponse(hyper::status::StatusCode),
+    IO(io::Error),
+    Serialization(serde_json::Error),
+}
+
+impl fmt::Display for HubError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            HubError::ApiClient(ref e) => format!("{}", e),
+            HubError::ApiError(ref code, ref response) => {
+                format!(
+                    "Received a non-200 response, status={}, response={:?}",
+                    code,
+                    response
+                )
+            }
+            HubError::AppAuth(ref e) => format!("GitHub App Authentication error, {}", e),
+            HubError::Auth(ref e) => format!("GitHub Authentication error, {}", e),
+            HubError::ContentDecode(ref e) => format!("{}", e),
+            HubError::HttpClient(ref e) => format!("{}", e),
+            HubError::HttpClientParse(ref e) => format!("{}", e),
+            HubError::HttpResponse(ref e) => format!("{}", e),
+            HubError::IO(ref e) => format!("{}", e),
+            HubError::Serialization(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for HubError {
+    fn description(&self) -> &str {
+        match *self {
+            HubError::ApiClient(ref err) => err.description(),
+            HubError::ApiError(_, _) => "Response returned a non-200 status code.",
+            HubError::AppAuth(_) => "GitHub App authorization error.",
+            HubError::Auth(_) => "GitHub authorization error.",
+            HubError::ContentDecode(ref err) => err.description(),
+            HubError::HttpClient(ref err) => err.description(),
+            HubError::HttpClientParse(ref err) => err.description(),
+            HubError::HttpResponse(_) => "Non-200 HTTP response.",
+            HubError::IO(ref err) => err.description(),
+            HubError::Serialization(ref err) => err.description(),
+        }
+    }
+}
+
+impl From<types::AuthErr> for HubError {
+    fn from(err: types::AuthErr) -> Self {
+        HubError::Auth(err)
+    }
+}
+
+impl From<hyper::Error> for HubError {
+    fn from(err: hyper::Error) -> Self {
+        HubError::HttpClient(err)
+    }
+}
+
+impl From<io::Error> for HubError {
+    fn from(err: io::Error) -> Self {
+        HubError::IO(err)
+    }
+}
+
+impl From<serde_json::Error> for HubError {
+    fn from(err: serde_json::Error) -> Self {
+        HubError::Serialization(err)
+    }
+}

--- a/components/github-api-client/src/lib.rs
+++ b/components/github-api-client/src/lib.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate base64;
+extern crate frank_jwt as jwt;
+extern crate habitat_http_client as hab_http;
+extern crate hyper;
+extern crate hyper_openssl;
+#[macro_use]
+extern crate log;
+extern crate regex;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+extern crate time;
+
+pub mod client;
+pub mod config;
+pub mod error;
+pub mod types;
+
+pub use client::GitHubClient;
+pub use config::GitHubCfg;
+pub use error::{HubError, HubResult};

--- a/components/github-api-client/src/types.rs
+++ b/components/github-api-client/src/types.rs
@@ -1,0 +1,400 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use base64;
+
+use error::{HubError, HubResult};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct App {
+    pub id: u32,
+    pub owner: AppOwner,
+    pub name: String,
+    pub description: String,
+    pub external_url: String,
+    pub html_url: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct AppInstallationToken {
+    pub token: String,
+    pub expires_at: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct AppAuthErr {
+    pub message: String,
+    pub documentation_url: String,
+}
+
+impl fmt::Display for AppAuthErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "message={}, documentation_url={}",
+            self.message,
+            self.documentation_url
+        )
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AuthOk {
+    pub access_token: String,
+    pub scope: String,
+    pub token_type: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct AuthErr {
+    pub error: String,
+    pub error_description: String,
+    pub error_uri: String,
+}
+
+impl fmt::Display for AuthErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "err={}, desc={}, uri={}",
+            self.error,
+            self.error_description,
+            self.error_uri
+        )
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AppOwner {
+    pub login: String,
+    pub id: u32,
+    pub avatar_url: String,
+    pub gravatar_id: String,
+    pub url: String,
+    pub html_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    pub organizations_url: String,
+    pub repos_url: String,
+    pub events_url: String,
+    pub received_events_url: String,
+    #[serde(rename = "type")]
+    pub _type: String,
+    pub site_admin: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Contents {
+    pub name: String,
+    pub path: String,
+    pub sha: String,
+    pub size: usize,
+    pub url: String,
+    pub html_url: String,
+    pub git_url: String,
+    pub download_url: String,
+    pub content: String,
+    pub encoding: String,
+}
+
+impl Contents {
+    pub fn decode(&self) -> HubResult<Vec<u8>> {
+        base64::decode(&self.content).map_err(HubError::ContentDecode)
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubWebhookPush {
+    /// The full Git ref that was pushed. Example: "refs/heads/master"
+    #[serde(rename = "ref")]
+    pub git_ref: String,
+    /// The SHA of the most recent commit on ref before the push
+    pub before: String,
+    /// The SHA of the most recent commit on ref after the push
+    pub after: String,
+    pub created: bool,
+    pub deleted: bool,
+    pub forced: bool,
+    pub base_ref: Option<String>,
+    pub compare: String,
+    /// An array of commit objects describing the pushed commits (The array includes a maximum
+    /// of 20 commits. If necessary, you can use the Commits API to fetch additional commits.
+    /// This limit is applied to timeline events only and isn't applied to webhook deliveries)
+    pub commits: Vec<GitHubWebhookCommit>,
+    pub head_commit: Option<GitHubWebhookCommit>,
+    pub repository: PushRepository,
+    pub pusher: GitHubOwner,
+    pub sender: GitHubWebhookSender,
+    pub installation: GitHubAppInstallation,
+}
+
+impl GitHubWebhookPush {
+    pub fn branch(&self) -> &str {
+        self.git_ref
+            .split("refs/heads/")
+            .collect::<Vec<&str>>()
+            .last()
+            .expect("bad git ref")
+    }
+
+    pub fn changed(&self) -> Vec<&String> {
+        let mut paths = vec![];
+        for commit in self.commits.iter() {
+            paths.extend(&commit.added);
+            paths.extend(&commit.removed);
+            paths.extend(&commit.modified);
+        }
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubWebhookCommit {
+    pub id: String,
+    pub tree_id: String,
+    /// Whether this commit is distinct from any that have been pushed before
+    pub distinct: bool,
+    /// The commit message
+    pub message: String,
+    pub timestamp: String,
+    /// Points to the commit API resource
+    pub url: String,
+    /// The git author of the commit
+    pub author: GitHubAuthor,
+    pub committer: GitHubAuthor,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub modified: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubAuthor {
+    /// Public name of commit author
+    pub name: String,
+    /// Public email of commit author
+    pub email: String,
+    /// Display name of commit author
+    pub username: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct GitHubAppInstallation {
+    pub id: u32,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubWebhookSender {
+    pub login: String,
+    pub id: u32,
+    pub avatar_url: String,
+    pub gravatar_id: Option<String>,
+    pub url: String,
+    pub html_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    pub organizations_url: String,
+    pub repos_url: String,
+    pub events_url: String,
+    pub received_events_url: String,
+    pub site_admin: bool,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubOwner {
+    /// Public name of commit author
+    pub name: String,
+    /// Public email of commit author
+    pub email: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PushRepository {
+    pub id: u32,
+    pub name: String,
+    pub full_name: String,
+    pub owner: Organization,
+    pub private: bool,
+    pub html_url: String,
+    pub description: Option<String>,
+    pub fork: bool,
+    pub git_url: String,
+    pub ssh_url: String,
+    pub clone_url: String,
+    pub default_branch: String,
+    pub master_branch: String,
+    pub organization: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Repository {
+    pub id: u32,
+    pub name: String,
+    pub full_name: String,
+    pub owner: User,
+    pub private: bool,
+    pub html_url: String,
+    pub description: Option<String>,
+    pub fork: bool,
+    pub git_url: String,
+    pub ssh_url: String,
+    pub clone_url: String,
+    pub default_branch: String,
+    pub master_branch: String,
+    pub organization: Organization,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Organization {
+    pub login: String,
+    pub id: u32,
+    pub avatar_url: String,
+    pub url: String,
+    pub company: Option<String>,
+    pub description: Option<String>,
+    pub gravatar_id: Option<String>,
+    pub hooks_url: Option<String>,
+    pub html_url: Option<String>,
+    pub followers_url: Option<String>,
+    pub following_url: Option<String>,
+    pub gists_url: Option<String>,
+    pub starred_url: Option<String>,
+    pub subscriptions_url: Option<String>,
+    pub organizations_url: Option<String>,
+    pub repos_url: Option<String>,
+    pub events_url: Option<String>,
+    pub received_events_url: Option<String>,
+    pub members_url: Option<String>,
+    pub site_admin: Option<bool>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Team {
+    pub id: u32,
+    pub url: String,
+    pub name: String,
+    pub slug: String,
+    pub description: Option<String>,
+    pub privacy: String,
+    pub permission: String,
+    pub members_url: String,
+    pub repositories_url: String,
+    pub members_count: u32,
+    pub repos_count: u32,
+    pub organization: Organization,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct User {
+    pub login: String,
+    pub id: u32,
+    pub avatar_url: String,
+    pub gravatar_id: String,
+    pub url: String,
+    pub html_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    pub organizations_url: String,
+    pub repos_url: String,
+    pub events_url: String,
+    pub received_events_url: String,
+    pub name: Option<String>,
+    pub company: Option<String>,
+    pub blog: Option<String>,
+    pub location: Option<String>,
+    pub email: Option<String>,
+    pub hireable: Option<bool>,
+    pub bio: Option<String>,
+    pub public_repos: Option<u32>,
+    pub public_gists: Option<u32>,
+    pub followers: Option<u32>,
+    pub following: Option<u32>,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct UserPlan {
+    pub name: String,
+    pub space: u32,
+    pub private_repos: u32,
+    pub collaborators: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Search {
+    pub total_count: u32,
+    pub incomplete_results: bool,
+    pub items: Vec<SearchItem>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SearchItem {
+    pub name: String,
+    pub path: String,
+    pub sha: String,
+    pub url: String,
+    pub git_url: String,
+    pub html_url: String,
+    pub repository: Repository,
+    pub score: f32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TeamMembership {
+    pub url: String,
+    pub role: String,
+    pub state: String,
+}
+
+impl TeamMembership {
+    pub fn active(&self) -> bool {
+        self.state == "active"
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn branch_from_hook() {
+        let mut hook = GitHubWebhookPush::default();
+        hook.git_ref = "refs/heads/master".to_string();
+        assert_eq!(hook.branch(), "master");
+    }
+}


### PR DESCRIPTION
This crate was in the habitat repository, but is only used in this repository. This pulls all history from the code and adds it into this repository.