### PR TITLE
Restore app_url

### DIFF
--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -1,3 +1,4 @@
+app_url                 = "https://bldr.habitat.sh"
 cookie_domain           = ""
 demo_app_url            = "https://www.habitat.sh/demo/build-system/steps/1/"
 docs_url                = "https://www.habitat.sh/docs"


### PR DESCRIPTION
This default config entry was removed by mistake in a922fbb.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://media1.giphy.com/media/oSsJhlQLkb21O/200w.gif)