### PR TITLE
Update bldr job status functionality

### DIFF
--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -84,8 +84,8 @@ impl HttpGateway for ApiSrv {
 
         // Allow one and only one auth config
         // TODO: Update configs so that structurally only a single auth config is possible
-        if ((config.github.is_none() && config.bitbucket.is_none()) ||
-                (config.github.is_some() && config.bitbucket.is_some()))
+        if (config.github.is_none() && config.bitbucket.is_none()) ||
+            (config.github.is_some() && config.bitbucket.is_some())
         {
             panic!("Must have one and only one auth config (github or bitbucket)");
         }

--- a/components/builder-jobsrv/src/migrations/2018-03-28-021112_job_group_origin_v2/up.sql
+++ b/components/builder-jobsrv/src/migrations/2018-03-28-021112_job_group_origin_v2/up.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION get_job_groups_for_origin_v2 (
+  op_origin text,
+  op_limit integer
+) RETURNS SETOF groups AS $$
+  SELECT *
+  FROM groups
+  WHERE project_name LIKE (op_origin || '/%')
+  ORDER BY created_at DESC
+  LIMIT op_limit
+$$ LANGUAGE SQL STABLE;

--- a/components/builder-protocol/protocols/jobsrv.proto
+++ b/components/builder-protocol/protocols/jobsrv.proto
@@ -157,10 +157,12 @@ message JobGroupCancel {
 
 message JobGroupGet {
   optional uint64 group_id = 1;
+  optional bool include_projects = 2;
 }
 
 message JobGroupOriginGet {
   optional string origin = 1;
+  optional uint32 limit = 2;
 }
 
 message JobGroupOriginResponse {

--- a/components/libbuild-protocols.rs
+++ b/components/libbuild-protocols.rs
@@ -2,7 +2,7 @@ mod protocols {
     extern crate pkg_config;
     extern crate protoc;
     extern crate protoc_rust;
-    
+
     use std::fs;
 
     pub fn generate_protocols() {
@@ -15,7 +15,9 @@ mod protocols {
                 .collect::<Vec<&str>>()
                 .as_slice(),
             includes: &["protocols"],
-        }).expect("protoc is not available on PATH");
+        }).expect(
+            "Failed to run protoc, please check that it is available on your PATH, and that the src/message folder is writable",
+        );
     }
 
     fn protocol_files() -> Vec<String> {

--- a/docs/Migrations.md
+++ b/docs/Migrations.md
@@ -2,6 +2,12 @@
 
 All builder migrations are run with [Diesel](http://diesel.rs). This document describes how to create and manage those migrations.
 
+## Install the Diesel client
+
+```
+cargo install diesel_cli --no-default-features --features postgres
+```
+
 ## Generating new migrations
 
 Every time you need to make a change to the Builder schema you will be required to generate a new migration


### PR DESCRIPTION
This is the services update for https://github.com/habitat-sh/habitat/pull/4841

Getting the schedule status is now much more lightweight. By default, we only query the last most recent 10 job groups when querying by origin. Also we only return detailed project information when needed instead of always querying and returning it to the caller.
 
Signed-off-by: Salim Alam <salam@chef.io>

![tenor-2406262](https://user-images.githubusercontent.com/13542112/38118801-1591984a-3372-11e8-9f2f-e1d7359a5b09.gif)
