### PR TITLE
Fix missing jobsrv_enabled flag in config

### DIFF
--- a/components/builder-originsrv/habitat/config/config.toml
+++ b/components/builder-originsrv/habitat/config/config.toml
@@ -1,3 +1,5 @@
+jobsrv_enabled = {{cfg.jobsrv_enabled}}
+
 [app]
 {{toToml cfg.app}}
 routers = [


### PR DESCRIPTION
1-liner fix to properly set the jobsrv_enabled flag on origin server

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-237061816](https://user-images.githubusercontent.com/13542112/39842246-9e5e49c8-539a-11e8-8462-1d4424572f71.gif)
