### PR TITLE
Turn UserToken into a newtype

### DIFF
--- a/components/builder-http-gateway/src/http/middleware.rs
+++ b/components/builder-http-gateway/src/http/middleware.rs
@@ -284,7 +284,7 @@ pub fn session_create_github(req: &mut Request, token: &str) -> IronResult<Sessi
     debug!(
         "GITHUB-CALL builder_http-gateway::middleware::session_create_github: Checking user with access token",
     );
-    match github.user(&(token.to_string() as UserToken)) {
+    match github.user(&UserToken::new(token.to_string())) {
         Ok(user) => {
             let mut request = SessionCreate::new();
             request.set_session_type(SessionType::User);

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::io::Read;
 use std::time::{UNIX_EPOCH, Duration, SystemTime};
 
@@ -72,7 +73,20 @@ impl AppToken {
 // Temporary type... will go away soon once we transition away from
 // personal Github tokens. Useful for expressing expectations through
 // explicitly typing, though.
-pub type UserToken = TokenString;
+#[derive(Clone, Debug)]
+pub struct UserToken(TokenString);
+
+impl UserToken {
+    pub fn new(token: TokenString) -> Self {
+        UserToken(token)
+    }
+}
+
+impl fmt::Display for UserToken {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Clone)]
 pub struct GitHubClient {


### PR DESCRIPTION
This makes `UserToken` a real type, as opposed to a simple alias,
which just makes all the typing very explicit; otherwise you could
accidentally pass any old `String` as a `UserToken`, which we don't
want.

In response to https://github.com/habitat-sh/builder/pull/263#discussion_r173257966

Signed-off-by: Christopher Maier <cmaier@chef.io>