### PR TITLE
Create the tmuxinator directory if it doesn't already exist

### DIFF
--- a/tools/ssh_helpers/hab-env
+++ b/tools/ssh_helpers/hab-env
@@ -2,15 +2,17 @@
 
 set -euo pipefail
 
-HAB_ENV=${1}
+HAB_ENV=${1:?specify an environment such as \"acceptance\" or \"live\"}
 SESSION="hab_${HAB_ENV}"
+SCRIPT_DIR=$(dirname "$0")
+TMUXINATOR_DIR=~/.tmuxinator
 
-# TODO: constrain the list of possible environments?
+mkdir -p "${TMUXINATOR_DIR}"
 
 # (Re-)generate a tmuxinator session description. This ensures we're
 # always up-to-date
-./generate-habitat-env-tmuxinator.sh ${HAB_ENV} \
-    > ~/.tmuxinator/${SESSION}.yml
+"${SCRIPT_DIR}/generate-habitat-env-tmuxinator.sh" "${HAB_ENV}" \
+    > "${TMUXINATOR_DIR}/${SESSION}.yml"
 
 # TODO: What if the session is already running?
-tmuxinator start ${SESSION}
+tmuxinator start "${SESSION}"

--- a/tools/ssh_helpers/update-habitat-ssh
+++ b/tools/ssh_helpers/update-habitat-ssh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=2129
 
 # Query AWS for habitat servers in a specified environment and inserts
 # entries into ~/.ssh/config for them. Any previous entries for the
@@ -12,15 +13,16 @@ set -euo pipefail
 environment=${1}
 start_pattern="###HABITAT-${environment}-START###"
 stop_pattern="###HABITAT-${environment}-STOP###"
+script_dir=$(dirname "$0")
 
 # Remove the entries from the config file
-sed -i '.habitat_backup' '/'${start_pattern}'/,/'${stop_pattern}'/d' ~/.ssh/config
+sed -i '.habitat_backup' '/'"${start_pattern}"'/,/'"${stop_pattern}"'/d' ~/.ssh/config
 
 echo "" >> ~/.ssh/config
 echo "${start_pattern}" >> ~/.ssh/config
 echo "" >> ~/.ssh/config
 
-for l in $(./hab-instances $environment | jq -r '.Reservations[] | .Instances[0] | .PublicDnsName + ";" + (.Tags | from_entries | ."X-Environment" + "-" + .Name)')
+for l in $("$script_dir/hab-instances" "$environment" | jq -r '.Reservations[] | .Instances[0] | .PublicDnsName + ";" + (.Tags | from_entries | ."X-Environment" + "-" + .Name)')
 do
     dns=${l%;*}
     name=${l#*;}


### PR DESCRIPTION
Also, clean up shellcheck lints,make the script run correctly regardless of the
current directory, and provide some instructive output if run without args.

I removed the "TODO: constrain the list of possible environments?" comment since
I think that is more the domain of the generate-habitat-env-tmuxinator.sh
script. If we added new environments, we don't want to have to modify this.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>