### PR TITLE
Config cleanup for Github and Bitbucket clients

### DIFF
--- a/.secrets/habitat-env.sample
+++ b/.secrets/habitat-env.sample
@@ -2,7 +2,8 @@
 
 APP_HOSTNAME="localhost"
 GITHUB_API_URL="https://api.github.com"
-GITHUB_WEB_URL="https://github.com"
+GITHUB_AUTHORIZE_URL="https://github.com/login/oauth/authorize"
+GITHUB_TOKEN_URL="https://github.com/login/oauth/access_token"
 GITHUB_CLIENT_ID="Iv1.04b78696442708f6"
 GITHUB_CLIENT_SECRET="b4acf029896e9c7fb6613390124e8ae3c35889aa"
 GITHUB_APP_ID=8053

--- a/.studiorc
+++ b/.studiorc
@@ -5,7 +5,8 @@ set -uo pipefail
 
 export APP_HOSTNAME
 export GITHUB_API_URL
-export GITHUB_WEB_URL
+export GITHUB_AUTHORIZE_URL
+export GITHUB_TOKEN_URL
 export GITHUB_CLIENT_ID
 export GITHUB_CLIENT_SECRET
 export SSL_CERT_FILE

--- a/BUILDER_CONTAINER.md
+++ b/BUILDER_CONTAINER.md
@@ -10,11 +10,12 @@
 
 * `APP_HOSTNAME` - Builder's addressable hostname. This is used for redirection back after authenticating with GitHub and proxying requests to the appropriate http gateway _(default: "localhost")_.
 * `GITHUB_API_URL` - external GitHub or GitHub Enterprise API endpoint Builder will connect to _(default: "https://api.github.com")_.
-* `GITHUB_WEB_URL` - external GitHub or GitHub Enterprise web URL endpoint Builder will connect to _(default: "https://github.com")_
+* `GITHUB_AUTHORIZE_URL` - external GitHub or GitHub Enterprise authorization URL endpoint Builder will connect to _(default: "https://github.com/login/oauth/authorize")_
+* `GITHUB_TOKEN_URL` - external GitHub or GitHub Enterprise token URL endpoint Builder will connect to _(default: "https://github.com/login/oauth/access_token")_
 * `GITHUB_CLIENT_ID` - GitHub OAuth application client-id *required*.
 * `GITHUB_CLIENT_SECRET` - GitHub OAuth application client-secret *required*.
-* `GITHUB_ADMIN_TEAM` - GitHub Team ID to grant admin gateway access to *required*.
 * `GITHUB_APP_ID` - GitHub App ID to make requests from the UI *required*.
