### PR TITLE
fix sed for linux

### DIFF
--- a/tools/ssh_helpers/update-habitat-ssh
+++ b/tools/ssh_helpers/update-habitat-ssh
@@ -16,7 +16,7 @@ stop_pattern="###HABITAT-${environment}-STOP###"
 script_dir=$(dirname "$0")
 
 # Remove the entries from the config file
-sed -i '.habitat_backup' '/'"${start_pattern}"'/,/'"${stop_pattern}"'/d' ~/.ssh/config
+sed -i'.habitat_backup' '/'"${start_pattern}"'/,/'"${stop_pattern}"'/d' ~/.ssh/config
 
 echo "" >> ~/.ssh/config
 echo "${start_pattern}" >> ~/.ssh/config


### PR DESCRIPTION
Sed in osx allows a space after the `-i` flag but the unix version doesn't.

![](https://media3.giphy.com/media/1wPShHVsCKCAIk9UlY/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>