### PR TITLE
Remove core/hab-butterfly from list of packages to download

### DIFF
--- a/terraform/scripts/create_bootstrap_bundle.sh
+++ b/terraform/scripts/create_bootstrap_bundle.sh
@@ -70,8 +70,7 @@ hab pkg binlink core/coreutils sort
 # the depot for the latest stable version of it.
 sup_packages=(core/hab-launcher
               core/hab/${hab_version}
-              core/hab-sup/${hab_version}
-              core/hab-butterfly/${hab_version})
+              core/hab-sup/${hab_version})
 
 # If the HAB_BLDR_URL environment variable is set, we'll use that
 # when downloading packages. Otherwise, we'll just default to the


### PR DESCRIPTION
It no longer exists!

Signed-off-by: Christopher Maier <cmaier@chef.io>