### PR TITLE
[CODEOWNERS] Add myself to a few components.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,11 +2,12 @@
 components/bitbucket-api-client @raskchanky
 components/builder-* @chefsalim @raskchanky @reset @elliott-davis
 components/builder-web @cnunciato @raskchanky @mgamini @elliott-davis
+components/builder-worker @chefsalim @raskchanky @reset @elliott-davis @fnichol
 components/github-api-client @raskchanky
 components/net @raskchanky
 components/oauth-common @raskchanky
 components/op @raskchanky
 components/segment-api-client @raskchanky
 support @fnichol @raskchanky @baumanj @elliott-davis
-tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky
+tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol
 .studiorc @elliott-davis @raskchanky


### PR DESCRIPTION
As I'm familiar with the worker code, I figured I should add myself to
start with. Since I'm babystepping my way in, I had to duplicate the
`builder-*` pattern to make a `builder-worker` entry like we did with
`builder-web`.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>