### PR TITLE
Support optional on-prem analytics

### DIFF
--- a/components/builder-api-proxy/config/habitat.conf.js
+++ b/components/builder-api-proxy/config/habitat.conf.js
@@ -1,4 +1,6 @@
 habitatConfig({
+    company_id: "{{cfg.analytics.company_id}}",
+    company_name: "{{cfg.analytics.company_name}}",
     cookie_domain: "{{cfg.cookie_domain}}",
     demo_app_url: "{{cfg.demo_app_url}}",
     docs_url: "{{cfg.docs_url}}",

--- a/components/builder-api-proxy/config/index.html
+++ b/components/builder-api-proxy/config/index.html
@@ -22,22 +22,21 @@
 
     <link rel="stylesheet" href="/assets/app-{{ pkg.release }}.css">
     <base href="/">
-    {{#if cfg.hosted}}
-      <!-- Heap -->
-      <script type="text/javascript">
-        window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
-        heap.load("460996886");
-      </script>
-    {{/if}}
   </head>
   <body>
+    {{#if cfg.analytics.enabled}}
+      <!-- Segment -->
+      <script>
+        !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+        analytics.load("{{ cfg.analytics.write_key }}");
+        analytics.page();
+        }}();
+      </script>
+    {{/if}}
     {{#if cfg.hosted}}
       <!-- Google Analytics -->
       <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5VR24H" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5VR24H');</script>
-
-      <!-- Segment -->
-      <script type="text/javascript">!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";analytics.load("NAwVPW04CeESMW3vtyqjJZmVMNBSQ1K1");analytics.page();}}();</script>
 
       <!-- Statuspage -->
       <script src="//cdn.statuspage.io/se-v2.js"></script>

--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -14,6 +14,12 @@ tutorials_url           = "https://www.habitat.sh/learn"
 use_gravatar            = true
 www_url                 = "https://www.habitat.sh"
 
+[analytics]
+company_id          = ""
+company_name        = ""
+enabled             = false
+write_key           = ""
+
 [github]
 app_id       = 5565
 app_url      = "https://github.com/apps/habitat-builder"

--- a/components/builder-web/app/actions/users.ts
+++ b/components/builder-web/app/actions/users.ts
@@ -16,6 +16,7 @@ import { authenticate, removeSession, loadOAuthProvider, loadBldrSessionState, l
 import { addNotification, SUCCESS, DANGER } from './notifications';
 import { BuilderApiClient } from '../client/builder-api';
 import { Browser } from '../browser';
+import config from '../config';
 
 export const CLEAR_ACCESS_TOKENS = 'CLEAR_ACCESS_TOKENS';
 export const CLEAR_NEW_ACCESS_TOKEN = 'CLEAR_NEW_ACCESS_TOKEN';
@@ -179,10 +180,16 @@ export function setDeletingAccessToken(payload) {
 }
 
 function notifySegment(data: any) {
-  const segment = window['analytics'];
-
-  if (segment && typeof segment.identify === 'function') {
-    segment.identify(data.id, { email: data.email, name: data.name });
+  const analytics = window['analytics'];
+  if (analytics && typeof analytics.identify === 'function') {
+    analytics.identify(data.id, {
+      email: data.email,
+      name: data.name,
+      company: {
+        id: config.company_id,
+        name: config.company_name
+      }
+    });
   }
 }
 

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -1,5 +1,9 @@
 habitatConfig({
 
+    // Company information, for analytics (optional)
+    company_id: "builder-dev",
+    company_name: "Habitat Builder Dev",
+
     // Cookie domain (optional; e.g., 'bldr.company.co')
     cookie_domain: "",
 

--- a/components/builder-web/index.html
+++ b/components/builder-web/index.html
@@ -1,5 +1,11 @@
 <!doctype html>
 <html prefix="og: http://ogp.me/ns#">
+
+  <!--
+    This page exists for development purposes only, so nothing you do here will affect the builder-api-proxy package.
+    That package's templated index.html file can be found at ../builder-api-proxy/config/index.html.
+  -->
+
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -20,6 +26,15 @@
     <base href="/">
   </head>
   <body>
+
+    <!-- Segment -->
+    <script>
+      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+      analytics.load("C1Qtb9N2MZ9YsJ9aoGP8Waw4hqRxoEXu"); // This key is for non-production use only.
+      analytics.page();
+      }}();
+    </script>
+
     <hab-app>
     <script>
         window.Habitat = { config: {} };


### PR DESCRIPTION
This change adds a new configuration section to allow on-prem customers to share usage data with us via Heap Analytics.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://media0.giphy.com/media/j06em2TZRnZ5u/200w.gif)