### PR TITLE
Tweak dev env config

### DIFF
--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -43,7 +43,7 @@ cat <<EOT > /hab/svc/builder-api-proxy/user.toml
 log_level = "debug"
 enable_builder = true
 
-app_url = "http://${APP_HOSTNAME}:9636"
+app_url = "http://${APP_HOSTNAME}"
 
 [github]
 api_url = "$GITHUB_API_URL"


### PR DESCRIPTION
1-liner config change for dev env to route API calls via the proxy instead of directly to the backend.

Signed-off-by: Salim Alam <salam@chef.io>