### PR TITLE
Refactor the way targets are calculated.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,154 @@
+UNAME_S := $(shell uname -s)
+BIN = airlock
+LIB = builder-db builder-core github-api-client net
+SRV = builder-api builder-depot builder-router builder-jobsrv builder-sessionsrv builder-originsrv builder-worker
+ALL = $(BIN) $(LIB) $(SRV)
+VERSION := $(shell cat VERSION)
+
+.DEFAULT_GOAL := build-bin
+
+linux:
+ifeq ($(UNAME_S),Darwin)
+	$(error Please run this from Linux)
+endif
+.PHONY: linux
+
+build: build-bin build-lib build-srv ## builds all the components
+build-all: build
+.PHONY: build build-all
+
+build-bin: $(addprefix build-,$(BIN)) ## builds the binary components
+.PHONY: build-bin
+
+build-lib: $(addprefix build-,$(LIB)) ## builds the library components
+.PHONY: build-lib
+
+build-srv: $(addprefix build-,$(SRV)) ## builds the service components
+.PHONY: build-srv
+
+unit: unit-bin unit-lib unit-srv ## executes all the components' unit test suites
+unit-all: unit
+.PHONY: unit unit-all
+
+unit-bin: $(addprefix unit-,$(BIN)) ## executes the binary components' unit test suites
+.PHONY: unit-bin
+
+unit-lib: $(addprefix unit-,$(LIB)) ## executes the library components' unit test suites
+.PHONY: unit-lib
+
+unit-srv: $(addprefix unit-,$(SRV)) ## executes the service components' unit test suites
+.PHONY: unit-srv
+
+lint: lint-bin lint-lib lint-srv ## executs all components' lints
+lint-all: lint
+.PHONY: lint lint-all
+
+lint-bin: $(addprefix lint-,$(BIN))
+.PHONY: lint-bin
+
+lint-lib: $(addprefix lint-,$(LIB))
+.PHONY: lint-lib
+
+lint-srv: $(addprefix lint-,$(SRV))
+.PHONY: lint-srv
+
+functional: functional-bin functional-lib functional-srv ## executes all the components' functional test suites
+functional-all: functional
+test: functional ## executes all components' test suites
+.PHONY: functional functional-all test
+
+functional-bin: $(addprefix unit-,$(BIN)) ## executes the binary components' unit functional suites
+.PHONY: functional-bin
+
+functional-lib: $(addprefix unit-,$(LIB)) ## executes the library components' unit functional suites
+.PHONY: functional-lib
+
+functional-srv: $(addprefix unit-,$(SRV)) ## executes the service components' unit functional suites
+.PHONY: functional-srv
+
+clean: clean-bin clean-lib clean-srv ## cleans all the components' clean test suites
+clean-all: clean
+.PHONY: clean clean-all
+
+clean-bin: $(addprefix clean-,$(BIN)) ## cleans the binary components' project trees
+.PHONY: clean-bin
+
+clean-lib: $(addprefix clean-,$(LIB)) ## cleans the library components' project trees
+.PHONY: clean-lib
+
+clean-srv: $(addprefix clean-,$(SRV)) ## cleans the service components' project trees
+.PHONY: clean-srv
+
+fmt: fmt-bin fmt-lib fmt-srv ## formats all the components' codebases
+fmt-all: fmt
+.PHONY: fmt fmt-all
+
+fmt-bin: $(addprefix fmt-,$(BIN)) ## formats the binary components' codebases
+.PHONY: clean-bin
+
+fmt-lib: $(addprefix fmt-,$(LIB)) ## formats the library components' codebases
+.PHONY: clean-lib
+
+fmt-srv: $(addprefix fmt-,$(SRV)) ## formats the service components' codebases
+.PHONY: clean-srv
+
+help:
+	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+.PHONY: help
+
+bundle: linux
+	sh -c 'AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) AWS_KEYPAIR_NAME=$(AWS_KEYPAIR_NAME) \
+		AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) terraform/scripts/create_bootstrap_bundle.sh \
+		$(VERSION)'
+
+changelog: linux
+	sh -c 'hab pkg install core/github_changelog_generator && \
+		hab pkg binlink core/git git --force && \
+		hab pkg binlink core/github_changelog_generator github_changelog_generator --force && \
+		github_changelog_generator --future-release $(VERSION) --token $(GITHUB_TOKEN)' --max-issues=1000
+
+define BUILD
+build-$1: linux ## builds the $1 component
+	sh -c 'cd components/$1 && cargo build'
+.PHONY: build-$1
+
+endef
+$(foreach component,$(ALL),$(eval $(call BUILD,$(component))))
+
+define UNIT
+unit-$1: linux ## executes the $1 component's unit test suite
+	sh -c 'cd components/$1 && cargo test'
+.PHONY: unit-$1
+endef
+$(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
+
+define LINT
+lint-$1: linux ## executes the $1 component's linter checks
+	sh -c 'cd components/$1 && cargo build --features clippy'
+.PHONY: lint-$1
+endef
+$(foreach component,$(ALL),$(eval $(call LINT,$(component))))
+
+define FUNCTIONAL
+functional-$1: linux ## executes the $1 component's functional test suite
+	sh -c 'cd components/$1 && cargo test --features functional'
+.PHONY: functional-$1
+
+endef
+$(foreach component,$(ALL),$(eval $(call FUNCTIONAL,$(component))))
+
+define CLEAN
+clean-$1: linux ## cleans the $1 component's project tree
+	sh -c 'cd components/$1 && cargo clean'
+.PHONY: clean-$1
+
+endef
+$(foreach component,$(ALL),$(eval $(call CLEAN,$(component))))
+
+define FMT
+fmt-$1: linux ## formats the $1 component
+	sh -c 'cd components/$1 && cargo fmt'
+.PHONY: fmt-$1
+
+endef
+$(foreach component,$(ALL),$(eval $(call FMT,$(component))))

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1681,7 +1681,7 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
         if !qualified {
             let mut request = OriginChannelPackageLatestGet::new();
             request.set_name(channel.clone());
-            request.set_target(target);
+            request.set_target(target.clone());
             request.set_visibilities(visibility_for_optional_session(
                 req,
                 session_id,
@@ -1720,7 +1720,7 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
     } else {
         if !qualified {
             let mut request = OriginPackageLatestGet::new();
-            request.set_target(target);
+            request.set_target(target.clone());
             request.set_visibilities(visibility_for_optional_session(
                 req,
                 session_id,
@@ -1756,8 +1756,10 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
                     .expect("depot not found");
 
                 let depot = lock.read().expect("depot read lock is poisoned");
+                let pkg_target = PackageTarget::from_str(&target);
 
-                if !depot.archive(&ident, &target).is_some() {
+                // If the target doesn't parse or there's no archive on disk, return 404
+                if pkg_target.is_err() || !depot.archive(&ident, &pkg_target.unwrap()).is_some() {
                     return Ok(Response::with(status::NotFound));
                 };
 


### PR DESCRIPTION
Specifically, via a URL query parameter if present, with a fallback to
the UserAgent header if not.

This is in support of including windows packages in the on-prem bootstrap archive.

![](https://media.giphy.com/media/NROBADF4nKFpe/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>