### PR TITLE
Check for jobsrv_enabled when syncing packages

### DIFF
--- a/components/builder-originsrv/habitat/default.toml
+++ b/components/builder-originsrv/habitat/default.toml
@@ -1,4 +1,5 @@
 log_level = "info"
+jobsrv_enabled = true
 
 [app]
 shards = []

--- a/components/builder-originsrv/src/config.rs
+++ b/components/builder-originsrv/src/config.rs
@@ -24,6 +24,8 @@ use error::SrvError;
 pub struct Config {
     pub app: AppCfg,
     pub datastore: DataStoreCfg,
+    /// Whether jobsrv is present or not
+    pub jobsrv_enabled: bool,
 }
 
 impl Default for Config {
@@ -33,6 +35,7 @@ impl Default for Config {
         Config {
             app: AppCfg::default(),
             datastore: datastore,
+            jobsrv_enabled: true,
         }
     }
 }

--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -99,7 +99,7 @@ impl DataStore {
         Ok(())
     }
 
-    pub fn register_async_events(&self) {
+    pub fn register_async_events(&self, jobsrv_enabled: bool) {
         self.async.register(
             "sync_invitations".to_string(),
             sync_invitations,
@@ -108,10 +108,13 @@ impl DataStore {
             "sync_origins".to_string(),
             sync_origins,
         );
-        self.async.register(
-            "sync_packages".to_string(),
-            sync_packages,
-        );
+
+        if jobsrv_enabled {
+            self.async.register(
+                "sync_packages".to_string(),
+                sync_packages,
+            );
+        }
     }
 
     pub fn start_async(&self) {

--- a/components/builder-originsrv/src/server/mod.rs
+++ b/components/builder-originsrv/src/server/mod.rs
@@ -175,8 +175,9 @@ impl Dispatcher for OriginSrv {
         config: Self::Config,
         router_pipe: Arc<String>,
     ) -> SrvResult<<Self::State as AppState>::InitState> {
+        let jobsrv_enabled = config.jobsrv_enabled;
         let state = ServerState::new(config, router_pipe)?;
-        state.datastore.register_async_events();
+        state.datastore.register_async_events(jobsrv_enabled);
         state.datastore.start_async();
         Ok(state)
     }


### PR DESCRIPTION
This change adds a jobsrv_enabled config value to sessionsrv, so that we don't attempt to sync package metadata with the jobsrv if it is not present.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-96440966](https://user-images.githubusercontent.com/13542112/38054812-dcbbcaa8-328c-11e8-8a73-717a068ab211.gif)