+* `GITHUB_APP_URL` - GitHub App URL for the configured Github App ID *required*.
 
 ```bash
 $ cd ${root}
@@ -24,8 +25,9 @@ $ docker build --no-cache \
   --build-arg GITHUB_CLIENT_SECRET=<your_GH_client_secret> \
   --build-arg GITHUB_ADDR=<optional_GH_addr> \
   --build-arg GITHUB_API_URL=<optional_GH_api_url> \
-  --build-arg GITHUB_WEB_URL=<optional_GH_web_url> \
-  --build-arg GITHUB_ADMIN_TEAM=0 \
+  --build-arg GITHUB_AUTHORIZE_URL=<optional_GH_authorize_url> \
+  --build-arg GITHUB_TOKEN_URL=<optional_GH_token_url> \
+  --build-arg GITHUB_APP_URL=<GH_app_url> \
   --build-arg GITHUB_APP_ID -t habitat/builder .
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@ MAINTAINER The Habitat Maintainers <humans@habitat.sh>
 ARG APP_HOSTNAME=localhost
 ARG GITHUB_ADDR=github.com
 ARG GITHUB_API_URL=https://api.github.com
-ARG GITHUB_WEB_URL=https://github.com
+ARG GITHUB_AUTHORIZE_URL=https://github.com/login/oauth/authorize
+ARG GITHUB_TOKEN_URL=https://github.com/login/oauth/access_token
 ARG GITHUB_CLIENT_ID=UNDEFINED
 ARG GITHUB_CLIENT_SECRET=UNDEFINED
-ARG GITHUB_ADMIN_TEAM=0
 ARG GITHUB_APP_ID=UNDEFINED
+ARG GITHUB_APP_URL=https://github.com/apps/habitat-builder-dev-studio
 
 ENV HAB_BLDR_CHANNEL unstable
 ENV RUST_LOG info
@@ -45,11 +46,12 @@ RUN /tmp/init-datastore.sh \
   && APP_HOSTNAME=$APP_HOSTNAME \
   GITHUB_ADDR=$GITHUB_ADDR \
   GITHUB_API_URL=$GITHUB_API_URL \
-  GITHUB_WEB_URL=$GITHUB_WEB_URL \
+  GITHUB_AUTHORIZE_URL=$GITHUB_AUTHORIZE_URL \
+  GITHUB_TOKEN_URL=$GITHUB_TOKEN_URL \
   GITHUB_CLIENT_ID=$GITHUB_CLIENT_ID \
   GITHUB_CLIENT_SECRET=$GITHUB_CLIENT_SECRET \
-  GITHUB_ADMIN_TEAM=$GITHUB_ADMIN_TEAM \
   GITHUB_APP_ID=$GITHUB_APP_ID \
+  GITHUB_APP_URL=$GITHUB_APP_URL \
   /tmp/config.sh
 
 RUN hab pkg exec core/openssl openssl s_client -showcerts -connect $GITHUB_ADDR:443 \

--- a/components/bitbucket-api-client/src/client.rs
+++ b/components/bitbucket-api-client/src/client.rs
@@ -39,11 +39,11 @@ impl OAuthClient for BitbucketClient {
     // it for an access token
     fn authenticate(&self, code: &str) -> OAuthResult<String> {
         // TODO JB: make the version here dynamic
-        let client = ApiClient::new(&self.config.web_url, "habitat", "0.54.0", None)
+        let client = ApiClient::new(&self.config.token_url, "bldr", "0.0.0", None)
             .map_err(OAuthError::ApiClient)?;
         let params = format!("grant_type=authorization_code&code={}", code);
         let req = client
-            .post("site/oauth2/access_token")
+            .post("")
             .header(Authorization(Basic {
                 username: self.config.client_id.clone(),
                 password: Some(self.config.client_secret.clone()),
@@ -71,7 +71,7 @@ impl OAuthClient for BitbucketClient {
     // about is username and email address
     fn user(&self, token: &OAuthUserToken) -> OAuthResult<OAuthUser> {
         // TODO JB: make the version here dynamic
-        let client = ApiClient::new(&self.config.api_url, "habitat", "0.54.0", None)
+        let client = ApiClient::new(&self.config.api_url, "bldr", "0.0.0", None)
             .map_err(OAuthError::ApiClient)?;
         let mut req = client.get("1.0/user");
         req = req.header(Authorization(Bearer { token: token.to_string() }));

--- a/components/bitbucket-api-client/src/config.rs
+++ b/components/bitbucket-api-client/src/config.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// URL to Bitbucket web site
-pub const DEFAULT_BITBUCKET_WEB_URL: &'static str = "https://bitbucket.org";
+pub const DEFAULT_BITBUCKET_TOKEN_URL: &'static str = "https://bitbucket.org/site/oauth2/access_token";
 
 /// URL to Bitbucket API site
 pub const DEFAULT_BITBUCKET_API_URL: &'static str = "https://api.bitbucket.org";
@@ -27,7 +27,7 @@ pub const DEV_BITBUCKET_CLIENT_SECRET: &'static str = "7EPUST337P4YCX6H8Pub9nrWB
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct BitbucketCfg {
-    pub web_url: String,
+    pub token_url: String,
     pub api_url: String,
     pub client_id: String,
     pub client_secret: String,
@@ -36,7 +36,7 @@ pub struct BitbucketCfg {
 impl Default for BitbucketCfg {
     fn default() -> Self {
         BitbucketCfg {
-            web_url: DEFAULT_BITBUCKET_WEB_URL.to_string(),
+            token_url: DEFAULT_BITBUCKET_TOKEN_URL.to_string(),
             api_url: DEFAULT_BITBUCKET_API_URL.to_string(),
             client_id: DEV_BITBUCKET_CLIENT_ID.to_string(),
             client_secret: DEV_BITBUCKET_CLIENT_SECRET.to_string(),

--- a/components/builder-api-proxy/config/habitat.conf.js
+++ b/components/builder-api-proxy/config/habitat.conf.js
@@ -8,7 +8,7 @@ habitatConfig({
     enable_publisher_docker: {{cfg.enable_publisher_docker}},
     enable_statuspage: {{cfg.hosted}},
     environment: "{{cfg.environment}}",
-    github_api_url: "{{cfg.github.url}}",
+    github_api_url: "{{cfg.github.api_url}}",
     github_app_url: "{{cfg.github.app_url}}",
     github_app_id: "{{cfg.github.app_id}}",
     habitat_api_url: "{{cfg.app_url}}",

--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -17,7 +17,7 @@ www_url                 = "https://www.habitat.sh"
 [github]
 app_id       = 5565
 app_url      = "https://github.com/apps/habitat-builder"
-url          = "https://api.github.com"
+api_url      = "https://api.github.com"
 
 [oauth]
 authorize_url  = "https://github.com/login/oauth/authorize"

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -6,8 +6,8 @@ port   = 9636
 
 [github]
 enabled        = false
-url            = "https://api.github.com"
-web_url        = "https://github.com"
+api_url        = "https://api.github.com"
+token_url      = "https://github.com/login/oauth/access_token"
 client_id      = ""
 client_secret  = ""
 app_id         = 5565
@@ -16,7 +16,7 @@ webhook_secret = ""
 [bitbucket]
 enabled        = false
 api_url        = "https://api.bitbucket.org"
-web_url        = "https://bitbucket.org"
+token_url      = "https://bitbucket.org/site/oauth2/access_token"
 client_id      = ""
 client_secret  = ""
 

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -167,7 +167,7 @@ mod tests {
         port = 9632
 
         [github]
-        url = "https://api.github.com"
+        api_url = "https://api.github.com"
         client_id = "0c2f738a7d0bd300de10"
         client_secret = "438223113eeb6e7edf2d2f91a232b72de72b9bdf"
 
@@ -185,17 +185,24 @@ mod tests {
         assert_eq!(config.http.port, 9636);
         assert_eq!(config.http.handler_count, 128);
         assert_eq!(&format!("{}", config.routers[0]), "172.18.0.2:9632");
-        assert_eq!(config.github.unwrap().url, "https://api.github.com");
-        assert_eq!(config.github.unwrap().client_id, "0c2f738a7d0bd300de10");
+
+        let github = config.github.unwrap();
+        assert_eq!(github.api_url, "https://api.github.com");
+        assert_eq!(github.client_id, "0c2f738a7d0bd300de10");
         assert_eq!(
-            config.github.unwrap().client_secret,
+            github.client_secret,
             "438223113eeb6e7edf2d2f91a232b72de72b9bdf"
         );
         assert_eq!(config.ui.root, Some("/some/path".to_string()));
         assert_eq!(config.segment.url, "https://api.segment.io");
-        assert_eq!(config.bitbucket.unwrap().web_url, "https://bitbucket.org");
-        assert_eq!(config.bitbucket.unwrap().client_id, "haha");
-        assert_eq!(config.bitbucket.unwrap().client_secret, "abc123");
+
+        let bitbucket = config.bitbucket.unwrap();
+        assert_eq!(
+            bitbucket.token_url,
+            "https://bitbucket.org/site/oauth2/access_token"
+        );
+        assert_eq!(bitbucket.client_id, "haha");
+        assert_eq!(bitbucket.client_secret, "abc123");
     }
 
     #[test]
@@ -231,7 +238,7 @@ mod tests {
         port = 9632
 
         [github]
-        url = "https://api.github.com"
+        api_url = "https://api.github.com"
         client_id = "0c2f738a7d0bd300de10"
         client_secret = "438223113eeb6e7edf2d2f91a232b72de72b9bdf"
         "#;
@@ -244,15 +251,17 @@ mod tests {
         assert_eq!(config.http.port, 9636);
         assert_eq!(config.http.handler_count, 128);
         assert_eq!(&format!("{}", config.routers[0]), "172.18.0.2:9632");
-        assert_eq!(config.github.unwrap().url, "https://api.github.com");
-        assert_eq!(config.github.unwrap().client_id, "0c2f738a7d0bd300de10");
+
+        let github = config.github.unwrap();
+        assert_eq!(github.api_url, "https://api.github.com");
+        assert_eq!(github.client_id, "0c2f738a7d0bd300de10");
         assert_eq!(
-            config.github.unwrap().client_secret,
+            github.client_secret,
             "438223113eeb6e7edf2d2f91a232b72de72b9bdf"
         );
         assert_eq!(config.ui.root, Some("/some/path".to_string()));
         assert_eq!(config.segment.url, "https://api.segment.io");
-        assert_eq!(config.bitbucket, None);
+        assert!(config.bitbucket.is_none());
     }
 
     #[test]

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -82,6 +82,14 @@ impl HttpGateway for ApiSrv {
         let basic;
         let admin;
 
+        // Allow one and only one auth config
+        // TODO: Update configs so that structurally only a single auth config is possible
+        if ((config.github.is_none() && config.bitbucket.is_none()) ||
+                (config.github.is_some() && config.bitbucket.is_some()))
+        {
+            panic!("Must have one and only one auth config (github or bitbucket)");
+        }
+
         if config.github.is_some() {
             let c = config.github.clone();
             let client = GitHubClient::new(c.unwrap());

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -153,7 +153,7 @@ mod tests {
         port = 9001
 
         [github]
-        url = "https://api.github.com"
+        api_url = "https://api.github.com"
         client_id = "0c2f738a7d0bd300de10"
         client_secret = "438223113eeb6e7edf2d2f91a232b72de72b9bdf"
         "#;
@@ -169,7 +169,7 @@ mod tests {
         assert_eq!(&format!("{}", config.http.listen), "127.0.0.1");
         assert_eq!(config.http.port, 9000);
         assert_eq!(&format!("{}", config.routers[0]), "172.18.0.2:9001");
-        assert_eq!(config.github.url, "https://api.github.com");
+        assert_eq!(config.github.api_url, "https://api.github.com");
         assert_eq!(config.github.client_id, "0c2f738a7d0bd300de10");
         assert_eq!(
             config.github.client_secret,

--- a/components/github-api-client/src/config.rs
+++ b/components/github-api-client/src/config.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 /// URL to GitHub API endpoint
-pub const DEFAULT_GITHUB_URL: &'static str = "https://api.github.com";
-/// URL to GitHub Web endpoint
-pub const DEFAULT_GITHUB_WEB_URL: &'static str = "https://github.com";
+pub const DEFAULT_GITHUB_API_URL: &'static str = "https://api.github.com";
+/// URL to GitHub Token endpoint
+pub const DEFAULT_GITHUB_TOKEN_URL: &'static str = "https://github.com/login/oauth/access_token";
 /// Default Client ID providing a value in development environments only.
 ///
 /// See https://developer.github.com/apps
@@ -33,9 +33,9 @@ pub const DEV_GITHUB_WEBHOOK_SECRET: &'static str = "58d4afaf5e5617ab0f8c39e5056
 #[serde(default)]
 pub struct GitHubCfg {
     /// URL to GitHub API
-    pub url: String,
+    pub api_url: String,
     /// URL to GitHub Web
-    pub web_url: String,
+    pub token_url: String,
     /// Path to GitHub App private key
     pub app_private_key: String,
     /// Client identifier used for GitHub API requests
@@ -51,8 +51,8 @@ pub struct GitHubCfg {
 impl Default for GitHubCfg {
     fn default() -> Self {
         GitHubCfg {
-            url: DEFAULT_GITHUB_URL.to_string(),
-            web_url: DEFAULT_GITHUB_WEB_URL.to_string(),
+            api_url: DEFAULT_GITHUB_API_URL.to_string(),
+            token_url: DEFAULT_GITHUB_TOKEN_URL.to_string(),
             app_private_key: "/src/.secrets/builder-github-app.pem".to_string(),
             client_id: DEV_GITHUB_CLIENT_ID.to_string(),
             client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -21,8 +21,8 @@ cat <<EOT > /hab/svc/builder-api/user.toml
 log_level = "debug"
 [github]
 enabled = true
-url = "$GITHUB_API_URL"
-web_url = "$GITHUB_WEB_URL"
+api_url = "$GITHUB_API_URL"
+token_url = "$GITHUB_TOKEN_URL"
 client_id = "$GITHUB_CLIENT_ID"
 client_secret = "$GITHUB_CLIENT_SECRET"
 app_id = $GITHUB_APP_ID
@@ -35,8 +35,7 @@ log_level = "debug"
 app_url = "http://${APP_HOSTNAME}:9636"
 
 [github]
-url = "$GITHUB_API_URL"
-web_url = "$GITHUB_WEB_URL"
+api_url = "$GITHUB_API_URL"
 client_secret = "$GITHUB_CLIENT_SECRET"
 app_id = $GITHUB_APP_ID
 app_url = "${GITHUB_APP_URL}"
@@ -44,7 +43,7 @@ app_url = "${GITHUB_APP_URL}"
 [oauth]
 provider       = "github"
 client_id      = "$GITHUB_CLIENT_ID"
-authorize_url  = "https://github.com/login/oauth/authorize"
+authorize_url  = "$GITHUB_AUTHORIZE_URL"
 EOT
 
 mkdir -p /hab/svc/builder-jobsrv
@@ -351,9 +350,6 @@ airlock_enabled = false
 data_path = "/hab/svc/builder-worker/data"
 bldr_url = "http://localhost:9636"
 [github]
-url = "$GITHUB_API_URL"
-web_url = "$GITHUB_WEB_URL"
-client_id = "$GITHUB_CLIENT_ID"
-client_secret = "$GITHUB_CLIENT_SECRET"
+api_url = "$GITHUB_API_URL"
 app_id = $GITHUB_APP_ID
 EOT


### PR DESCRIPTION
This change does cleanup of the auth configs in readiness for the on-prem builder:
* Rename github "url" configuration to "api_url" (to be consistent across GH / Bitbucket)
* Rename "web_url" to "token_url" to be consistent with OAuth terminology
* Allow token_url to be fully configurable like the API and Authorize URLs
* Add github app URL to a couple of places that were missing it
* Remove deprecated config (admin_team) 
* Add a check to make sure we have exactly one auth config for builder api
* Fix up some unit tests that were failing 
* Other misc cleanup

After this change is merged, builder devs will need to update their .secrets/habitat-env file. The acceptance and prod env will also need appropriate updates to their configs.
 
Signed-off-by: Salim Alam <salam@chef.io>

![tenor-170289869](https://user-images.githubusercontent.com/13542112/37734745-44e73f4c-2d09-11e8-8b16-47303cf9d777.gif)
