### PR TITLE
Remove archive check from show_package

### DIFF
--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1229,20 +1229,7 @@ fn download_package(req: &mut Request) -> IronResult<Response> {
     ident_req.set_visibilities(vis);
     ident_req.set_ident(ident);
 
-    let target = match helpers::extract_query_value("target", req) {
-        Some(t) => match PackageTarget::from_str(&t) {
-            Ok(pt) => pt,
-            Err(e) => {
-                warn!("error parsing bad target: {}, e: {:?}", &t, &e);
-                return Ok(Response::with((
-                    status::NotImplemented,
-                    format!("Unsupported client platform ({}).", t),
-                )));
-            }
-        },
-        None => target_from_headers(req).unwrap(),
-    };
-
+    let target = target_from_req(req);
     if !depot.targets.contains(&target) {
         return Ok(Response::with((
             status::NotImplemented,
@@ -1684,17 +1671,13 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
 
     let mut ident = ident_from_req(req);
     let qualified = ident.fully_qualified();
-
-    let target = match helpers::extract_query_value("target", req) {
-        Some(t) => t,
-        None => target_from_headers(req).unwrap().to_string(),
-    };
+    let target = target_from_req(req);
 
     if let Some(channel) = channel {
         if !qualified {
             let mut request = OriginChannelPackageLatestGet::new();
             request.set_name(channel.clone());
-            request.set_target(target.clone());
+            request.set_target(target.to_string());
             request.set_visibilities(visibility_for_optional_session(
                 req,
                 session_id,
@@ -1733,7 +1716,7 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
     } else {
         if !qualified {
             let mut request = OriginPackageLatestGet::new();
-            request.set_target(target.clone());
+            request.set_target(target.to_string());
             request.set_visibilities(visibility_for_optional_session(
                 req,
                 session_id,
@@ -2171,8 +2154,12 @@ fn ident_from_req(req: &mut Request) -> OriginPackageIdent {
 
 fn ident_from_params(params: &Params) -> OriginPackageIdent {
     let mut ident = OriginPackageIdent::new();
-    ident.set_origin(params.find("origin").unwrap().to_string());
-    ident.set_name(params.find("pkg").unwrap().to_string());
+    if let Some(origin) = params.find("origin") {
+        ident.set_origin(origin.to_string());
+    }
+    if let Some(name) = params.find("pkg") {
+        ident.set_name(name.to_string());
+    }
     if let Some(ver) = params.find("version") {
         ident.set_version(ver.to_string());
     }
@@ -2193,31 +2180,44 @@ fn download_content_as_file(content: &[u8], filename: String) -> IronResult<Resp
     Ok(response)
 }
 
-fn target_from_headers(req: &mut Request) -> result::Result<PackageTarget, Response> {
-    let user_agent_header = req.headers.get::<UserAgent>().unwrap();
-    let user_agent = user_agent_header.as_str();
-    debug!("Headers = {}", &user_agent);
+fn target_from_req(req: &mut Request) -> PackageTarget {
+    // A target in a query param over-rides the user agent platform
+    let target = match helpers::extract_query_value("target", req) {
+        Some(t) => {
+            debug!("Query requested target = {}", t);
+            t
+        }
+        None => {
+            let user_agent_header = req.headers.get::<UserAgent>().unwrap();
+            let user_agent = user_agent_header.as_str();
+            debug!("Headers = {}", &user_agent);
 
-    let user_agent_regex =
-        Regex::new(r"(?P<client>[^\s]+)\s?(\((?P<target>\w+-\w+); (?P<kernel>.*)\))?").unwrap();
-    let user_agent_capture = user_agent_regex
-        .captures(user_agent)
-        .expect("Invalid user agent supplied.");
+            let user_agent_regex = Regex::new(
+                r"(?P<client>[^\s]+)\s?(\((?P<target>\w+-\w+); (?P<kernel>.*)\))?",
+            ).unwrap();
 
-    // All of our tooling that depends on this function to return a target will have a user
-    // agent that includes the platform. Therefore, if we can't find a target, it's safe to
-    // assume that some other kind of HTTP tool is being used, e.g. curl. For those kinds
-    // of clients, the target platform isn't important, so let's default it to linux
-    // instead of returning a bad request.
-    let target = if let Some(target_match) = user_agent_capture.name("target") {
-        target_match.as_str()
-    } else {
-        "x86_64-linux"
+            match user_agent_regex.captures(user_agent) {
+                Some(user_agent_capture) => {
+                    if let Some(target_match) = user_agent_capture.name("target") {
+                        target_match.as_str().to_string()
+                    } else {
+                        "".to_string()
+                    }
+                }
+                None => "".to_string(),
+            }
+        }
     };
 
-    match PackageTarget::from_str(target) {
-        Ok(t) => Ok(t),
-        Err(_) => Err(Response::with(status::BadRequest)),
+    // All of our tooling that depends on this function to return a target will have a user
+    // agent that includes the platform, or will specify a target in the query.
+    // Therefore, if we can't find a valid target, it's safe to assume that some other kind of HTTP
+    // tool is being used, e.g. curl, with looser constraints. For those kinds of cases,
+    // let's default it to Linux instead of returning a bad request if we can't properly parse
+    // the inbound target.
+    match PackageTarget::from_str(&target) {
+        Ok(t) => t,
+        Err(_) => PackageTarget::from_str("x86_64-linux").unwrap(),
     }
 }
 


### PR DESCRIPTION
This change removes a costly check from show_package API call.  If we have valid metadata in originsrv for a package, we will assume that it's archive is in the correct location as well.  This will be a valid assumption as we move package storage to S3 shortly. We also don't need to re-check the target since we already pass it in to the OriginPackageGet call.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-13670767](https://user-images.githubusercontent.com/13542112/40686615-c1bd307a-634c-11e8-904c-c079b4b119b4.gif)
