### PR TITLE
Add Okta as an authentication provider

### DIFF
--- a/components/builder-protocol/protocols/sessionsrv.proto
+++ b/components/builder-protocol/protocols/sessionsrv.proto
@@ -7,6 +7,7 @@ enum OAuthProvider {
   Bitbucket = 2;
   AzureAD = 3;
   GitLab = 4;
+  Okta = 5;
 }
 
 message Account {

--- a/components/builder-protocol/src/sessionsrv.rs
+++ b/components/builder-protocol/src/sessionsrv.rs
@@ -55,6 +55,7 @@ impl FromStr for OAuthProvider {
             "github" => Ok(OAuthProvider::GitHub),
             "gitlab" => Ok(OAuthProvider::GitLab),
             "bitbucket" => Ok(OAuthProvider::Bitbucket),
+            "okta" => Ok(OAuthProvider::Okta),
             "none" => Ok(OAuthProvider::None),
             "" => Ok(OAuthProvider::None),
             _ => Err(Error::BadOAuthProvider),

--- a/components/builder-web/app/oauth-providers/index.ts
+++ b/components/builder-web/app/oauth-providers/index.ts
@@ -2,7 +2,8 @@ enum OAuthProviderType {
   AzureAD = 'azure-ad',
   GitHub = 'github',
   GitLab = 'gitlab',
-  Bitbucket = 'bitbucket'
+  Bitbucket = 'bitbucket',
+  Okta = 'okta'
 }
 
 export abstract class OAuthProvider {
@@ -50,6 +51,8 @@ export abstract class OAuthProvider {
         return new GitLabProvider(clientID, authorizeUrl, redirectUrl, signupUrl, state);
       case OAuthProviderType.Bitbucket:
         return new BitbucketProvider(clientID, authorizeUrl, redirectUrl, signupUrl);
+      case OAuthProviderType.Okta:
+        return new OktaProvider(clientID, authorizeUrl, redirectUrl, signupUrl, state);
       case undefined:
       case '':
         console.error(`Please configure Builder with an OAuth provider. Supported providers are ${OAuthProvider.providers}.`);
@@ -144,3 +147,27 @@ class BitbucketProvider extends OAuthProvider {
     );
   }
 }
+
+class OktaProvider extends OAuthProvider {
+  name: string = 'Okta';
+
+  constructor(clientID: string, authorizeUrl: string, redirectUrl: string, signupUrl: string, state: string) {
+    super(
+      OAuthProviderType.Okta,
+      clientID,
+      authorizeUrl,
+      redirectUrl,
+      signupUrl,
+      true,
+      {
+        client_id: clientID,
+        redirect_uri: redirectUrl,
+        response_type: 'code',
+        state: state,
+        scope: 'openid profile email',
+        nonce: 0
+      }
+    );
+  }
+}
+

--- a/components/oauth-client/src/client.rs
+++ b/components/oauth-client/src/client.rs
@@ -24,6 +24,7 @@ use azure_ad::AzureAD;
 use github::GitHub;
 use gitlab::GitLab;
 use bitbucket::Bitbucket;
+use okta::Okta;
 
 pub struct OAuth2Client {
     inner: reqwest::Client,
@@ -63,6 +64,7 @@ impl OAuth2Client {
             "github" => Box::new(GitHub),
             "gitlab" => Box::new(GitLab),
             "bitbucket" => Box::new(Bitbucket),
+            "okta" => Box::new(Okta),
             _ => panic!("Unknown OAuth provider: {}", config.provider),
         };
 

--- a/components/oauth-client/src/lib.rs
+++ b/components/oauth-client/src/lib.rs
@@ -27,6 +27,7 @@ pub mod config;
 pub mod github;
 pub mod gitlab;
 pub mod bitbucket;
+pub mod okta;
 pub mod error;
 pub mod types;
 pub mod metrics;

--- a/components/oauth-client/src/okta.rs
+++ b/components/oauth-client/src/okta.rs
@@ -1,0 +1,111 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use reqwest::Client;
+use reqwest::header::{qitem, Accept, Authorization, Bearer, ContentType, Headers};
+use reqwest::mime;
+use serde_json;
+
+use config::OAuth2Cfg;
+use error::{Error, Result};
+use types::*;
+
+pub struct Okta;
+
+#[derive(Deserialize)]
+struct AuthOk {
+    pub access_token: String,
+}
+
+#[derive(Deserialize)]
+struct User {
+    pub sub: String,
+    pub preferred_username: String,
+    pub email: Option<String>,
+}
+
+impl Okta {
+    fn user(&self, config: &OAuth2Cfg, client: &Client, token: &str) -> Result<OAuth2User> {
+        let mut headers = Headers::new();
+        headers.set(Accept(vec![qitem(mime::APPLICATION_JSON)]));
+        headers.set(Authorization(Bearer {
+            token: token.to_string(),
+        }));
+
+        let mut resp = client
+            .get(&config.userinfo_url)
+            .headers(headers)
+            .send()
+            .map_err(Error::HttpClient)?;
+
+        let body = resp.text().map_err(Error::HttpClient)?;
+        debug!("Okta response body: {}", body);
+
+        if resp.status().is_success() {
+            let user = match serde_json::from_str::<User>(&body) {
+                Ok(msg) => msg,
+                Err(e) => return Err(Error::Serialization(e)),
+            };
+
+            Ok(OAuth2User {
+                id: user.sub,
+                username: user.preferred_username,
+                email: user.email,
+            })
+        } else {
+            Err(Error::HttpResponse(resp.status(), body))
+        }
+    }
+}
+
+impl OAuth2Provider for Okta {
+    fn authenticate(
+        &self,
+        config: &OAuth2Cfg,
+        client: &Client,
+        code: &str,
+    ) -> Result<(String, OAuth2User)> {
+        let url = format!("{}", config.token_url);
+        let params = format!(
+            "client_id={}&client_secret={}&grant_type=authorization_code&code={}&redirect_uri={}",
+            config.client_id, config.client_secret, code, config.redirect_url
+        );
+
+        let mut headers = Headers::new();
+        headers.set(Accept(vec![qitem(mime::APPLICATION_JSON)]));
+        headers.set(ContentType::form_url_encoded());
+
+        let mut resp = client
+            .post(&url)
+            .headers(headers)
+            .body(params)
+            .send()
+            .map_err(Error::HttpClient)?;
+
+        let body = resp.text().map_err(Error::HttpClient)?;
+        debug!("Okta response body: {}", body);
+
+        let token = if resp.status().is_success() {
+            match serde_json::from_str::<AuthOk>(&body) {
+                Ok(msg) => msg.access_token,
+                Err(e) => return Err(Error::Serialization(e)),
+            }
+        } else {
+            return Err(Error::HttpResponse(resp.status(), body));
+        };
+
+        let user = self.user(config, client, &token)?;
+        Ok((token, user))
+    }
+}


### PR DESCRIPTION
This PR adds Okta as an authentication provider.

To make this work you need to create a new application in Okta and select the "Web" type, configure the URIs and select the option "Authorization Code" in the "Grant type allowed" field.

For Builder you need the following configuration:
```
OAUTH_PROVIDER="okta"
OAUTH_USERINFO_URL="https://<your.okta.domain>.com/oauth2/v1/userinfo"
OAUTH_AUTHORIZE_URL="https://<your.okta.domain>.com/oauth2/v1/authorize"
OAUTH_TOKEN_URL="https://<your.okta.domain>.com/oauth2/v1/token"
```

I've tested this with their Single Single-On and Multi-Factor Authentication products.