### PR TITLE
Add baumanj back to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,6 @@ components/net @chefsalim @raskchanky
 components/oauth-client @chefsalim @raskchanky
 components/op @chefsalim @raskchanky
 components/segment-api-client @chefsalim @raskchanky
-support @fnichol @chefsalim @raskchanky @elliott-davis
-tools @chefsalim @christophermaier @eeyun @raskchanky @fnichol
+support @fnichol @chefsalim @raskchanky @baumanj @elliott-davis
+tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol
 .studiorc @chefsalim @elliott-davis @raskchanky


### PR DESCRIPTION
This reverts commit 1476bb0066a2c513a02217e373f9b8f248973a45, but has some
extra fixups since there was an intervening change

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>