### PR TITLE
Deprecate use of github teams for permissions

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -100,7 +100,7 @@ build-builder() { stop-on-failure _build-builder "$@"; }
 
 ui-dev-mode() {
   for svc in sessionsrv worker api originsrv; do
-  cat <<CONFIG | hab config apply builder-${svc}.default $(date +%s)
+  cat <<CONFIG | hab config apply builder-${svc}.default "$(date +%s)"
 [github]
 client_id = "Iv1.732260b62f84db15"
 client_secret = "fc7654ed8c65ccfe014cd339a55e3538f935027a"
@@ -112,7 +112,7 @@ done
 upload_github_keys() {
   if [[ -f "/src/.secrets/builder-github-app.pem" ]]; then
     for svc in sessionsrv worker api originsrv; do
-      hab file upload "builder-${svc}.default" $(date +%s) "/src/.secrets/builder-github-app.pem"
+      hab file upload "builder-${svc}.default" "$(date +%s)" "/src/.secrets/builder-github-app.pem"
     done
   else
     echo "Please follow instruction #6 here: https://github.com/habitat-sh/habitat/blob/master/BUILDER_DEV.md#pre-reqs"
@@ -208,11 +208,16 @@ _stop-builder() {
 stop-builder() { stop-on-failure _stop-builder "$@"; }
 
 generate_bldr_keys() {
-  KEY_NAME=$(hab user key generate bldr | grep -Po "bldr-\d+")
-  for svc in api jobsrv worker; do
-    hab file upload "builder-${svc}.default" $(date +%s) "/hab/cache/keys/${KEY_NAME}.pub"
-    hab file upload "builder-${svc}.default" $(date +%s) "/hab/cache/keys/${KEY_NAME}.box.key"
-  done
+  if [ -n "$(find /hab/cache/keys -name "bldr-*.pub")" ]; then
+    echo "Re-using existing builder key"
+  else
+    echo "Generating builder key"
+    KEY_NAME=$(hab user key generate bldr | grep -Po "bldr-\d+")
+    for svc in api jobsrv worker; do
+      hab file upload "builder-${svc}.default" "$(date +%s)" "/hab/cache/keys/${KEY_NAME}.pub"
+      hab file upload "builder-${svc}.default" "$(date +%s)" "/hab/cache/keys/${KEY_NAME}.box.key"
+    done
+  fi
 }
 
 load_package() {

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -134,32 +134,6 @@ impl GitHubClient {
         }
     }
 
-    pub fn check_team_membership(
-        &self,
-        token: &AppToken,
-        team: u32,
-        user: &str,
-    ) -> HubResult<Option<TeamMembership>> {
-        let url = Url::parse(&format!("{}/teams/{}/memberships/{}", self.url, team, user))
-            .map_err(HubError::HttpClientParse)?;
-
-        Counter::Api("check_team_membership").increment();
-        let mut rep = http_get(url, Some(&token.inner_token))?;
-        let mut body = String::new();
-        rep.read_to_string(&mut body)?;
-        debug!("GitHub response body, {}", body);
-        match rep.status {
-            StatusCode::NotFound => return Ok(None),
-            StatusCode::Ok => (),
-            status => {
-                let err: HashMap<String, String> = serde_json::from_str(&body)?;
-                return Err(HubError::ApiError(status, err));
-            }
-        }
-        let membership = serde_json::from_str(&body)?;
-        Ok(Some(membership))
-    }
-
     /// Returns the contents of a file or directory in a repository.
     pub fn contents(&self, token: &AppToken, repo: u32, path: &str) -> HubResult<Option<Contents>> {
         let url = Url::parse(&format!(

--- a/components/github-api-client/src/types.rs
+++ b/components/github-api-client/src/types.rs
@@ -374,19 +374,6 @@ pub struct SearchItem {
     pub score: f32,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct TeamMembership {
-    pub url: String,
-    pub role: String,
-    pub state: String,
-}
-
-impl TeamMembership {
-    pub fn active(&self) -> bool {
-        self.state == "active"
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -20,6 +20,7 @@ mkdir -p /hab/svc/builder-api
 cat <<EOT > /hab/svc/builder-api/user.toml
 log_level = "debug"
 [github]
+enabled = true
 url = "$GITHUB_API_URL"
 web_url = "$GITHUB_WEB_URL"
 client_id = "$GITHUB_CLIENT_ID"


### PR DESCRIPTION
This PR deprecates the use of github teams for the RBAC-like permission flags that are associated with account logins.  The worker permission has already been moved over to personal access tokens, and the other two (admin and early_access) are not used. Removing the use of github teams will simplify the auth flow for both hosted and on-premise builder deployments. 

This PR also has a couple of updates to configs for the dev environment.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-212195186](https://user-images.githubusercontent.com/13542112/37637325-3eaba1c2-2bc4-11e8-850c-49ed1e802bc6.gif)
