### PR TITLE
Improve token comparison

### DIFF
--- a/components/builder-sessionsrv/src/server/handlers.rs
+++ b/components/builder-sessionsrv/src/server/handlers.rs
@@ -210,7 +210,9 @@ pub fn account_token_validate(
     cache_tokens_for_account(state, account_id)?; // Pre-emptively populate cache if needed
 
     let is_valid = match state.tokens.read().unwrap().get(&account_id) {
-        Some(&Some(ref token)) => token == msg.get_token(),
+        Some(&Some(ref token)) => {
+            token.trim_right_matches('=') == msg.get_token().trim_right_matches('=')
+        }
         Some(&None) => false,
         None => panic!("Not reachable!"),
     };

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -1,7 +1,7 @@
 habitatConfig({
 
     // Enable personal access tokens (this feature is under development)
-    enable_access_tokens: false,
+    enable_access_tokens: true,
 
     // Enable Builder-specific features
     enable_builder: true,


### PR DESCRIPTION
Modify the access token comparison to ignore the right trailing '='.  This is usually just a filler added by base64 conversion. When copying the token, it's easy to lose the '=', and we want to avoid having unneeded false negatives during the token check.

Also a minor switch to a default in a sample config file.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-170292987](https://user-images.githubusercontent.com/13542112/37181915-cc0b7c7a-22e3-11e8-96c0-dda7404e20d7.gif)
