### PR TITLE
Strip quotes from serde strings

### DIFF
--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -257,20 +257,22 @@ impl OAuthClient for GitHubClient {
         )?;
 
         // Gitlab API has username instead of login
+        // TODO: Convert this to use a structured deserialization and
+        // cleaner distinction between the GitHub and GitLab APIs
         let username = if user["login"].is_string() {
-            user["login"].to_string()
+            user["login"].as_str().unwrap().to_string()
         } else {
             assert!(user["username"].is_string());
-            user["username"].to_string()
+            user["username"].as_str().unwrap().to_string()
         };
 
         let email = if user["email"].is_string() {
-            Some(user["email"].to_string())
+            Some(user["email"].as_str().unwrap().to_string())
         } else {
             None
         };
 
-        let id = user["id"].to_string();
+        let id = user["id"].as_u64().unwrap().to_string();
 
         debug!("OAuthUser: {}, {}, {:?}", id, username, email);
 


### PR DESCRIPTION
The serde Value to_string function does not strip quotes from strings.  We need to do the as_... functions to get the quotation marks to get stripped.  This fixes a regression where the logged in user is not correctly recognized.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-217342806](https://user-images.githubusercontent.com/13542112/38222351-0fbea60e-3699-11e8-82cb-a49f9b2f1ca5.gif)
