### PR TITLE
Better support on-prem behavior in Builder UI

### DIFF
--- a/components/builder-api-proxy/config/habitat.conf.js
+++ b/components/builder-api-proxy/config/habitat.conf.js
@@ -1,6 +1,7 @@
 habitatConfig({
     habitat_api_url: "{{cfg.app_url}}",
     community_url: "{{cfg.community_url}}",
+    cookie_domain: "{{cfg.cookie_domain}}",
     docs_url: "{{cfg.docs_url}}",
     environment: "{{cfg.environment}}",
     friends_only: {{cfg.friends_only}},
@@ -29,5 +30,6 @@ habitatConfig({
     learn_url: "{{cfg.learn_url}}",
     enable_builder: {{cfg.enable_builder}},
     enable_access_tokens: {{cfg.enable_access_tokens}},
+    enable_statuspage: {{cfg.hosted}},
     use_gravatar: {{cfg.use_gravatar}}
 });

--- a/components/builder-api-proxy/config/index.html
+++ b/components/builder-api-proxy/config/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html prefix="og: http://ogp.me/ns#">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>Habitat - Automation that travels with the app.</title>
+    <meta name="description" content="Habitat allows automation to travel with your app, so you can be confident that what you build, deploy and manage will behave consistently in any runtime.">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    {{#if cfg.hosted}}
+      <meta property="og:title" content="Habitat - Automation that travels with the app.">
+      <meta property="og:type" content="website">
+      <meta property="og:image" content="https://www.habitat.sh/assets/images/habitat-social.jpg">
+      <meta property="og:url" content="https://www.habitat.sh/">
+      <meta property="og:description" content="Habitat allows automation to travel with your app, so you can be confident that what you build, deploy and manage will behave consistently in any runtime.">
+      <meta name="twitter:card" content="summary_large_image">
+      <meta name="twitter:site" content="@chef">
+      <meta name="twitter:creator" content="@chef">
+      <meta name="twitter:image" content="/assets/images/habitat-social.jpg">
+      <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="habitat.sh">
+    {{/if}}
+
+    <link rel="stylesheet" href="/assets/app-{{ pkg.release }}.css">
+    <base href="/">
+    {{#if cfg.hosted}}
+      <!-- Heap -->
+      <script type="text/javascript">
+        window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+        heap.load("460996886");
+      </script>
+    {{/if}}
+  </head>
+  <body>
+    {{#if cfg.hosted}}
+      <!-- Google Analytics -->
+      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5VR24H" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5VR24H');</script>
+
+      <!-- Segment -->
+      <script type="text/javascript">!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";analytics.load("NAwVPW04CeESMW3vtyqjJZmVMNBSQ1K1");analytics.page();}}();</script>
+
+      <!-- Statuspage -->
+      <script src="//cdn.statuspage.io/se-v2.js"></script>
+    {{/if}}
+    <hab-app>
+    <script>
+        window.Habitat = { config: {} };
+        function habitatConfig(options) {
+          window.Habitat.config = options || {};
+        };
+    </script>
+    <script src="/habitat.conf.js"></script>
+    <script src="/assets/app-{{ pkg.release }}.js"></script>
+  </body>
+</html>

--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -65,7 +65,7 @@ http {
   }
 
   server {
-    index index.html;
+    index /index.html;
     listen       *:{{cfg.http.listen_port}};
     server_name  {{sys.hostname}};
     root         {{pkg.path}}/app;
@@ -97,6 +97,7 @@ http {
 
     location /index.html {
       add_header Cache-Control "private, no-cache, no-store";
+      root {{pkg.svc_config_path}};
       break;
     }
 

--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -18,6 +18,8 @@ learn_url            = "https://www.habitat.sh/learn"
 enable_builder       = true
 enable_access_tokens = true
 use_gravatar         = true
+hosted               = false
+cookie_domain        = ""
 
 [github]
 url          = "https://api.github.com"

--- a/components/builder-api-proxy/plan.sh
+++ b/components/builder-api-proxy/plan.sh
@@ -12,7 +12,6 @@ pkg_build_deps=(
   core/phantomjs
   core/python2
   core/make
-  core/openssl
 )
 pkg_svc_user="root"
 pkg_svc_run="nginx -c ${pkg_svc_config_path}/nginx.conf"
@@ -50,7 +49,10 @@ do_build() {
   for b in node_modules/.bin/*; do
     fix_interpreter $(readlink -f -n $b) core/coreutils bin/env
   done
-  npm run dist
+
+  # Pass the release identifier to the bundle script to enable cache-busting
+  npm run dist -- ${pkg_prefix: -14}
+
   rm -rf dist/node_modules
   popd > /dev/null
 }

--- a/components/builder-web/app/actions.test.ts
+++ b/components/builder-web/app/actions.test.ts
@@ -67,8 +67,8 @@ describe('actions', () => {
         expect(cookies.set.calls.allArgs()).toEqual(
           [
             ['oauthToken', 'some-token', { domain: 'localhost', secure: false }],
-            ['oauthToken', 'some-token', { domain: 'habitat.sh', secure: false }],
-            ['oauthToken', 'some-token', { domain: 'acceptance.habitat.foo', secure: false }],
+            ['oauthToken', 'some-token', { domain: 'builder.habitat.sh', secure: false }],
+            ['oauthToken', 'some-token', { domain: 'builder.acceptance.habitat.foo', secure: false }],
             ['oauthToken', 'some-token', { domain: '1.2.3.4', secure: false }]
           ]
         );

--- a/components/builder-web/app/browser.ts
+++ b/components/builder-web/app/browser.ts
@@ -1,19 +1,10 @@
 import * as cookies from 'js-cookie';
+import config from './config';
 
 export class Browser {
 
   static get cookieDomain() {
-    let delim = '.';
-    let hostname = this.currentHostname;
-    let tld = hostname.split(delim).pop();
-
-    if (isNaN(Number(tld))) {
-      let domain = hostname.split(delim);
-      domain.shift();
-      return domain.join(delim) || hostname;
-    } else {
-      return hostname;
-    }
+    return config.cookie_domain || this.currentHostname;
   }
 
   static get currentHostname() {

--- a/components/builder-web/app/side-nav/side-nav.component.html
+++ b/components/builder-web/app/side-nav/side-nav.component.html
@@ -58,9 +58,11 @@
       </a>
     </li>
   </ul>
-  <h3>Service Status</h3>
-  <ul>
-    <li><hab-statuspage></hab-statuspage></li>
-  </ul>
+  <ng-container *ngIf="config.enable_statuspage">
+    <h3>Service Status</h3>
+    <ul>
+      <li><hab-statuspage></hab-statuspage></li>
+    </ul>
+  </ng-container>
   <span class="version" [title]="config['version']">{{ config['version'] }}</span>
 </nav>

--- a/components/builder-web/bin/dist
+++ b/components/builder-web/bin/dist
@@ -10,13 +10,6 @@ mkdir -p dist/assets
 cp -R assets favicon.ico robots.txt opensearch.xml dist
 npm run build
 mkdir -p dist/node_modules
-cp habitat.conf.sample.js dist/habitat.conf.js
 
-css_sha=$(openssl dgst -sha256 assets/app.css | cut -d ' ' -f 2)
-cp assets/app.css "dist/assets/app-${css_sha}.css"
-
-js_sha=$(openssl dgst -sha256 assets/app.js | cut -d ' ' -f 2)
-cp assets/app.js "dist/assets/app-${js_sha}.js"
-sed -e "/id=\"hab-css\"/ s/app\.css/app-${css_sha}\.css/" \
-    -e "/id=\"hab-js\"/ s/app\.js/app-${js_sha}\.js/" \
-    index.html > dist/index.html
+cp assets/app.css "dist/assets/app-$1.css"
+cp assets/app.js "dist/assets/app-$1.js"

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -6,6 +6,9 @@ habitatConfig({
     // Enable Builder-specific features
     enable_builder: true,
 
+    // Enable StatusPage.io integration
+    enable_statuspage: false,
+
     // The URL for community information
     community_url: "https://www.habitat.sh/community",
 

--- a/components/builder-web/index.html
+++ b/components/builder-web/index.html
@@ -6,42 +6,20 @@
     <title>Habitat - Automation that travels with the app.</title>
     <meta name="description" content="Habitat allows automation to travel with your app, so you can be confident that what you build, deploy and manage will behave consistently in any runtime.">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
     <meta property="og:title" content="Habitat - Automation that travels with the app.">
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://www.habitat.sh/assets/images/habitat-social.jpg">
     <meta property="og:url" content="https://www.habitat.sh/">
     <meta property="og:description" content="Habitat allows automation to travel with your app, so you can be confident that what you build, deploy and manage will behave consistently in any runtime.">
-
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@chef">
     <meta name="twitter:creator" content="@chef">
     <meta name="twitter:image" content="/assets/images/habitat-social.jpg">
-
     <link id="hab-css" rel="stylesheet" href="/assets/app.css">
     <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="habitat.sh">
-
     <base href="/">
-    <!-- Heap Analytics -->
-    <script type="text/javascript">
-      window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
-      heap.load("460996886");
-    </script>
-    <!-- End Heap Analytics -->
   </head>
   <body>
-    <!-- Google Tag Manager -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5VR24H"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5VR24H');</script>
-    <!-- End Google Tag Manager -->
-    <!-- Segment -->
-    <script type="text/javascript">!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";analytics.load("NAwVPW04CeESMW3vtyqjJZmVMNBSQ1K1");analytics.page();}}();</script>
-    <!-- End Segment -->
     <hab-app>
     <script>
         window.Habitat = { config: {} };


### PR DESCRIPTION
This change adds two new configuration properties, `hosted` and `cookie_domain`, to allow us to suppress certain behaviors in on-prem installations.

Specifically, we insert third-party scripts (e.g., Google Analytics, Heap Analytics, Segment and StatusPage) only in our hosted environments, and we allow cookie domains to be configurable (defaulting to the current hostname).

Also suppresses third-party scripts in the development environment, which has been causing our UX friends some headaches lately. 😄 

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-155459627](https://user-images.githubusercontent.com/274700/37546464-36ac46da-292a-11e8-9404-61a2502e515f.gif)
