### PR TITLE
Minor fix to s3migrate script

### DIFF
--- a/support/builder/s3migrate.sh
+++ b/support/builder/s3migrate.sh
@@ -99,7 +99,7 @@ setBucket() {
         fi
     done
 
-    if [[ -z ${bucket_name} ]]; then
+    if [[ -z ${bucket_name:-} ]]; then
       echo ""
       echo "Please enter a target bucket name and press [ENTER]:"
       read bucket_name


### PR DESCRIPTION
Add a default to the bucket_name check in the s3migrate script, since if curl returns a non-zero exit, the bucket_name can get unset.

Signed-off-by: Salim Alam <salam@chef.io>