### PR TITLE
Convert Segment to use APIClient for proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,6 +2418,7 @@ name = "segment-api-client"
 version = "0.0.0"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/segment-api-client/Cargo.toml
+++ b/components/segment-api-client/Cargo.toml
@@ -6,6 +6,7 @@ workspace = "../../"
 
 [dependencies]
 base64 = "*"
+habitat_http_client = { git = "https://github.com/habitat-sh/core.git" }
 hyper = "0.10"
 hyper-openssl = "0.2"
 log = "*"

--- a/components/segment-api-client/src/error.rs
+++ b/components/segment-api-client/src/error.rs
@@ -20,11 +20,13 @@ use std::io;
 use base64;
 use hyper;
 use serde_json;
+use hab_http;
 
 pub type SegmentResult<T> = Result<T, SegmentError>;
 
 #[derive(Debug)]
 pub enum SegmentError {
+    ApiClient(hab_http::Error),
     ApiError(hyper::status::StatusCode, HashMap<String, String>),
     ContentDecode(base64::DecodeError),
     HttpClient(hyper::Error),
@@ -37,6 +39,7 @@ pub enum SegmentError {
 impl fmt::Display for SegmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
+            SegmentError::ApiClient(ref e) => format!("{}", e),
             SegmentError::ApiError(ref code, ref response) => format!(
                 "Received a non-200 response, status={}, response={:?}",
                 code, response
@@ -55,6 +58,7 @@ impl fmt::Display for SegmentError {
 impl error::Error for SegmentError {
     fn description(&self) -> &str {
         match *self {
+            SegmentError::ApiClient(ref err) => err.description(),
             SegmentError::ApiError(_, _) => "Response returned a non-200 status code.",
             SegmentError::ContentDecode(ref err) => err.description(),
             SegmentError::HttpClient(ref err) => err.description(),

--- a/components/segment-api-client/src/lib.rs
+++ b/components/segment-api-client/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 extern crate base64;
+extern crate habitat_http_client as hab_http;
 extern crate hyper;
 extern crate hyper_openssl;
 extern crate log;


### PR DESCRIPTION
Convert the Segment API client to use APIClient as the base, in order to pick up the proxy support that is a part of APIClient.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-35509492](https://user-images.githubusercontent.com/13542112/39788323-c70271cc-52de-11e8-8caf-a69159859f70.gif)
