### PR TITLE
Add proxy timeout config to builder-api-proxy

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -144,6 +144,8 @@ http {
 
     location /v1/depot {
       client_max_body_size {{cfg.nginx.max_body_size}};
+      proxy_send_timeout {{cfg.nginx.proxy_send_timeout}};
+      proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
       proxy_cache my_cache;
       proxy_pass http://backend;
     }

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -37,6 +37,8 @@ worker_connections   = 8000
 worker_processes     = "auto"
 worker_rlimit_nofile = 8192
 max_body_size        = "1024m"
+proxy_send_timeout   = 60
+proxy_read_timeout   = 60
 
 [http]
 keepalive_timeout = "20s"


### PR DESCRIPTION
This change adds a proxy timeout config setting to the builder-api-proxy. It is useful when we need to adjust the service to handle upload/download of large files.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-167176814](https://user-images.githubusercontent.com/13542112/39891676-0d86a54e-5453-11e8-84c0-916a9bb377e7.gif)
