### PR TITLE
Remove docker pinnings and add sbin to worker path

### DIFF
--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -5,8 +5,8 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_deps=(habitat/airlock core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
-  core/libarchive core/zlib core/hab-studio core/hab-pkg-export-docker/0.54.0/20180221020412
-  core/docker/17.09.0/20171001205930 core/curl)
+  core/libarchive core/zlib core/hab-studio core/hab-pkg-export-docker
+  core/docker core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
 pkg_binds=(


### PR DESCRIPTION
Yes, this will break some of the isolation in the worker environment but the alternative is building app armor as a hab package.

Signed-off-by: Elliott Davis <elliott@excellent.io>