### PR TITLE
Updates to S3migrate & tweaks to s3backend

### DIFF
--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -29,8 +29,8 @@ url       = "https://api.segment.io"
 write_key = ""
 
 [s3]
-backend = "Minio"
+backend = "minio"
 key_id = "depot"
-secret_key = "depot"
+secret_key = "password"
 endpoint = "http://localhost:9000"
 bucket_name = "habitat-builder-artifact-store.default"

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -103,6 +103,7 @@ impl GatewayCfg for Config {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
 pub enum S3Backend {
     Aws,
     Minio,
@@ -188,7 +189,7 @@ mod tests {
         port = 9000
 
         [s3]
-        backend = "Aws"
+        backend = "aws"
         endpoint = "https://aws"
         bucket_name = "mybucket"
 


### PR DESCRIPTION
A couple of minor tweaks here
1. downcased the backend enum so that in the default.toml's etc we don't have a camel-case "Aws" or "Minio".
2. Changes default.toml to match the default values in the rust component.
3. Most importantly, modifies the s3migrate.sh tool to use the s3bulk go tool.
Signed-off-by: Ian Henry <ihenry@chef.io>