### PR TITLE
Add segment-api-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     # Builder Rust program components
     - _RUST_BLDR_BIN_COMPONENTS="components/builder-api components/builder-jobsrv components/builder-originsrv components/builder-router components/builder-sessionsrv components/builder-worker"
     # Builder Rust crate components
-    - _RUST_BLDR_LIB_COMPONENTS="components/builder-core components/builder-db components/builder-depot components/builder-http-gateway components/net components/github-api-client"
+    - _RUST_BLDR_LIB_COMPONENTS="components/builder-core components/builder-db components/builder-depot components/builder-http-gateway components/net components/github-api-client components/segment-api-client"
 
 matrix:
   include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "persistent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "segment-api-client 0.0.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,7 +717,7 @@ dependencies = [
  "persistent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "segment-api-client 0.0.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -981,7 +981,7 @@ dependencies = [
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
+ "segment-api-client 0.0.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2100,7 +2100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "segment-api-client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#8bd1b4326e46eb550a590d5543061093913225f2"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2930,7 +2929,6 @@ dependencies = [
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a2ff3fc5223829be817806c6441279c676e454cc7da608faf03b0ccc09d3889"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
-"checksum segment-api-client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)" = "<none>"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum sequence_trie 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "32157204e5c9d3c04007bd7e56e96e987635ce0e8e23c085b1e403861b76c351"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ members = [
   "components/builder-worker",
   "components/github-api-client",
   "components/net",
-  "components/op"
+  "components/op",
+  "components/segment-api-client"
 ]

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -49,7 +49,7 @@ branch = "release/v0.8"
 path = "../github-api-client"
 
 [dependencies.segment-api-client]
-git = "https://github.com/habitat-sh/habitat.git"
+path = "../segment-api-client"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -47,7 +47,7 @@ path = "../builder-core"
 path = "../github-api-client"
 
 [dependencies.segment-api-client]
-git = "https://github.com/habitat-sh/habitat.git"
+path = "../segment-api-client"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/builder-http-gateway/Cargo.toml
+++ b/components/builder-http-gateway/Cargo.toml
@@ -40,7 +40,7 @@ branch = "release/v0.8"
 path = "../github-api-client"
 
 [dependencies.segment-api-client]
-git = "https://github.com/habitat-sh/habitat.git"
+path = "../segment-api-client"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/segment-api-client/Cargo.toml
+++ b/components/segment-api-client/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "segment-api-client"
+version = "0.0.0"
+authors = ["Josh Black <raskchanky@gmail.com>"]
+workspace = "../../"
+
+[dependencies]
+base64 = "*"
+hyper = "0.10"
+hyper-openssl = "0.2"
+log = "*"
+serde = "*"
+serde_derive = "*"
+serde_json = "*"
+
+[[bin]]
+name = "segment-client"
+path = "src/main.rs"

--- a/components/segment-api-client/src/client.rs
+++ b/components/segment-api-client/src/client.rs
@@ -1,0 +1,112 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use hyper;
+use hyper::client::Response;
+use hyper::header::{Authorization, Accept, Basic, ContentType, Headers, UserAgent, qitem};
+use hyper::net::HttpsConnector;
+use hyper_openssl::OpensslClient;
+use hyper::mime::{Mime, TopLevel, SubLevel};
+use serde_json;
+
+use config::SegmentCfg;
+use error::{SegmentError, SegmentResult};
+
+const USER_AGENT: &'static str = "Habitat-Builder";
+const HTTP_TIMEOUT: u64 = 3_000;
+
+#[derive(Clone, Debug)]
+pub struct SegmentClient {
+    pub url: String,
+    pub write_key: String,
+}
+
+impl SegmentClient {
+    pub fn new(config: SegmentCfg) -> Self {
+        SegmentClient {
+            url: config.url,
+            write_key: config.write_key,
+        }
+    }
+
+    pub fn identify(&self, user_id: &str) -> SegmentResult<Response> {
+        let json = json!({
+            "userId": user_id
+        });
+
+        self.http_post(
+            "identify",
+            &self.write_key,
+            serde_json::to_string(&json).unwrap(),
+        )
+    }
+
+    pub fn track(&self, user_id: &str, event: &str) -> SegmentResult<Response> {
+        let json = json!({
+            "userId": user_id,
+            "event": event
+        });
+
+        self.http_post(
+            "track",
+            &self.write_key,
+            serde_json::to_string(&json).unwrap(),
+        )
+    }
+
+    fn http_post<U>(&self, path: &str, token: U, body: String) -> SegmentResult<Response>
+    where
+        U: ToString,
+    {
+        let url = format!("{}/v1/{}", self.url, path);
+        let client = hyper_client();
+        let req = client.post(&url).body(&body).headers(
+            configure_headers(token),
+        );
+        req.send().map_err(SegmentError::HttpClient)
+    }
+}
+
+fn configure_headers<U>(token: U) -> Headers
+where
+    U: ToString,
+{
+    let mut headers = Headers::new();
+    headers.set(Accept(vec![
+        qitem(
+            Mime(TopLevel::Application, SubLevel::Json, vec![])
+        ),
+    ]));
+    headers.set(ContentType(
+        Mime(TopLevel::Application, SubLevel::Json, vec![]),
+    ));
+    headers.set(UserAgent(USER_AGENT.to_string()));
+    headers.set(Authorization(Basic {
+        username: token.to_string(),
+        password: None,
+    }));
+
+    headers
+}
+
+fn hyper_client() -> hyper::Client {
+    let ssl = OpensslClient::new().unwrap();
+    let connector = HttpsConnector::new(ssl);
+    let mut client = hyper::Client::with_connector(connector);
+    client.set_read_timeout(Some(Duration::from_millis(HTTP_TIMEOUT)));
+    client.set_write_timeout(Some(Duration::from_millis(HTTP_TIMEOUT)));
+    client
+}

--- a/components/segment-api-client/src/config.rs
+++ b/components/segment-api-client/src/config.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// URL to Segment API endpoint
+pub const DEFAULT_SEGMENT_URL: &'static str = "https://api.segment.io";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct SegmentCfg {
+    /// URL to Segment API
+    #[serde(default = "default_url")]
+    pub url: String,
+    /// Write key used for Segment API requests
+    pub write_key: String,
+}
+
+impl Default for SegmentCfg {
+    fn default() -> Self {
+        SegmentCfg {
+            url: DEFAULT_SEGMENT_URL.to_string(),
+            write_key: "".to_string(),
+        }
+    }
+}
+
+fn default_url() -> String {
+    DEFAULT_SEGMENT_URL.to_string()
+}

--- a/components/segment-api-client/src/error.rs
+++ b/components/segment-api-client/src/error.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::error;
+use std::fmt;
+use std::io;
+
+use base64;
+use hyper;
+use serde_json;
+
+pub type SegmentResult<T> = Result<T, SegmentError>;
+
+#[derive(Debug)]
+pub enum SegmentError {
+    ApiError(hyper::status::StatusCode, HashMap<String, String>),
+    ContentDecode(base64::DecodeError),
+    HttpClient(hyper::Error),
+    HttpClientParse(hyper::error::ParseError),
+    HttpResponse(hyper::status::StatusCode),
+    IO(io::Error),
+    Serialization(serde_json::Error),
+}
+
+impl fmt::Display for SegmentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            SegmentError::ApiError(ref code, ref response) => {
+                format!(
+                    "Received a non-200 response, status={}, response={:?}",
+                    code,
+                    response
+                )
+            }
+            SegmentError::ContentDecode(ref e) => format!("{}", e),
+            SegmentError::HttpClient(ref e) => format!("{}", e),
+            SegmentError::HttpClientParse(ref e) => format!("{}", e),
+            SegmentError::HttpResponse(ref e) => format!("{}", e),
+            SegmentError::IO(ref e) => format!("{}", e),
+            SegmentError::Serialization(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for SegmentError {
+    fn description(&self) -> &str {
+        match *self {
+            SegmentError::ApiError(_, _) => "Response returned a non-200 status code.",
+            SegmentError::ContentDecode(ref err) => err.description(),
+            SegmentError::HttpClient(ref err) => err.description(),
+            SegmentError::HttpClientParse(ref err) => err.description(),
+            SegmentError::HttpResponse(_) => "Non-200 HTTP response.",
+            SegmentError::IO(ref err) => err.description(),
+            SegmentError::Serialization(ref err) => err.description(),
+        }
+    }
+}

--- a/components/segment-api-client/src/lib.rs
+++ b/components/segment-api-client/src/lib.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate base64;
+extern crate hyper;
+extern crate hyper_openssl;
+extern crate log;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
+
+pub mod client;
+pub mod config;
+pub mod error;
+
+pub use client::SegmentClient;
+pub use config::SegmentCfg;
+pub use error::{SegmentError, SegmentResult};

--- a/components/segment-api-client/src/main.rs
+++ b/components/segment-api-client/src/main.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This is only here to allow manual testing of the API client.
+extern crate segment_api_client as segment;
+#[macro_use]
+extern crate log;
+
+use std::env;
+use std::process::exit;
+
+use segment::client::SegmentClient;
+use segment::config::SegmentCfg;
+
+fn main() {
+    let mut config = SegmentCfg::default();
+    match env::args().nth(1) {
+        Some(w) => config.write_key = w,
+        None => {
+            println!("Usage: segment-client WRITE_KEY");
+            exit(1);
+        }
+    }
+
+    let client = SegmentClient::new(config);
+    match client.identify("abc123") {
+        Ok(_) => (),
+        Err(e) => {
+            debug!("Error calling identify. e = {:?}", e);
+            exit(1);
+        }
+    }
+    match client.track("abc123", "tested tracking") {
+        Ok(_) => (),
+        Err(e) => {
+            debug!("Error calling identify. e = {:?}", e);
+            exit(1);
+        }
+    }
+}


### PR DESCRIPTION
This pulls the `segment-api-client` crate over from the habitat repository.

See https://github.com/habitat-sh/habitat/issues/4724