### PR TITLE
Use OpenID for authenticating against GitLab

### DIFF
--- a/components/builder-protocol/protocols/sessionsrv.proto
+++ b/components/builder-protocol/protocols/sessionsrv.proto
@@ -6,6 +6,7 @@ enum OAuthProvider {
   None = 1;
   Bitbucket = 2;
   AzureAD = 3;
+  GitLab = 4;
 }
 
 message Account {

--- a/components/builder-protocol/src/sessionsrv.rs
+++ b/components/builder-protocol/src/sessionsrv.rs
@@ -53,6 +53,7 @@ impl FromStr for OAuthProvider {
         match value.to_lowercase().as_ref() {
             "azure-ad" => Ok(OAuthProvider::AzureAD),
             "github" => Ok(OAuthProvider::GitHub),
+            "gitlab" => Ok(OAuthProvider::GitLab),
             "bitbucket" => Ok(OAuthProvider::Bitbucket),
             "none" => Ok(OAuthProvider::None),
             "" => Ok(OAuthProvider::None),

--- a/components/builder-web/app/oauth-providers/index.ts
+++ b/components/builder-web/app/oauth-providers/index.ts
@@ -119,7 +119,8 @@ class GitLabProvider extends OAuthProvider {
         client_id: clientID,
         redirect_uri: redirectUrl,
         response_type: 'code',
-        state: state
+        state: state,
+        scope: 'openid'
       }
     );
   }

--- a/components/oauth-client/src/gitlab.rs
+++ b/components/oauth-client/src/gitlab.rs
@@ -30,8 +30,8 @@ struct AuthOk {
 
 #[derive(Deserialize)]
 struct User {
-    pub id: u32,
-    pub username: String,
+    pub sub: String,
+    pub nickname: String,
     pub email: Option<String>,
 }
 
@@ -59,8 +59,8 @@ impl GitLab {
             };
 
             Ok(OAuth2User {
-                id: user.id.to_string(),
-                username: user.username,
+                id: user.sub,
+                username: user.nickname,
                 email: user.email,
             })
         } else {


### PR DESCRIPTION
Authenticating against GitLab was failing because the scope was missing in the request, and it was missing in the protocol definition.

This PR adds the missing pieces and switches to using OpenID for authenticating with GitLab. I've tested this against gitlab.com and a private GitLab EE instance.

These are the URLs that need to be configured:
```
OAUTH_USERINFO_URL="https://gitlab.com/oauth/userinfo"
OAUTH_AUTHORIZE_URL="https://gitlab.com/oauth/authorize"
OAUTH_TOKEN_URL="https://gitlab.com/oauth/token"
```

I did not find a place to document this, so that is not included in this PR.