### PR TITLE
Refactor metrics infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ name = "github-api-client"
 version = "0.0.0"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "builder_core 0.0.0",
  "frank_jwt 2.5.1 (git+https://github.com/habitat-sh/frank_jwt?branch=habitat)",
  "habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -16,7 +16,7 @@ use std::io::Read;
 use std::str::FromStr;
 
 use bldr_core::build_config::{BLDR_CFG, BuildCfg};
-use bldr_core::metrics;
+use bldr_core::metrics::CounterMetric;
 use constant_time_eq::constant_time_eq;
 use github_api_client::{GitHubClient, AppToken};
 use hab_core::package::Plan;
@@ -55,7 +55,7 @@ impl FromStr for GitHubEvent {
 }
 
 pub fn handle_event(req: &mut Request) -> IronResult<Response> {
-    metrics::incr(Counter::GitHubEvent);
+    Counter::GitHubEvent.incr();
 
     let event = match req.headers.get::<XGitHubEvent>() {
         Some(&XGitHubEvent(ref event)) => {

--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 use bldr_core::build_config::{BLDR_CFG, BuildCfg};
 use bldr_core::metrics;
 use constant_time_eq::constant_time_eq;
-use github_api_client::GitHubClient;
+use github_api_client::{GitHubClient, AppToken};
 use hab_core::package::Plan;
 use hex;
 use http_gateway::http::controller::*;
@@ -34,6 +34,7 @@ use serde_json;
 
 use error::Error;
 use headers::*;
+use metrics::Counter;
 use types::*;
 
 pub enum GitHubEvent {
@@ -54,7 +55,7 @@ impl FromStr for GitHubEvent {
 }
 
 pub fn handle_event(req: &mut Request) -> IronResult<Response> {
-    metrics::Counter::GithubEvent.increment();
+    metrics::incr(Counter::GithubEvent);
 
     let event = match req.headers.get::<XGitHubEvent>() {
         Some(&XGitHubEvent(ref event)) => {
@@ -137,7 +138,6 @@ pub fn repo_file_content(req: &mut Request) -> IronResult<Response> {
             install_id,
             path
         );
-        metrics::Counter::GithubInstallationToken.increment();
         match github.app_installation_token(install_id) {
             Ok(token) => token,
             Err(err) => {
@@ -147,7 +147,6 @@ pub fn repo_file_content(req: &mut Request) -> IronResult<Response> {
         }
     };
 
-    metrics::Counter::GithubApi.increment();
     match github.contents(&token, repo_id, path) {
         Ok(None) => Ok(Response::with(status::NotFound)),
         Ok(search) => Ok(render_json(status::Ok, &search)),
@@ -186,7 +185,6 @@ fn handle_push(req: &mut Request, body: &str) -> IronResult<Response> {
         "GITHUB-CALL builder_api::github::handle_push: Getting app_installation_token; installation_id={}",
         hook.installation.id
     );
-    metrics::Counter::GithubInstallationToken.increment();
     let token = match github.app_installation_token(hook.installation.id) {
         Ok(token) => token,
         Err(err) => {
@@ -241,9 +239,8 @@ fn build_plans(req: &mut Request, repo_url: &str, plans: Vec<Plan>) -> IronResul
     Ok(render_json(status::Ok, &plans))
 }
 
-fn read_bldr_config(github: &GitHubClient, token: &str, hook: &GitHubWebhookPush) -> BuildCfg {
-    metrics::Counter::GithubApi.increment();
-    match github.contents(token, hook.repository.id, BLDR_CFG) {
+fn read_bldr_config(github: &GitHubClient, token: &AppToken, hook: &GitHubWebhookPush) -> BuildCfg {
+    match github.contents(&token, hook.repository.id, BLDR_CFG) {
         Ok(Some(contents)) => {
             match contents.decode() {
                 Ok(ref bytes) => {
@@ -271,13 +268,13 @@ fn read_bldr_config(github: &GitHubClient, token: &str, hook: &GitHubWebhookPush
 
 fn read_plans(
     github: &GitHubClient,
-    token: &str,
+    token: &AppToken,
     hook: &GitHubWebhookPush,
     config: &BuildCfg,
 ) -> Vec<Plan> {
     let mut plans = Vec::with_capacity(config.projects().len());
     for project in config.triggered_by(hook.branch(), hook.changed().as_slice()) {
-        if let Some(plan) = read_plan(github, token, hook, &project.plan_file().to_string_lossy()) {
+        if let Some(plan) = read_plan(github, &token, hook, &project.plan_file().to_string_lossy()) {
             plans.push(plan)
         }
     }
@@ -286,12 +283,11 @@ fn read_plans(
 
 fn read_plan(
     github: &GitHubClient,
-    token: &str,
+    token: &AppToken,
     hook: &GitHubWebhookPush,
     path: &str,
 ) -> Option<Plan> {
-    metrics::Counter::GithubApi.increment();
-    match github.contents(token, hook.repository.id, path) {
+    match github.contents(&token, hook.repository.id, path) {
         Ok(Some(contents)) => {
             match contents.decode() {
                 Ok(bytes) => {

--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -274,7 +274,13 @@ fn read_plans(
 ) -> Vec<Plan> {
     let mut plans = Vec::with_capacity(config.projects().len());
     for project in config.triggered_by(hook.branch(), hook.changed().as_slice()) {
-        if let Some(plan) = read_plan(github, &token, hook, &project.plan_file().to_string_lossy()) {
+        if let Some(plan) = read_plan(
+            github,
+            &token,
+            hook,
+            &project.plan_file().to_string_lossy(),
+        )
+        {
             plans.push(plan)
         }
     }

--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -55,7 +55,7 @@ impl FromStr for GitHubEvent {
 }
 
 pub fn handle_event(req: &mut Request) -> IronResult<Response> {
-    metrics::incr(Counter::GithubEvent);
+    metrics::incr(Counter::GitHubEvent);
 
     let event = match req.headers.get::<XGitHubEvent>() {
         Some(&XGitHubEvent(ref event)) => {

--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -55,7 +55,7 @@ impl FromStr for GitHubEvent {
 }
 
 pub fn handle_event(req: &mut Request) -> IronResult<Response> {
-    Counter::GitHubEvent.incr();
+    Counter::GitHubEvent.increment();
 
     let event = match req.headers.get::<XGitHubEvent>() {
         Some(&XGitHubEvent(ref event)) => {

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -53,6 +53,7 @@ pub mod config;
 pub mod error;
 pub mod github;
 pub mod headers;
+pub mod metrics;
 pub mod server;
 mod types;
 

--- a/components/builder-api/src/metrics.rs
+++ b/components/builder-api/src/metrics.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Centralized definition of all Builder API metrics that we
+//! wish to track.
+
+use std::borrow::Cow;
+use bldr_core::metrics;
+
+pub enum Counter {
+    GithubEvent
+}
+
+impl metrics::CounterMetric for Counter {}
+
+impl metrics::Metric for Counter {
+    fn id(&self) -> Cow<'static, str> {
+        match *self {
+            Counter::GithubEvent => "github.event".into(),
+        }
+    }
+}

--- a/components/builder-api/src/metrics.rs
+++ b/components/builder-api/src/metrics.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use bldr_core::metrics;
 
 pub enum Counter {
-    GithubEvent
+    GitHubEvent
 }
 
 impl metrics::CounterMetric for Counter {}
@@ -27,7 +27,7 @@ impl metrics::CounterMetric for Counter {}
 impl metrics::Metric for Counter {
     fn id(&self) -> Cow<'static, str> {
         match *self {
-            Counter::GithubEvent => "github.event".into(),
+            Counter::GitHubEvent => "github.event".into(),
         }
     }
 }

--- a/components/builder-api/src/metrics.rs
+++ b/components/builder-api/src/metrics.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use bldr_core::metrics;
 
 pub enum Counter {
-    GitHubEvent
+    GitHubEvent,
 }
 
 impl metrics::CounterMetric for Counter {}

--- a/components/builder-core/src/metrics.rs
+++ b/components/builder-core/src/metrics.rs
@@ -45,11 +45,11 @@ pub trait Metric {
 
 /// Marker trait for counter metrics (don't want to accidentally
 /// increment a gauge metric!)
-pub trait CounterMetric {}
+pub trait CounterMetric : Metric {}
 
 /// Increment the given metric by one
 pub fn incr<C>(counter: C)
-    where C: Metric + CounterMetric {
+    where C: CounterMetric {
     match sender().send((MetricType::Counter,
                          MetricOperation::Increment,
                          counter.id(),

--- a/components/builder-core/src/metrics.rs
+++ b/components/builder-core/src/metrics.rs
@@ -43,19 +43,16 @@ pub trait Metric {
     fn id(&self) -> MetricId;
 }
 
-/// Marker trait for counter metrics (don't want to accidentally
-/// increment a gauge metric!)
-pub trait CounterMetric : Metric {}
-
-/// Increment the given metric by one
-pub fn incr<C>(counter: C)
-    where C: CounterMetric {
-    match sender().send((MetricType::Counter,
-                         MetricOperation::Increment,
-                         counter.id(),
-                         None)) {
-        Ok(_) => (),
-        Err(e) => error!("Failed to increment counter, error: {:?}", e)
+pub trait CounterMetric : Metric {
+    /// Increment the metric by one
+    fn incr(&self) {
+        match sender().send((MetricType::Counter,
+                             MetricOperation::Increment,
+                             self.id(),
+                             None)) {
+            Ok(_) => (),
+            Err(e) => error!("Failed to increment counter, error: {:?}", e)
+        }
     }
 }
 

--- a/components/builder-core/src/metrics.rs
+++ b/components/builder-core/src/metrics.rs
@@ -45,7 +45,7 @@ pub trait Metric {
 
 pub trait CounterMetric : Metric {
     /// Increment the metric by one
-    fn incr(&self) {
+    fn increment(&self) {
         match sender().send((MetricType::Counter,
                              MetricOperation::Increment,
                              self.id(),

--- a/components/builder-core/src/metrics.rs
+++ b/components/builder-core/src/metrics.rs
@@ -43,15 +43,17 @@ pub trait Metric {
     fn id(&self) -> MetricId;
 }
 
-pub trait CounterMetric : Metric {
+pub trait CounterMetric: Metric {
     /// Increment the metric by one
     fn increment(&self) {
-        match sender().send((MetricType::Counter,
-                             MetricOperation::Increment,
-                             self.id(),
-                             None)) {
+        match sender().send((
+            MetricType::Counter,
+            MetricOperation::Increment,
+            self.id(),
+            None,
+        )) {
             Ok(_) => (),
-            Err(e) => error!("Failed to increment counter, error: {:?}", e)
+            Err(e) => error!("Failed to increment counter, error: {:?}", e),
         }
     }
 }

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -54,6 +54,7 @@ extern crate github_api_client;
 pub mod config;
 pub mod error;
 pub mod doctor;
+pub mod metrics;
 pub mod server;
 pub mod handlers;
 

--- a/components/builder-depot/src/metrics.rs
+++ b/components/builder-depot/src/metrics.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use bldr_core::metrics;
 
 pub enum Counter {
-    SearchPackages
+    SearchPackages,
 }
 
 impl metrics::CounterMetric for Counter {}
@@ -27,7 +27,7 @@ impl metrics::CounterMetric for Counter {}
 impl metrics::Metric for Counter {
     fn id(&self) -> Cow<'static, str> {
         match *self {
-            Counter::SearchPackages => "search-packages".into()
+            Counter::SearchPackages => "search-packages".into(),
         }
     }
 }

--- a/components/builder-depot/src/metrics.rs
+++ b/components/builder-depot/src/metrics.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Centralized definition of all Builder Depot metrics that we wish
+//! to track.
+
+use std::borrow::Cow;
+use bldr_core::metrics;
+
+pub enum Counter {
+    SearchPackages
+}
+
+impl metrics::CounterMetric for Counter {}
+
+impl metrics::Metric for Counter {
+    fn id(&self) -> Cow<'static, str> {
+        match *self {
+            Counter::SearchPackages => "search-packages".into()
+        }
+    }
+}

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -19,7 +19,8 @@ use std::result;
 use std::str::FromStr;
 
 use base64;
-use bldr_core::{self, metrics};
+use bldr_core;
+use bldr_core::metrics::CounterMetric;
 use bldr_core::helpers::transition_visibility;
 use bodyparser;
 use github_api_client::GitHubClient;
@@ -1803,7 +1804,7 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
 }
 
 fn search_packages(req: &mut Request) -> IronResult<Response> {
-    metrics::incr(Counter::SearchPackages);
+    Counter::SearchPackages.incr();
 
     let session_id = helpers::get_optional_session_id(req);
     let mut request = OriginPackageSearchRequest::new();

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -55,6 +55,7 @@ use uuid::Uuid;
 
 use super::DepotUtil;
 use error::{Error, Result};
+use metrics::Counter;
 use handlers;
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -1802,7 +1803,7 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
 }
 
 fn search_packages(req: &mut Request) -> IronResult<Response> {
-    metrics::Counter::SearchPackages.increment();
+    metrics::incr(Counter::SearchPackages);
 
     let session_id = helpers::get_optional_session_id(req);
     let mut request = OriginPackageSearchRequest::new();

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1804,7 +1804,7 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
 }
 
 fn search_packages(req: &mut Request) -> IronResult<Response> {
-    Counter::SearchPackages.incr();
+    Counter::SearchPackages.increment();
 
     let session_id = helpers::get_optional_session_id(req);
     let mut request = OriginPackageSearchRequest::new();

--- a/components/builder-http-gateway/src/http/middleware.rs
+++ b/components/builder-http-gateway/src/http/middleware.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use base64;
-use bldr_core::{self, metrics};
+use bldr_core;
 use core::env;
 use github_api_client::{GitHubCfg, GitHubClient, HubError};
 use hab_net::{ErrCode, NetError};
@@ -35,6 +35,8 @@ use segment_api_client::SegmentClient;
 use serde_json;
 use std::path::PathBuf;
 use unicase::UniCase;
+
+use github_api_client::UserToken;
 
 use super::net_err_to_http;
 use conn::RouteBroker;
@@ -282,8 +284,7 @@ pub fn session_create_github(req: &mut Request, token: &str) -> IronResult<Sessi
     debug!(
         "GITHUB-CALL builder_http-gateway::middleware::session_create_github: Checking user with access token",
     );
-    metrics::Counter::GithubApi.increment();
-    match github.user(&token) {
+    match github.user(&(token.to_string() as UserToken)) {
         Ok(user) => {
             let mut request = SessionCreate::new();
             request.set_session_type(SessionType::User);

--- a/components/builder-sessionsrv/src/server/handlers.rs
+++ b/components/builder-sessionsrv/src/server/handlers.rs
@@ -16,7 +16,7 @@ use std::env;
 
 use hab_net::app::prelude::*;
 use hab_net::privilege::FeatureFlags;
-use bldr_core::{self, metrics};
+use bldr_core;
 
 use protocol::net;
 use protocol::sessionsrv as proto;
@@ -483,16 +483,15 @@ pub fn account_invitation_list(
 }
 
 fn assign_permissions(name: &str, flags: &mut FeatureFlags, state: &ServerState) {
+    let installation_id = state.permissions.app_install_id;
     debug!(
         "GITHUB-CALL builder_sessionsrv::server::handlers::assign_permissions: Getting app_installation_token; installation_id={}",
-        state.permissions.app_install_id
+        installation_id
     );
-    metrics::Counter::GithubInstallationToken.increment();
     match state.github.app_installation_token(
         state.permissions.app_install_id,
     ) {
         Ok(token) => {
-            metrics::Counter::GithubApi.increment();
             debug!(
                 "GITHUB-CALL builder_sessionsrv::server::handlers::assign_permissions: Checking team membership for {}",
                 name
@@ -512,7 +511,6 @@ fn assign_permissions(name: &str, flags: &mut FeatureFlags, state: &ServerState)
                 Err(err) => warn!("Failed to check github team membership, {}", err),
             }
             for team in state.permissions.early_access_teams.iter() {
-                metrics::Counter::GithubApi.increment();
                 debug!(
                     "GITHUB-CALL builder_sessionsrv::server::handlers::assign_permissions: Checking team membership for {}",
                     name
@@ -530,7 +528,6 @@ fn assign_permissions(name: &str, flags: &mut FeatureFlags, state: &ServerState)
                 }
             }
             for team in state.permissions.build_worker_teams.iter() {
-                metrics::Counter::GithubApi.increment();
                 debug!(
                     "GITHUB-CALL builder_sessionsrv::server::handlers::assign_permissions: Checking team membership for {}",
                     name

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -47,6 +47,7 @@ pub mod config;
 pub mod error;
 pub mod heartbeat;
 pub mod log_forwarder;
+pub mod metrics;
 mod network;
 pub mod runner;
 pub mod server;

--- a/components/builder-worker/src/metrics.rs
+++ b/components/builder-worker/src/metrics.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Centralized definition of all Builder Worker metrics that we wish
+//! to track.
+
+use std::borrow::Cow;
+use bldr_core::metrics;
+
+pub type InstallationId = u32;
+
+pub enum Counter {
+    GitClone(InstallationId)
+}
+
+impl metrics::CounterMetric for Counter {}
+
+impl metrics::Metric for Counter {
+    fn id(&self) -> Cow<'static, str> {
+        match *self {
+            Counter::GitClone(ref installation_id) => {
+                format!("github.clone.{}", installation_id).into()
+            }
+        }
+    }
+}

--- a/components/builder-worker/src/metrics.rs
+++ b/components/builder-worker/src/metrics.rs
@@ -21,7 +21,7 @@ use bldr_core::metrics;
 pub type InstallationId = u32;
 
 pub enum Counter {
-    GitClone(InstallationId)
+    GitClone(InstallationId),
 }
 
 impl metrics::CounterMetric for Counter {}

--- a/components/builder-worker/src/vcs.rs
+++ b/components/builder-worker/src/vcs.rs
@@ -90,7 +90,7 @@ impl VCS {
                             Error::GithubAppAuthErr(e)
                         })?;
                         // TBD: Split metrics into authenticated and non-authenticated
-                        Counter::GitClone(id).incr();
+                        Counter::GitClone(id).increment();
                         Some(t.inner_token().to_string())
                     }
                 };

--- a/components/builder-worker/src/vcs.rs
+++ b/components/builder-worker/src/vcs.rs
@@ -15,7 +15,7 @@
 use std::path::Path;
 
 use bldr_core::job::Job;
-use bldr_core::metrics;
+use bldr_core::metrics::CounterMetric;
 use metrics::Counter;
 use git2;
 use github_api_client::{GitHubClient, GitHubCfg};
@@ -90,7 +90,7 @@ impl VCS {
                             Error::GithubAppAuthErr(e)
                         })?;
                         // TBD: Split metrics into authenticated and non-authenticated
-                        metrics::incr(Counter::GitClone(id));
+                        Counter::GitClone(id).incr();
                         Some(t.inner_token().to_string())
                     }
                 };

--- a/components/github-api-client/Cargo.toml
+++ b/components/github-api-client/Cargo.toml
@@ -16,5 +16,9 @@ serde_derive = "*"
 serde_json = "*"
 time = "*"
 
+# For metrics library
+[dependencies.builder_core]
+path = "../builder-core"
+
 [dependencies.habitat_http_client]
 git = "https://github.com/habitat-sh/habitat.git"

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -120,7 +120,7 @@ impl GitHubClient {
             install_id
         )).map_err(HubError::HttpClientParse)?;
 
-        Counter::InstallationToken.incr();
+        Counter::InstallationToken.increment();
         let mut rep = http_post(url, Some(app_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;
@@ -143,7 +143,7 @@ impl GitHubClient {
             code
         )).map_err(HubError::HttpClientParse)?;
 
-        Counter::Authenticate.incr();
+        Counter::Authenticate.increment();
         let mut rep = http_post(url, None::<String>)?;
         if rep.status.is_success() {
             let mut body = String::new();
@@ -170,7 +170,7 @@ impl GitHubClient {
         let url = Url::parse(&format!("{}/teams/{}/memberships/{}", self.url, team, user))
             .map_err(HubError::HttpClientParse)?;
 
-        Counter::Api("check_team_membership").incr();
+        Counter::Api("check_team_membership").increment();
         let mut rep = http_get(url, Some(&token.inner_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;
@@ -196,7 +196,7 @@ impl GitHubClient {
             path
         )).map_err(HubError::HttpClientParse)?;
 
-        Counter::Api("contents").incr();
+        Counter::Api("contents").increment();
         let mut rep = http_get(url, Some(&token.inner_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;
@@ -220,7 +220,7 @@ impl GitHubClient {
 
     pub fn repo(&self, token: &AppToken, repo: u32) -> HubResult<Option<Repository>> {
         let url = Url::parse(&format!("{}/repositories/{}", self.url, repo)).unwrap();
-        Counter::Api("repo").incr();
+        Counter::Api("repo").increment();
         let mut rep = http_get(url, Some(&token.inner_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;
@@ -239,7 +239,7 @@ impl GitHubClient {
 
     pub fn user(&self, token: &UserToken) -> HubResult<User> {
         let url = Url::parse(&format!("{}/user", self.url)).unwrap();
-        Counter::UserApi("user").incr();
+        Counter::UserApi("user").increment();
         let mut rep = http_get(url, Some(token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::time::{UNIX_EPOCH, Duration, SystemTime};
 
-use builder_core::metrics;
+use builder_core::metrics::CounterMetric;
 use hab_http::ApiClient;
 use hyper::{self, Url};
 use hyper::client::IntoUrl;
@@ -120,7 +120,7 @@ impl GitHubClient {
             install_id
         )).map_err(HubError::HttpClientParse)?;
 
-        metrics::incr(Counter::InstallationToken);
+        Counter::InstallationToken.incr();
         let mut rep = http_post(url, Some(app_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;
@@ -143,7 +143,7 @@ impl GitHubClient {
             code
         )).map_err(HubError::HttpClientParse)?;
 
-        metrics::incr(Counter::Authenticate);
+        Counter::Authenticate.incr();
         let mut rep = http_post(url, None::<String>)?;
         if rep.status.is_success() {
             let mut body = String::new();
@@ -170,7 +170,7 @@ impl GitHubClient {
         let url = Url::parse(&format!("{}/teams/{}/memberships/{}", self.url, team, user))
             .map_err(HubError::HttpClientParse)?;
 
-        metrics::incr(Counter::Api("check_team_membership"));
+        Counter::Api("check_team_membership").incr();
         let mut rep = http_get(url, Some(&token.inner_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;
@@ -196,7 +196,7 @@ impl GitHubClient {
             path
         )).map_err(HubError::HttpClientParse)?;
 
-        metrics::incr(Counter::Api("contents"));
+        Counter::Api("contents").incr();
         let mut rep = http_get(url, Some(&token.inner_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;
@@ -220,7 +220,7 @@ impl GitHubClient {
 
     pub fn repo(&self, token: &AppToken, repo: u32) -> HubResult<Option<Repository>> {
         let url = Url::parse(&format!("{}/repositories/{}", self.url, repo)).unwrap();
-        metrics::incr(Counter::Api("repo"));
+        Counter::Api("repo").incr();
         let mut rep = http_get(url, Some(&token.inner_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;
@@ -239,7 +239,7 @@ impl GitHubClient {
 
     pub fn user(&self, token: &UserToken) -> HubResult<User> {
         let url = Url::parse(&format!("{}/user", self.url)).unwrap();
-        metrics::incr(Counter::UserApi("user"));
+        Counter::UserApi("user").incr();
         let mut rep = http_get(url, Some(token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -47,14 +47,17 @@ pub struct AppToken {
 
     // Leave this here in anticipation of using it for tagged metrics
     #[allow(dead_code)]
-    installation_id: InstallationId
+    installation_id: InstallationId,
 }
 
 impl AppToken {
     // Not public, because you should only get these from
     // `GitHubClient::app_installation_token`
     fn new(inner_token: TokenString, installation_id: InstallationId) -> Self {
-        AppToken{inner_token, installation_id}
+        AppToken {
+            inner_token,
+            installation_id,
+        }
     }
 
     // Only providing this for builder-worker's benefit... it

--- a/components/github-api-client/src/lib.rs
+++ b/components/github-api-client/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 extern crate base64;
+extern crate builder_core;
 extern crate frank_jwt as jwt;
 extern crate habitat_http_client as hab_http;
 extern crate hyper;
@@ -29,8 +30,10 @@ extern crate time;
 pub mod client;
 pub mod config;
 pub mod error;
+pub mod metrics;
 pub mod types;
 
 pub use client::GitHubClient;
 pub use config::GitHubCfg;
 pub use error::{HubError, HubResult};
+pub use client::{AppToken, UserToken};

--- a/components/github-api-client/src/metrics.rs
+++ b/components/github-api-client/src/metrics.rs
@@ -36,12 +36,8 @@ impl metrics::Metric for Counter {
         match *self {
             Counter::Authenticate => "github.authenticate".into(),
             Counter::InstallationToken => "github.installation-token".into(),
-            Counter::Api(ref endpoint) => {
-                format!("github.api.{}", endpoint).into()
-            }
-            Counter::UserApi(ref endpoint) => {
-                format!("github.user-api.{}", endpoint).into()
-            }
+            Counter::Api(ref endpoint) => format!("github.api.{}", endpoint).into(),
+            Counter::UserApi(ref endpoint) => format!("github.user-api.{}", endpoint).into(),
         }
     }
 }

--- a/components/github-api-client/src/metrics.rs
+++ b/components/github-api-client/src/metrics.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Centralized definition of all Github API client metrics that we
+//! wish to track.
+
+use std::borrow::Cow;
+use builder_core::metrics;
+
+pub type Endpoint = &'static str;
+
+pub enum Counter {
+    Authenticate,
+    InstallationToken,
+    // Github App-mediated API calls
+    Api(Endpoint),
+    // Github API calls, but using a user's personal Github token
+    UserApi(Endpoint),
+}
+
+impl metrics::CounterMetric for Counter {}
+
+impl metrics::Metric for Counter {
+    fn id(&self) -> Cow<'static, str> {
+        match *self {
+            Counter::Authenticate => "github.authenticate".into(),
+            Counter::InstallationToken => "github.installation-token".into(),
+            Counter::Api(ref endpoint) => {
+                format!("github.api.{}", endpoint).into()
+            }
+            Counter::UserApi(ref endpoint) => {
+                format!("github.user-api.{}", endpoint).into()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit involves several refactorings of our existing metrics code
that should make it more flexible moving forward. It evolved through
several iterations, so I'll attempt to lay out the story here in
prose, rather than individual commits; sorry :/

Since our existing metrics are mainly around Github API interactions,
that's what most of this discussion will focus on.

First, rather than instrumenting each call site where we make a Github
API call, our metrics calls are now embedded within our Github API
client library; anything that calls it will automatically be measured.

Second, a new set of Github token types are introduced: `AppToken` and
`UserToken`. The former bundles together an API token with the Github
App installation ID that was used to generate it. Everything outside
the `github-api-client` library will just see this as an opaque type,
but bundling the `installation_id` will ensure that we can trace each
call back to the installation that made it. This functionality is
unused in the current commit, but is in preparation for future work
where we can use it to take advantage of DataDog's metric tags.

The `UserToken` is simply a type alias, but is useful for making it
explicit where App tokens are used, and where they aren't. The sole
user of the `UserToken` type will be phased out over time, as we roll
out Builder tokens more widely.

Third, the metrics code itself has been refactored to be more
modular. Previously, all the metrics we tracked, across all of
Builder, were centralized in the `builder-core` crate. Now, only the
core metric functionality is located there, and each crate that sends
metrics has its own `metrics.rs` module that defines the metrics
relevant to that crate.

Additionally, new traits have been introduced, such as `Metric` and
`CounterMetric` that can be used by whatever types you choose to
implement your metrics with. Currently, the metrics have been
implemented with enums, but nothing would stop you from building
metrics on other types as desired.

The actual sending of the metrics has been decoupled from the types as
well; now you simply pass a metric to a function from the
`builder-core::metrics` module. Right now, there's only `incr` for
incrementing counters, which is the only thing we use, but other
functions for decrementing, gauges, and other StatsD types could
easily be made. This way, it should be relatively easy to swap out the
underlying StatsD client, which I believe we will want to do shortly,
in order to take advantage of DataDog's tagging capabilities.

Finally, what used to be increments of the `github.api` metric, are
now broken out by endpoint. Now we have things like
`github.api.contents`, `github.api.check_team_membership`, etc. This
will provide a more granular view of our API activity. It does _not_
yet incorporate the installation ID into these metrics, though; that
will require tagging to work properly in DataDog.

Signed-off-by: Christopher Maier <cmaier@chef.io>