### PR TITLE
Use profile.name instead of username

### DIFF
--- a/components/builder-web/app/origin/origin-create-page/origin-create-page.component.ts
+++ b/components/builder-web/app/origin/origin-create-page/origin-create-page.component.ts
@@ -66,7 +66,7 @@ export class OriginCreatePageComponent implements AfterViewInit {
   }
 
   get username() {
-    return this.store.getState().users.current.username;
+    return this.store.getState().users.current.profile.name;
   }
 
   createOrigin(origin) {

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -90,7 +90,7 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
   }
 
   canDelete(member) {
-    return this.store.getState().users.current.username !== member;
+    return this.store.getState().users.current.profile.name !== member;
   }
 
   delete(member) {

--- a/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.ts
+++ b/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.ts
@@ -70,7 +70,7 @@ export class DockerExportSettingsComponent implements OnChanges, OnDestroy {
   }
 
   get username() {
-    return this.store.getState().users.current.username;
+    return this.store.getState().users.current.profile.name;
   }
 
   get valid() {


### PR DESCRIPTION
As part of the detachment from GitHub auth, we changed source of the information we privilege about the signed-in user. (It had been GitHub, and is now the user’s Builder profile.) This fixes a few places where that change was overlooked.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/sS8YbjrTzu4KI/200w.gif)