### PR TITLE
Don’t constrain width on the sign-in page

### DIFF
--- a/components/builder-web/app/sign-in-page/_sign-in-page.component.scss
+++ b/components/builder-web/app/sign-in-page/_sign-in-page.component.scss
@@ -40,6 +40,7 @@
 
     .content {
       padding-right: 0;
+      max-width: none;
     }
   }
 


### PR DESCRIPTION
A recent change modified the width of `content` elements to constrain it to 3/4 width on the desktop, but we don’t want to apply that constraint on the sign-in page. This fixes it.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/yYSSBtDgbbRzq/200w.gif)