### PR TITLE
Remove installation_id from metric name

### DIFF
--- a/components/builder-worker/src/metrics.rs
+++ b/components/builder-worker/src/metrics.rs
@@ -21,7 +21,8 @@ use bldr_core::metrics;
 pub type InstallationId = u32;
 
 pub enum Counter {
-    GitClone(InstallationId),
+    GitClone,
+    GitAuthenticatedClone,
 }
 
 impl metrics::CounterMetric for Counter {}
@@ -29,8 +30,11 @@ impl metrics::CounterMetric for Counter {}
 impl metrics::Metric for Counter {
     fn id(&self) -> Cow<'static, str> {
         match *self {
-            Counter::GitClone(ref installation_id) => {
-                format!("github.clone.{}", installation_id).into()
+            Counter::GitAuthenticatedClone => {
+                format!("github.authenticated_clone").into()
+            },
+            Counter::GitClone => {
+                format!("github.clone").into()
             }
         }
     }

--- a/components/builder-worker/src/vcs.rs
+++ b/components/builder-worker/src/vcs.rs
@@ -74,6 +74,7 @@ impl VCS {
                         debug!(
                             "GITHUB-CALL builder_worker::vcs::clone: no installation_id present, no token generated"
                         );
+                        Counter::GitClone.increment();
                         None
                     }
                     Some(id) => {
@@ -89,8 +90,7 @@ impl VCS {
                         let t = self.github_client.app_installation_token(id).map_err(|e| {
                             Error::GithubAppAuthErr(e)
                         })?;
-                        // TBD: Split metrics into authenticated and non-authenticated
-                        Counter::GitClone(id).increment();
+                        Counter::GitAuthenticatedClone.increment();
                         Some(t.inner_token().to_string())
                     }
                 };


### PR DESCRIPTION
This was a leftover from a previous incarnation of the metrics
work. Now, we create a `github.authenticated_clone` and `github.clone`
metric to capture both authenticated and non-authenticated clones.

Signed-off-by: Christopher Maier <cmaier@chef.io>