### PR TITLE
Rename error messages to be unique to origin secrets

### DIFF
--- a/components/builder-originsrv/src/server/handlers.rs
+++ b/components/builder-originsrv/src/server/handlers.rs
@@ -1250,11 +1250,11 @@ pub fn origin_secret_create(
         Ok(ref os) => conn.route_reply(req, os)?,
         Err(SrvError::OriginSecretCreate(ref db))
             if db.code().is_some() && *db.code().unwrap() == postgres::error::UNIQUE_VIOLATION => {
-            let err = NetError::new(ErrCode::ENTITY_CONFLICT, "vt:origin-create:1");
+            let err = NetError::new(ErrCode::ENTITY_CONFLICT, "vt:origin-secret-create:1");
             conn.route_reply(req, &*err)?;
         }
         Err(e) => {
-            let err = NetError::new(ErrCode::DATA_STORE, "vt:origin-create:2");
+            let err = NetError::new(ErrCode::DATA_STORE, "vt:origin-secret-create:2");
             error!("{}, {}", err, e);
             conn.route_reply(req, &*err)?;
         }


### PR DESCRIPTION
Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/3o7qDKdHAqamtq0uBi/200w.gif)