### PR TITLE
Re-start worker on cancel

### DIFF
--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -152,7 +152,12 @@ impl Server {
             let reply = self.runner_cli.recv_ack()?;
             self.fe_sock.send(reply, 0)?;
         }
-        Ok(())
+
+        // Currently, there's no good way to cancel a studio build that is in progress.
+        // Terminate the worker process (it will get restarted by the supervisor) in
+        // order to handle the case where a build is hung.
+        warn!("Exiting worker (cancel received)");
+        ::std::process::exit(0);
     }
 
     fn reject_job(&mut self) -> Result<()> {


### PR DESCRIPTION
Currently, there is no good way to cancel a studio build in progress.  The build worker can get into a situation where a studio build is hung (for example, a custom do_build can drop into a debugger with some Python builds, etc).  Exiting the process and letting the supervisor re-start the worker seems to be the only workable solution atm.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-19705610](https://user-images.githubusercontent.com/13542112/39502215-d6754b2c-4d73-11e8-8498-2ae54e871f42.gif)
