### PR TITLE
Fix regression in use of JobGroupGet message

### DIFF
--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -354,6 +354,7 @@ pub fn job_group_cancel(req: &mut Request) -> IronResult<Response> {
 
     let mut jgg = JobGroupGet::new();
     jgg.set_group_id(group_id);
+    jgg.set_include_projects(true);
 
     let group = match route_message::<JobGroupGet, JobGroup>(req, &jgg) {
         Ok(group) => group,

--- a/components/builder-http-gateway/src/http/helpers.rs
+++ b/components/builder-http-gateway/src/http/helpers.rs
@@ -356,6 +356,7 @@ pub fn promote_or_demote_job_group(
 ) -> NetResult<NetOk> {
     let mut group_get = JobGroupGet::new();
     group_get.set_group_id(group_id);
+    group_get.set_include_projects(true);
     let group = route_message::<JobGroupGet, JobGroup>(req, &group_get)?;
 
     // This only makes sense if the group is complete. If the group isn't complete, return now and

--- a/components/builder-jobsrv/src/server/handlers.rs
+++ b/components/builder-jobsrv/src/server/handlers.rs
@@ -223,6 +223,7 @@ pub fn job_group_cancel(
     // Get the job group
     let mut jgc = jobsrv::JobGroupGet::new();
     jgc.set_group_id(msg.get_group_id());
+    jgc.set_include_projects(true);
 
     let group = match state.datastore.get_job_group(&jgc) {
         Ok(group_opt) => {

--- a/components/builder-jobsrv/src/server/scheduler.rs
+++ b/components/builder-jobsrv/src/server/scheduler.rs
@@ -430,6 +430,7 @@ impl ScheduleMgr {
     fn get_group(&mut self, group_id: u64) -> Result<jobsrv::JobGroup> {
         let mut msg: jobsrv::JobGroupGet = jobsrv::JobGroupGet::new();
         msg.set_group_id(group_id);
+        msg.set_include_projects(true);
 
         match self.datastore.get_job_group(&msg) {
             Ok(group_opt) => {


### PR DESCRIPTION
This fixes a regression from an earlier commit (https://github.com/habitat-sh/builder/commit/048bb282bf173f1d55cf3a68a1cb3b9458c6f0ea) - reverse dependency builds will not work correctly if the include_projects field is not set.

Signed-off-by: Salim Alam <salam@chef.io>