### PR TITLE
Some tweaks to S3 config

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -69,6 +69,7 @@ install-packages() {
   core/procps-ng \
   core/shadow \
   core/curl \
+  core/aws-cli \
   -b -c stable
 }
 
@@ -92,7 +93,7 @@ _build-builder() {
   fi
 
   if [[ "$#" -eq 0 ]]; then
-    build-builder api jobsrv originsrv router sessionsrv worker minio
+    build-builder api jobsrv originsrv router sessionsrv worker
     return $?
   fi
 
@@ -103,7 +104,7 @@ _build-builder() {
 build-builder() { stop-on-failure _build-builder "$@"; }
 
 ui-dev-mode() {
-  for svc in sessionsrv worker api originsrv minio; do
+  for svc in sessionsrv worker api originsrv; do
   cat <<CONFIG | hab config apply builder-${svc}.default "$(date +%s)"
 [github]
 client_id = "Iv1.732260b62f84db15"
@@ -115,7 +116,7 @@ done
 
 upload_github_keys() {
   if [[ -f "/src/.secrets/builder-github-app.pem" ]]; then
-    for svc in sessionsrv worker api originsrv minio; do
+    for svc in sessionsrv worker api originsrv; do
       hab file upload "builder-${svc}.default" "$(date +%s)" "/src/.secrets/builder-github-app.pem"
     done
   else
@@ -141,14 +142,15 @@ _start-builder() {
     start-builder sessionsrv
     start-builder worker
     start-builder minio
+    configure-minio
     sleep 2
     generate_bldr_keys
     upload_github_keys
-    configure-minio
+
     echo "Builder Started: Navigate to http://localhost/#/pkgs/core to access the web UI."
     echo "Minio login available at http://localhost:9000"
-    echo "Username: DEFAULTKEYID"
-    echo "Password: DEFAULTSECRETACCESSKEY"
+    echo "Username: depot"
+    echo "Password: password"
     echo "AWS-CLI ENVVARS have been set with these values"
     return $?
   fi
@@ -188,17 +190,14 @@ if hab sup status habitat/builder-datastore | grep "habitat/builder-datastore" >
 }
 
 configure-minio() {
- if hab svc status habitat/builder-minio | grep "habitat/builder-minio" > /dev/null; then
-   echo "habitat/builder-minio is already loaded"
-   hab pkg install -bf core/aws-cli
-   export AWS_ACCESS_KEY_ID="DEFAULTKEYID"
-   export AWS_SECRET_ACCESS_KEY="DEFAULTSECRETACCESSKEY"
-   aws --endpoint-url http://localhost:9000 s3api create-bucket --bucket "habitat-builder-dev-artifact-store.default"
-   echo "Default bucket created successfully with dev credentials"
- else
-     hab svc load habitat/builder-minio
-     start-minio
- fi
+   export AWS_ACCESS_KEY_ID="depot"
+   export AWS_SECRET_ACCESS_KEY="password"
+   if aws --endpoint-url http://localhost:9000 s3api list-buckets | grep "habitat-builder-artifact-store.default" > /dev/null; then
+     echo "Minio already configured"
+   else
+     echo "Creating bucket in Minio"
+     aws --endpoint-url http://localhost:9000 s3api create-bucket --bucket "habitat-builder-artifact-store.default"
+   fi
 }
 
 start-cache() {

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -30,7 +30,7 @@ write_key = ""
 
 [s3]
 backend = "Minio"
-key_id = "DEFAULTKEYID"
-secret_key = "DEFAULTSECRETACCESSKEY"
+key_id = "depot"
+secret_key = "depot"
 endpoint = "http://localhost:9000"
-bucket_name = "habitat-builder-dev-artifact-store.default"
+bucket_name = "habitat-builder-artifact-store.default"

--- a/components/builder-depot/src/backend/s3.rs
+++ b/components/builder-depot/src/backend/s3.rs
@@ -239,7 +239,7 @@ impl S3Handler {
                 let mut part_num: i64 = 0;
                 let mut should_break = false;
                 loop {
-                    let mut length = 0;
+                    let mut length;
                     {
                         let buffer = reader.fill_buf()?;
                         length = buffer.len();

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -102,7 +102,7 @@ impl GatewayCfg for Config {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub enum S3Backend {
     Aws,
     Minio,
@@ -122,9 +122,9 @@ pub struct S3Cfg {
 impl Default for S3Cfg {
     fn default() -> Self {
         S3Cfg {
-            key_id: String::from("DEFAULTKEYID"),
-            secret_key: String::from("DEFAULTSECRETACCESSKEY"),
-            bucket_name: String::from("habitat-builder-dev-artifact-store.default"),
+            key_id: String::from("depot"),
+            secret_key: String::from("password"),
+            bucket_name: String::from("habitat-builder-artifact-store.default"),
             backend: S3Backend::Minio,
             endpoint: String::from("http://localhost:9000"),
         }
@@ -187,6 +187,11 @@ mod tests {
         listen = "127.0.0.1"
         port = 9000
 
+        [s3]
+        backend = "Aws"
+        endpoint = "https://aws"
+        bucket_name = "mybucket"
+
         [[routers]]
         host = "172.18.0.2"
         port = 9001
@@ -208,6 +213,12 @@ mod tests {
             config.upstream_origins,
             vec!["foo".to_string(), "bar".to_string()]
         );
+        assert_eq!(config.s3.backend, S3Backend::Aws);
+        assert_eq!(config.s3.key_id, "depot".to_string());
+        assert_eq!(config.s3.secret_key, "password".to_string());
+        assert_eq!(config.s3.endpoint, "https://aws".to_string());
+        assert_eq!(config.s3.bucket_name, "mybucket".to_string());
+
         assert_eq!(&format!("{}", config.http.listen), "127.0.0.1");
         assert_eq!(config.http.port, 9000);
         assert_eq!(&format!("{}", config.routers[0]), "172.18.0.2:9001");

--- a/components/builder-minio/habitat/default.toml
+++ b/components/builder-minio/habitat/default.toml
@@ -1,4 +1,4 @@
-key_id = "DEFAULTKEYID"
-secret_key = "DEFAULTSECRETACCESSKEY"
+key_id = "depot"
+secret_key = "password"
 use_ssl = false
 gen_cert = false

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -16,6 +16,12 @@ else
   exit 1
 fi
 
+mkdir -p /hab/svc/builder-minio
+cat <<EOT > /hab/svc/builder-minio/user.toml
+key_id = "depot"
+secret_key = "password"
+EOT
+
 mkdir -p /hab/svc/builder-router
 cat <<EOT > /hab/svc/builder-router/user.toml
 log_level = "info"


### PR DESCRIPTION
A few tweaks to the S3 config / related scripts:
1. Simplify default Minio creds
2. Update bucket creation to be slightly more idempotent
3. Remove file upload of un-needed pem file to minio
4. Remove minio from build commands in dev env (not needed)
5. Tweak the default bucket name to be more consistent with other envs
6. Remove un-defined function call
7. Add a user.toml with updated certs for the minio in the dev env
8. Fix a compile warning in the S3 handler
9. Add some unit tests for the S3 config

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-224099044](https://user-images.githubusercontent.com/13542112/41186938-c5a0f9b4-6b54-11e8-9cd6-cb206bb4f3fa.gif)
