### PR TITLE
Specify a default OAuth signup URL

### DIFF
--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -30,7 +30,7 @@ provider       = "github"
 client_id      = ""
 authorize_url  = "https://github.com/login/oauth/authorize"
 redirect_url   = ""
-signup_url     = ""
+signup_url     = "https://github.com/join"
 
 [nginx]
 worker_rlimit_nofile = 8192

--- a/components/builder-web/app/oauth-providers/index.ts
+++ b/components/builder-web/app/oauth-providers/index.ts
@@ -34,7 +34,7 @@ export abstract class OAuthProvider {
     }
 
     if (!this.signupUrl) {
-      console.warn(`Consider configuring Builder with an OAuth signup URL for your users (e.g., 'https://github.com/join').`);
+      console.warn(`Consider configuring Builder with an OAuth signup URL for your users. (e.g., 'https://github.com/join').`);
     }
   }
 


### PR DESCRIPTION
When specified, this URL is used on the sign-in view to link to the OAuth provider's account-creation page. We default to GitHub as our default provider.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-205401561](https://user-images.githubusercontent.com/274700/37497066-508fd984-2873-11e8-9bf4-db8612ff98a4.gif)
