### PR TITLE
Add support for fetching packages from an upstream depot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
+ "habitat_depot_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat_net 0.0.0",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1096,6 +1097,7 @@ dependencies = [
  "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
+ "habitat_depot_client 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "habitat_net 0.0.0",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1114,7 +1116,7 @@ dependencies = [
  "serde 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2264,6 +2266,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2631,14 +2641,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "2.2.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3367,6 +3377,7 @@ dependencies = [
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d2f806b0fcdabd98acd380dc8daef485e22bcb7cddc811d1337967f2528cf5"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "241faa9a8ca28a03cbbb9815a5d085f271d4c0168a19181f106aa93240c22ddb"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
 "checksum route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3255338088df8146ba63d60a9b8e3556f1146ce2973bc05a75181a42ce2256"
@@ -3410,7 +3421,7 @@ dependencies = [
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
 "checksum tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e"
-"checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
+"checksum tempfile 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8cddbd26c5686ece823b507f304c8f188daef548b4cb753512d929ce478a093c"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/components/builder-core/src/access_token.rs
+++ b/components/builder-core/src/access_token.rs
@@ -21,6 +21,7 @@ use integrations::{decrypt, encrypt, validate};
 use protocol::{message, sessionsrv};
 
 pub const BUILDER_ACCOUNT_ID: u64 = 0;
+pub const BUILDER_ACCOUNT_NAME: &'static str = "BUILDER";
 
 // Access token prefix rules:
 // MUST CONTAIN AN *INVALID* base-64 character

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -12,6 +12,7 @@ bodyparser = "*"
 env_logger = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
 builder-http-gateway = { path = "../builder-http-gateway" }
+habitat_depot_client = { git = "https://github.com/habitat-sh/habitat.git" }
 hyper = "0.10"
 iron = "*"
 iron-test = "*"

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -49,6 +49,9 @@ pub struct Config {
     pub targets: Vec<PackageTarget>,
     /// Whether jobsrv is present or not
     pub jobsrv_enabled: bool,
+    /// Upstream depot to pull packages from if someone tries to install from this depot and they
+    /// aren't present. This is optional because e.g. public Builder doesn't have an upstream.
+    pub upstream_depot: Option<String>,
 }
 
 impl ConfigFile for Config {
@@ -72,6 +75,7 @@ impl Default for Config {
                 PackageTarget::new(Platform::Windows, Architecture::X86_64),
             ],
             jobsrv_enabled: true,
+            upstream_depot: None,
         }
     }
 }
@@ -131,6 +135,7 @@ mod tests {
         log_dir = "/hab/svc/hab-depot/var/log"
         key_dir = "/hab/svc/hab-depot/files"
         jobsrv_enabled = false
+        upstream_depot = "http://example.com"
 
         [[targets]]
         platform = "linux"
@@ -157,6 +162,10 @@ mod tests {
         assert_eq!(config.log_dir, PathBuf::from("/hab/svc/hab-depot/var/log"));
         assert_eq!(config.key_dir, PathBuf::from("/hab/svc/hab-depot/files"));
         assert_eq!(config.jobsrv_enabled, false);
+        assert_eq!(
+            config.upstream_depot,
+            Some(String::from("http://example.com"))
+        );
         assert_eq!(&format!("{}", config.http.listen), "127.0.0.1");
         assert_eq!(config.http.port, 9000);
         assert_eq!(&format!("{}", config.routers[0]), "172.18.0.2:9001");
@@ -176,5 +185,6 @@ mod tests {
 
         let config = Config::from_raw(&content).unwrap();
         assert_eq!(config.http.port, 9000);
+        assert_eq!(config.upstream_depot, None);
     }
 }

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -23,6 +23,7 @@ extern crate crypto;
 extern crate github_api_client;
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;
+extern crate habitat_depot_client as depot_client;
 extern crate habitat_net as hab_net;
 extern crate hyper;
 extern crate iron;
@@ -69,6 +70,7 @@ use crypto::digest::Digest;
 use hab_core::package::{Identifiable, PackageArchive, PackageTarget};
 use iron::typemap;
 
+#[derive(Clone, Debug)]
 pub struct DepotUtil {
     pub config: Config,
 }

--- a/components/builder-http-gateway/Cargo.toml
+++ b/components/builder-http-gateway/Cargo.toml
@@ -8,9 +8,10 @@ workspace = "../../"
 [dependencies]
 base64 = "*"
 bodyparser = "*"
+builder_core = { path = "../builder-core" }
 env_logger = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
-builder_core = { path = "../builder-core" }
+habitat_depot_client = { git = "https://github.com/habitat-sh/habitat.git" }
 habitat_net = { path = "../net" }
 hyper = "0.10"
 iron = "*"

--- a/components/builder-http-gateway/src/http/middleware.rs
+++ b/components/builder-http-gateway/src/http/middleware.rs
@@ -17,6 +17,7 @@ use bldr_core;
 use core::env;
 use oauth_client::client::OAuth2Client;
 use oauth_client::types::OAuth2User;
+use depot_client::Client as DepotClient;
 use github_api_client::GitHubClient;
 use hab_net::{ErrCode, NetError};
 use hab_net::conn::RouteClient;
@@ -95,6 +96,12 @@ pub struct GitHubCli;
 
 impl Key for GitHubCli {
     type Value = GitHubClient;
+}
+
+pub struct DepotCli;
+
+impl Key for DepotCli {
+    type Value = DepotClient;
 }
 
 pub struct SegmentCli;

--- a/components/builder-http-gateway/src/lib.rs
+++ b/components/builder-http-gateway/src/lib.rs
@@ -16,12 +16,12 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
 extern crate base64;
-extern crate oauth_client;
-extern crate github_api_client;
 extern crate bodyparser;
 extern crate builder_core as bldr_core;
+extern crate github_api_client;
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as core;
+extern crate habitat_depot_client as depot_client;
 extern crate habitat_net as hab_net;
 #[macro_use]
 extern crate hyper;
@@ -31,6 +31,7 @@ extern crate iron;
 extern crate log;
 extern crate mount;
 extern crate num_cpus;
+extern crate oauth_client;
 extern crate params;
 extern crate persistent;
 extern crate protobuf;


### PR DESCRIPTION
This adds support for fetching packages from an upstream depot, as you might have guessed from my clever and obscure PR title.

This is achieved through one new line of configuration in the `[depot]` section of `builder-api`'s config file:

```toml
[depot]
upstream_depot = "http://example.com"
```

This is optional, and it's disabled by default.  Some sites, e.g. public Builder, do not need an upstream.

The primary driver for this is on-prem depots and the need to install packages via `hab pkg install`.  Before `hab pkg install` actually installs packages, it tries to fetch the details for a package from the depot, both to see what the latest version is, and verify that it actually exists.  This is the place where the bulk of the action happens.

In the event that we fail to find the package the user wants to install, rather than returning a 404, we attempt to fetch the package from the upstream depot (if one is configured).  Then we fake the upload process, as though the package had been uploaded manually.  Note that the owner of the package in this particular case will be Builder itself.  We also put it into the `stable` channel, because that's where `hab pkg install` expects to find it.  All of this happens in-band with the request to install a package, in an effort to provide the user with immediate results.

Additionally, any time someone makes a request to view the details of a package, we check the upstream depot in a background thread and pull in any updates that are available.

In order to make all of this work, there was a significant amount of refactoring inside `builder-depot`, which is notoriously a bit hairy.  I've tested:
* `hab pkg install` on a package that doesn't exist at all in my local depot (but does exist in the upstream)
* `hab pkg install` on a package that doesn't exist in either local or upstream
* `hab pkg install` on a package that exists in my local depot but is not currently installed
* `hab pkg upload` on a brand new package that doesn't exist in the depot
* `hab pkg upload` on a package that already exists in the depot

As far as I can tell, everything works, but I would appreciate anyone that reviews this PR to run everything through its paces as much as you can, particularly if you already have a local Builder dev env setup.

Also note the accompanying PR to `builder-depot-client` here: https://github.com/habitat-sh/habitat/pull/5034

Closes https://github.com/habitat-sh/builder/issues/150

![](https://media.giphy.com/media/7pjExnCBJ477y/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>