### PR TITLE
Add UI support for Azure Container Registry

### DIFF
--- a/components/builder-api-proxy/config/habitat.conf.js
+++ b/components/builder-api-proxy/config/habitat.conf.js
@@ -3,6 +3,9 @@ habitatConfig({
     demo_app_url: "{{cfg.demo_app_url}}",
     docs_url: "{{cfg.docs_url}}",
     enable_builder: {{cfg.enable_builder}},
+    enable_publisher_amazon: {{cfg.enable_publisher_amazon}},
+    enable_publisher_azure: {{cfg.enable_publisher_azure}},
+    enable_publisher_docker: {{cfg.enable_publisher_docker}},
     enable_statuspage: {{cfg.hosted}},
     environment: "{{cfg.environment}}",
     github_api_url: "{{cfg.github.url}}",
@@ -17,7 +20,7 @@ habitatConfig({
     source_code_url: "{{cfg.source_code_url}}",
     status_url: "{{cfg.status_url}}",
     tutorials_url: "{{cfg.tutorials_url}}",
-    use_gravatar: {{cfg.use_gravatar}}
+    use_gravatar: {{cfg.use_gravatar}},
     version: "{{pkg.ident}}",
     www_url: "{{cfg.www_url}}",
 });

--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -1,14 +1,17 @@
-cookie_domain        = ""
-demo_app_url         = "https://www.habitat.sh/demo/build-system/steps/1/"
-docs_url             = "https://www.habitat.sh/docs"
-enable_builder       = false
-environment          = "production"
-hosted               = false
-source_code_url      = "https://github.com/habitat-sh/habitat"
-status_url           = "https://status.habitat.sh/"
-tutorials_url        = "https://www.habitat.sh/learn"
-use_gravatar         = true
-www_url              = "https://www.habitat.sh"
+cookie_domain           = ""
+demo_app_url            = "https://www.habitat.sh/demo/build-system/steps/1/"
+docs_url                = "https://www.habitat.sh/docs"
+enable_publisher_amazon = false
+enable_publisher_azure  = false
+enable_publisher_docker = false
+enable_builder          = false
+environment             = "production"
+hosted                  = false
+source_code_url         = "https://github.com/habitat-sh/habitat"
+status_url              = "https://status.habitat.sh/"
+tutorials_url           = "https://www.habitat.sh/learn"
+use_gravatar            = true
+www_url                 = "https://www.habitat.sh"
 
 [github]
 app_id       = 5565

--- a/components/builder-web/app/initial-state.ts
+++ b/components/builder-web/app/initial-state.ts
@@ -75,7 +75,11 @@ export default Record({
     })()
   })(),
   features: Record({
-    accessTokens: false,
+    publishers: Record({
+      amazon: false,
+      azure: false,
+      docker: false
+    })(),
     builder: false
   })(),
   notifications: Record({

--- a/components/builder-web/app/origin/origin-page/integration-credentials-form/integration-credentials-form.dialog.html
+++ b/components/builder-web/app/origin/origin-page/integration-credentials-form/integration-credentials-form.dialog.html
@@ -1,8 +1,8 @@
 <div class="dialog">
   <form (ngSubmit)="onSubmit()" #dockerForm="ngForm">
     <section class="heading">
-      <hab-icon symbol="docker"></hab-icon>
-      <h1>Add Registry Account</h1>
+      <hab-icon [symbol]="data.type"></hab-icon>
+      <h1>{{ labelFor('type') }} Settings</h1>
     </section>
     <section class="body">
       <label for="name">Integration Name</label>
@@ -11,39 +11,39 @@
         name="name"
         #name="ngModel"
         [(ngModel)]="model.name"
-        placeholder="integration name"
+        [placeholder]="labelFor('type')"
         [class.invalid]="name.invalid && name.dirty"
         autocomplete="off"
         [disabled]="data.name"
         required>
       <ng-container *ngIf="data.type !== 'docker'">
-        <label>Registry URL</label>
+        <label>{{ labelFor('url') }}</label>
         <input
           type="text"
           name="registry_url"
           #registry_url="ngModel"
           [(ngModel)]="model.registry_url"
-          placeholder="registry URL"
           [class.invalid]="registry_url.invalid && registry_url.dirty"
+          [placeholder]="placeholderFor('url')"
           autocomplete="off">
       </ng-container>
-      <label for="username">Registry Username</label>
+      <label for="username">{{ labelFor('username') }}</label>
       <input
         type="text"
         name="username"
         #username="ngModel"
         [(ngModel)]="model.username"
-        placeholder="username"
+        [placeholder]="placeholderFor('username')"
         [class.invalid]="username.invalid && username.dirty"
         autocomplete="off"
         required>
-      <label for="password">Registry Password</label>
+      <label for="password">{{ labelFor('password') }}</label>
       <input
         type="password"
         name="password"
         #password="ngModel"
         [(ngModel)]="model.password"
-        placeholder="password"
+        [placeholder]="placeholderFor('password')"
         [class.invalid]="password.invalid && password.dirty"
         required>
       <p *ngIf="creds.validating || creds.validated" [class]="status.className">

--- a/components/builder-web/app/origin/origin-page/integration-credentials-form/integration-credentials-form.dialog.ts
+++ b/components/builder-web/app/origin/origin-page/integration-credentials-form/integration-credentials-form.dialog.ts
@@ -89,6 +89,28 @@ export class IntegrationCredentialsFormDialog implements OnDestroy {
     }
   }
 
+  labelFor(field) {
+    return {
+      docker: {
+        type: 'Docker Hub',
+        username: 'Docker Hub Username',
+        password: 'Docker Hub Password'
+      },
+      amazon: {
+        type: 'Amazon Container Registry',
+        url: 'Registry URL',
+        username: 'IAM Access Key ID',
+        password: 'IAM Secret Access Key'
+      },
+      azure: {
+        type: 'Azure Container Registry',
+        url: 'Server URL',
+        username: 'Service Principal ID',
+        password: 'Service Principal Password'
+      }
+    }[this.data.type][field];
+  }
+
   onNoClick(): void {
     this.dialogRef.close();
   }
@@ -113,6 +135,25 @@ export class IntegrationCredentialsFormDialog implements OnDestroy {
       // We can currently only validate DockerHub creds (╯︵╰,)
       this.dialogRef.close(this.model);
     }
+  }
+
+  placeholderFor(field) {
+    return {
+      docker: {
+        username: 'Username',
+        password: 'Password'
+      },
+      amazon: {
+        url: 'https://aws-account-id.dkr.ecr.region.amazonaws.com',
+        username: 'Access Key ID',
+        password: 'Secret Access Key'
+      },
+      azure: {
+        url: 'yourserver.azurecr.io',
+        username: 'Principal ID',
+        password: 'Principal Password'
+      }
+    }[this.data.type][field];
   }
 
   close() {

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/_origin-integrations-tab.component.scss
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/_origin-integrations-tab.component.scss
@@ -26,7 +26,7 @@
         @include tablet-up {
           flex: 1;
         }
-  
+
         display: flex;
         align-items: center;
       }
