### PR TITLE
Corrects sourcing of config which fails under dash

### DIFF
--- a/components/builder-minio/habitat/config/config.sh
+++ b/components/builder-minio/habitat/config/config.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# Provides id and key instead of generating one
-export MINIO_ACCESS_KEY="{{cfg.key_id}}"
-export MINIO_SECRET_KEY="{{cfg.secret_key}}"

--- a/components/builder-minio/habitat/hooks/run
+++ b/components/builder-minio/habitat/hooks/run
@@ -2,7 +2,8 @@
 
 exec 2>&1
 
-source "{{pkg.svc_config_path}}/config.sh"
+export MINIO_ACCESS_KEY="{{cfg.key_id}}"
+export MINIO_SECRET_KEY="{{cfg.secret_key}}"
 
 exec minio server \
 --config-dir {{pkg.svc_config_path}} \


### PR DESCRIPTION
sourcing of the config script fails without bash because `source` is a bash built-in, this removes a need to source the config.

Signed-off-by: Ian Henry <ihenry@chef.io>