### PR TITLE
Add native TLS and IPv6 support to builder-api-proxy

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -64,11 +64,34 @@ http {
     server 127.0.0.1:{{bind.http.first.cfg.port}};
   }
 
+  {{~#if cfg.server.listen_tls}}
+  server {
+    listen       *:{{cfg.server.listen_port}};
+    listen       [::]:{{cfg.server.listen_port}};
+    server_name  {{sys.hostname}};
+    return       308 https://$host$request_uri;
+  }
+  {{~/if}}
+
   server {
     index /index.html;
-    listen       *:{{cfg.http.listen_port}};
     server_name  {{sys.hostname}};
     root         {{pkg.path}}/app;
+
+    {{~#if cfg.server.listen_tls}}
+    listen                    *:{{cfg.server.listen_tls_port}} ssl;
+    listen                    [::]:{{cfg.server.listen_tls_port}} ssl;
+    ssl_certificate           {{pkg.svc_files_path}}/{{cfg.server.cert_file}};
+    ssl_certificate_key       {{pkg.svc_files_path}}/{{cfg.server.cert_key_file}};
+    ssl_protocols             {{cfg.server.ssl_protocols}};
+    ssl_ciphers               {{cfg.server.ssl_ciphers}};
+    ssl_prefer_server_ciphers {{cfg.server.ssl_prefer_server_ciphers}};
+    ssl_session_cache         {{cfg.server.ssl_session_cache}};
+    ssl_session_timeout       {{cfg.server.ssl_session_timeout}};
+    {{~else}}
+    listen                    *:{{cfg.server.listen_port}};
+    listen                    [::]:{{cfg.server.listen_port}};
+    {{~/if}}
 
     if ($http_x_forwarded_proto = "http") {
       rewrite ^(.*)$ https://$host$1 permanent;

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -40,7 +40,18 @@ max_body_size        = "1024m"
 
 [http]
 keepalive_timeout = "20s"
-listen_port       = 80
 sendfile          = "on"
 tcp_nopush        = "on"
 tcp_nodelay       = "on"
+
+[server]
+listen_port               = 80
+listen_tls_port           = 443
+listen_tls                = false
+cert_file                 = "ssl-certificate.crt"
+cert_key_file             = "ssl-certificate.key"
+ssl_protocols             = "TLSv1 TLSv1.1 TLSv1.2"
+ssl_ciphers               = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
+ssl_session_cache         = "shared:SSL:10m"
+ssl_session_timeout       = "10m"
+ssl_prefer_server_ciphers = "on"

--- a/components/builder-api-proxy/habitat/plan.sh
+++ b/components/builder-api-proxy/habitat/plan.sh
@@ -16,13 +16,14 @@ pkg_build_deps=(
 pkg_svc_user="root"
 pkg_svc_run="nginx -c ${pkg_svc_config_path}/nginx.conf"
 pkg_exports=(
-  [port]=http.listen_port
+  [port]=server.listen_port
+  [ssl-port]=server.listen_tls_port
   [url]=app_url
 )
 pkg_binds=(
   [http]="port"
 )
-pkg_exposes=(port)
+pkg_exposes=(port ssl-port)
 
 pkg_version() {
   # TED: After migrating the builder repo we needed to add to


### PR DESCRIPTION
This change enables builder-api-proxy to configure SSL endpoints natively.  This is useful in an on-premise deployment of Builder, where there is no external reverse proxy available.  In order to use this feature, the listen_tls flag needs to be set to true in the config, and the SSL cert and key files need to be uploaded to the builder-api-proxy service via `hab file upload`.  Also, nginx is configured to listen on both IPv4 and IPv6 endpoints.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-244613887](https://user-images.githubusercontent.com/13542112/39555300-1a37a9f4-4e2d-11e8-9b76-9e8f6fa89e44.gif)
