### PR TITLE
Remove Sass import of deleted component

### DIFF
--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -231,7 +231,6 @@ main {
 
 @import 'dialog';
 @import 'banner/banner.component';
-@import 'footer/footer.component';
 @import 'user-nav/user-nav.component';
 @import 'notifications/notifications';
 @import 'origin/origin.module';


### PR DESCRIPTION
This component was removed in 558e32c. (The include is currently breaking the CSS build.)

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://media3.giphy.com/media/5YfdHBiQRCH547uFhR/200w.gif)