### PR TITLE
Make nginx body size configurable

### DIFF
--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -120,7 +120,7 @@ http {
     }
 
     location /v1/depot {
-      client_max_body_size 1024m;
+      client_max_body_size {{cfg.nginx.max_body_size}};
       proxy_cache my_cache;
       proxy_pass http://backend;
     }

--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -36,6 +36,7 @@ signup_url     = "https://github.com/join"
 worker_connections   = 8000
 worker_processes     = "auto"
 worker_rlimit_nofile = 8192
+max_body_size        = "1024m"
 
 [http]
 keepalive_timeout = "20s"


### PR DESCRIPTION
We currently restrict the size of http client body to 1GB in the builder-api-proxy, with no way to make it configurable.  This change adds a config option for scenarios where we need to change the max size (for example, larger package upload sizes)

Signed-off-by: Salim Alam <salam@chef.io>

