### PR TITLE
Update dev env nginx timeouts

### DIFF
--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -60,6 +60,14 @@ provider       = "$OAUTH_PROVIDER"
 client_id      = "$OAUTH_CLIENT_ID"
 authorize_url  = "$OAUTH_AUTHORIZE_URL"
 redirect_url   = "$OAUTH_REDIRECT_URL"
+
+[nginx]
+max_body_size = "2048m"
+proxy_send_timeout = 180
+proxy_read_timeout = 180
+
+[http]
+keepalive_timeout = "180s"
 EOT
 
 mkdir -p /hab/svc/builder-jobsrv


### PR DESCRIPTION
Updates the dev env with more appropriate nginx timeouts and ups the body size limit for package uploads - this matches what we have in the builder on-prem.

Signed-off-by: Salim Alam <salam@chef.io>