### PR TITLE
Make `sed -i` work on both linux and Mac OS

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -58,8 +58,8 @@ resource "null_resource" "api_provision" {
   provisioner "remote-exec" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
-      "sudo sed -i \"$ a tags: env:${var.env}, role:api\" /etc/dd-agent/datadog.conf",
-      "sudo sed -i \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a tags: env:${var.env}, role:api\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
     ]
   }
 
@@ -173,8 +173,8 @@ resource "null_resource" "datastore_provision" {
   provisioner "remote-exec" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
-      "sudo sed -i \"$ a tags: env:${var.env}, role:datastore\" /etc/dd-agent/datadog.conf",
-      "sudo sed -i \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a tags: env:${var.env}, role:datastore\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
     ]
   }
 
@@ -290,9 +290,9 @@ resource "aws_instance" "jobsrv" {
   provisioner "remote-exec" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
-      "sudo sed -i \"$ a dogstreams: /tmp/builder-scheduler.log:/etc/dd-agent/sch_log_parser.py:my_log_parser\" /etc/dd-agent/datadog.conf",
-      "sudo sed -i \"$ a tags: env:${var.env}, role:jobsrv\" /etc/dd-agent/datadog.conf",
-      "sudo sed -i \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a dogstreams: /tmp/builder-scheduler.log:/etc/dd-agent/sch_log_parser.py:my_log_parser\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a tags: env:${var.env}, role:jobsrv\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
       "sudo cp /tmp/sch_log_parser.py /etc/dd-agent/sch_log_parser.py",
       "sudo cp /tmp/builder.logrotate /etc/logrotate.d/builder",
       "sudo /etc/init.d/datadog-agent start"
@@ -385,8 +385,8 @@ resource "aws_instance" "originsrv" {
   provisioner "remote-exec" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
-      "sudo sed -i \"$ a tags: env:${var.env}, role:originsrv\" /etc/dd-agent/datadog.conf",
-      "sudo sed -i \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a tags: env:${var.env}, role:originsrv\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
       "sudo /etc/init.d/datadog-agent start"
     ]
   }
@@ -476,8 +476,8 @@ resource "aws_instance" "router" {
   provisioner "remote-exec" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
-      "sudo sed -i \"$ a tags: env:${var.env}, role:router\" /etc/dd-agent/datadog.conf",
-      "sudo sed -i \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a tags: env:${var.env}, role:router\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
       "sudo /etc/init.d/datadog-agent start"
     ]
   }
@@ -568,8 +568,8 @@ resource "aws_instance" "sessionsrv" {
   provisioner "remote-exec" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
-      "sudo sed -i \"$ a tags: env:${var.env}, role:sessionsrv\" /etc/dd-agent/datadog.conf",
-      "sudo sed -i \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a tags: env:${var.env}, role:sessionsrv\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
       "sudo /etc/init.d/datadog-agent start"
     ]
   }
@@ -666,8 +666,8 @@ resource "aws_instance" "worker" {
   provisioner "remote-exec" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
-      "sudo sed -i \"$ a tags: env:${var.env}, role:worker\" /etc/dd-agent/datadog.conf",
-      "sudo sed -i \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a tags: env:${var.env}, role:worker\" /etc/dd-agent/datadog.conf",
+      "sudo sed -i'' \"$ a use_dogstatsd: yes\" /etc/dd-agent/datadog.conf",
       "sudo cp /tmp/builder.logrotate /etc/logrotate.d/builder",
       "sudo /etc/init.d/datadog-agent stop"
     ]


### PR DESCRIPTION
Because the Mac OS version of sed's -i option requires an argument but linux's
does not, the way to get inline ovewrite behavior on both is to supply a zero-
length argument with no spaces after the -i.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>