### PR TITLE
Remove upstream from dev env

### DIFF
--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -36,10 +36,6 @@ client_secret = "$OAUTH_CLIENT_SECRET"
 [github]
 api_url = "$GITHUB_API_URL"
 app_id = $GITHUB_APP_ID
-
-[depot]
-upstream_depot = "https://bldr.habitat.sh"
-upstream_origins = ["core","habitat"]
 EOT
 
 mkdir -p /hab/svc/builder-api-proxy


### PR DESCRIPTION
Removing the upstream config from the dev env.  While useful, it should be an explicit choice to enable it since it has potentially unexpected/undesired side effects during development.

Signed-off-by: Salim Alam <salam@chef.io>