@@ -38,28 +38,31 @@
         &.docker {
           background-color: $docker-blue;
         }
-  
+
         &.google {
           background-color: $google-blue;
         }
-  
+
         &.amazon {
           background-color: $amazon-orange;
         }
-  
+
         &.azure {
           background-color: $azure-blue;
         }
       }
 
       .add-icon {
-        margin: 0 $default-margin / 2;
+        hab-icon {
+          margin: 0 $default-margin / 2;
+        }
       }
 
       .label {
-        margin-right: $default-margin;
+        white-space: normal;
+        text-align: left;
         font-weight: 600;
-        line-height: normal;
+        line-height: 20px;
       }
 
       hab-icon {

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.html
@@ -10,19 +10,21 @@
         (.hart file) to a Docker container and publish it to your registry account(s).
       </p>
       <div class="buttons">
-        <div class="wrapper" *ngFor="let provider of providers">
-          <button mat-raised-button (click)="addIntegration(provider.key)">
-            <div class="tile {{ provider.key }}">
-              <hab-icon [symbol]="provider.key"></hab-icon>
-            </div>
-            <div class="add-icon">
-              <hab-icon symbol="add-circle"></hab-icon>
-            </div>
-            <div class="label">
-              {{ provider.name }}
-            </div>
-          </button>
-        </div>
+        <ng-container *ngFor="let provider of providers">
+          <div class="wrapper" *ngIf="provider.enabled">
+            <button mat-raised-button (click)="addIntegration(provider.key)">
+              <div class="tile {{ provider.key }}">
+                <hab-icon [symbol]="provider.key"></hab-icon>
+              </div>
+              <div class="add-icon">
+                <hab-icon symbol="add-circle"></hab-icon>
+              </div>
+              <div class="label">
+                {{ provider.name }}
+              </div>
+            </button>
+          </div>
+        </ng-container>
       </div>
     </section>
     <section>

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.ts
@@ -64,14 +64,23 @@ export class OriginIntegrationsTabComponent implements OnInit, OnDestroy {
   }
 
   get providers() {
+    const publishers = this.store.getState().features.publishers;
+
     return [
       {
         key: 'docker',
-        name: 'Docker Hub'
+        name: 'Docker Hub',
+        enabled: publishers.docker
       },
       {
         key: 'amazon',
-        name: 'Amazon Container Registry'
+        name: 'Amazon Container Registry',
+        enabled: publishers.amazon
+      },
+      {
+        key: 'azure',
+        name: 'Azure Container Registry',
+        enabled: publishers.azure
       }
     ];
   }

--- a/components/builder-web/app/reducers/features.ts
+++ b/components/builder-web/app/reducers/features.ts
@@ -20,7 +20,11 @@ export default function builds(state = initialState['features'], action) {
   switch (action.type) {
 
     case actionTypes.LOAD_FEATURES:
-      return state.set('builder', !!config['enable_builder']);
+      return state
+        .setIn(['publishers', 'amazon'], !!config['enable_publisher_amazon'])
+        .setIn(['publishers', 'azure'], !!config['enable_publisher_azure'])
+        .setIn(['publishers', 'docker'], !!config['enable_publisher_docker'])
+        .set('builder', !!config['enable_builder']);
 
     default:
       return state;

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -12,6 +12,11 @@ habitatConfig({
     // Enable Builder-specific features
     enable_builder: true,
 
+    // Enable supported container-registry integrations
+    enable_publisher_amazon: false,
+    enable_publisher_azure: false,
+    enable_publisher_docker: false,
+
     // Enable StatusPage.io integration
     enable_statuspage: false,
 


### PR DESCRIPTION
This change adds an additional container-publishing option for Azure to the origin Integrations tab. It also adds some differentiation between the three registries’ modal dialogs, since they all differ slightly in their terminology and example settings, and it makes all three publishers configurable as well.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://media1.giphy.com/media/JPVrYda99Rwju/200w.gif)