### PR TITLE
Temporarily remove baumanj

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,6 @@ components/net @raskchanky
 components/oauth-common @raskchanky
 components/op @raskchanky
 components/segment-api-client @raskchanky
-support @fnichol @raskchanky @baumanj @elliott-davis
-tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol
+support @fnichol @raskchanky @elliott-davis
+tools @chefsalim @christophermaier @eeyun @raskchanky @fnichol
 .studiorc @elliott-davis @raskchanky


### PR DESCRIPTION
I won't be doing any habitat PRs for a bit, so I don't want authors waiting around for my response

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>