### PR TITLE
False positive "already started" messages in the dev-env w/ v0.56.0

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -164,7 +164,7 @@ start-builder() { stop-on-failure _start-builder "$@"; }
 _load-if-not-loaded() {
   local pkg_ident
   pkg_ident=$1
-  if hab sup status "$pkg_ident" > /dev/null; then
+  if hab sup status "${pkg_ident}" | grep "${pkg_ident}" > /dev/null; then
     echo "$pkg_ident is already loaded"
   else
     hab svc load "$@"
@@ -173,7 +173,7 @@ _load-if-not-loaded() {
 load-if-not-loaded() { stop-on-failure _load-if-not-loaded "$@"; }
 
 start-datastore() {
-  if hab sup status habitat/builder-datastore > /dev/null; then
+if hab sup status habitat/builder-datastore | grep "builder-datastore" > /dev/null; then
     echo "habitat/builder-datastore is already loaded"
   else
     init-datastore


### PR DESCRIPTION
Seeing false positive "already started" messages in the builder dev-env after upgrading to hab v0.56.0. I _think_ it's related to the exit code provided by `hab sup status` now we grep for appropriate output to determine whether a service is started.

Signed-off-by: Ian Henry <ihenry@chef.io>