### PR TITLE
Deprecate hab bldr encrypt

### DIFF
--- a/test/builder-api/src/keys.js
+++ b/test/builder-api/src/keys.js
@@ -174,17 +174,4 @@ describe('Keys API', function() {
         });
     });
   });
-
-  describe('Builder keys', function() {
-    it('can retrieve the latest key', function(done) {
-      this.skip(); // don't run in master until passing
-      request.get('/depot/builder/keys/latest')
-        .expect(200)
-        .end(function(err, res) {
-          expect(res.text).to.include('BOX-PUB-1');
-          expect(res.text.match(/bldr-[0-9]{14}/)).to.not.be.null;
-          done(err);
-        });
-    });
-  });
 });


### PR DESCRIPTION
The server side counterpart to https://github.com/habitat-sh/habitat/pull/4811
Removes un-needed API.

Closes: #294

Signed-off-by: Salim Alam <salam@chef.io>