### PR TITLE
Add audit logs for package promotion and demotion

### DIFF
--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -116,6 +116,25 @@ impl DataStore {
         async_thread.start(4);
     }
 
+    pub fn package_channel_audit(&self, pca: &originsrv::PackageChannelAudit) -> SrvResult<()> {
+        let conn = self.pool.get(pca)?;
+
+        &conn.query(
+            "SELECT * FROM add_audit_entry_v1($1, $2, $3, $4, $5, $6, $7)",
+            &[
+                &(pca.get_origin_id() as i64),
+                &(pca.get_package_id() as i64),
+                &(pca.get_channel_id() as i64),
+                &(pca.get_operation() as i16),
+                &(pca.get_trigger() as i16),
+                &(pca.get_requester_id() as i64),
+                &pca.get_requester_name().to_string(),
+            ],
+        ).map_err(SrvError::PackageChannelAudit)?;
+
+        Ok(())
+    }
+
     pub fn update_origin_package(&self, opu: &originsrv::OriginPackageUpdate) -> SrvResult<()> {
         let conn = self.pool.get(opu)?;
         let pkg = opu.get_pkg();

--- a/components/builder-originsrv/src/error.rs
+++ b/components/builder-originsrv/src/error.rs
@@ -108,6 +108,7 @@ pub enum SrvError {
     OriginUpdate(postgres::error::Error),
     OriginAccountList(postgres::error::Error),
     OriginAccountInOrigin(postgres::error::Error),
+    PackageChannelAudit(postgres::error::Error),
     Protocol(protocol::ProtocolError),
     SyncInvitations(postgres::error::Error),
     SyncInvitationsUpdate(postgres::error::Error),
@@ -350,6 +351,9 @@ impl fmt::Display for SrvError {
             SrvError::OriginAccountInOrigin(ref e) => {
                 format!("Error checking if this account is in an origin, {}", e)
             }
+            SrvError::PackageChannelAudit(ref e) => {
+                format!("Error auditing package channel rank change, {}", e)
+            }
             SrvError::Protocol(ref e) => format!("{}", e),
             SrvError::SyncInvitations(ref e) => {
                 format!("Error syncing invitations for account, {}", e)
@@ -450,6 +454,7 @@ impl error::Error for SrvError {
             SrvError::OriginSecretList(ref err) => err.description(),
             SrvError::OriginAccountInOrigin(ref err) => err.description(),
             SrvError::OriginUpdate(ref err) => err.description(),
+            SrvError::PackageChannelAudit(ref err) => err.description(),
             SrvError::Protocol(ref err) => err.description(),
             SrvError::SyncInvitations(ref err) => err.description(),
             SrvError::SyncInvitationsUpdate(ref err) => err.description(),

--- a/components/builder-originsrv/src/migrations/2018-06-13-213130_add_audit/down.sql
+++ b/components/builder-originsrv/src/migrations/2018-06-13-213130_add_audit/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS audit;
+DROP FUNCTION IF EXISTS add_audit_entry_v1(bigint, bigint, bigint, smallint, smallint, bigint, text);

--- a/components/builder-originsrv/src/migrations/2018-06-13-213130_add_audit/up.sql
+++ b/components/builder-originsrv/src/migrations/2018-06-13-213130_add_audit/up.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS audit (
+  origin_id bigint,
+  package_id bigint,
+  channel_id bigint,
+  operation smallint,
+  trigger smallint,
+  requester_id bigint,
+  requester_name text,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION add_audit_entry_v1 (
+  p_origin_id bigint,
+  p_package_id bigint,
+  p_channel_id bigint,
+  p_operation smallint,
+  p_trigger smallint,
+  p_requester_id bigint,
+  p_requester_name text
+) RETURNS SETOF audit AS $$
+INSERT INTO audit (origin_id, package_id, channel_id, operation, trigger, requester_id, requester_name)
+VALUES (p_origin_id, p_package_id, p_channel_id, p_operation, p_trigger, p_requester_id, p_requester_name)
+RETURNING *;
+$$ LANGUAGE SQL VOLATILE;

--- a/components/builder-originsrv/src/server/handlers.rs
+++ b/components/builder-originsrv/src/server/handlers.rs
@@ -33,6 +33,23 @@ pub fn origin_check_access(
     Ok(())
 }
 
+pub fn package_channel_audit(
+    req: &mut Message,
+    conn: &mut RouteConn,
+    state: &mut ServerState,
+) -> SrvResult<()> {
+    let msg = req.parse::<proto::PackageChannelAudit>()?;
+    match state.datastore.package_channel_audit(&msg) {
+        Ok(()) => conn.route_reply(req, &net::NetOk::new())?,
+        Err(e) => {
+            let err = NetError::new(ErrCode::DATA_STORE, "vt:package-channel-audit:1");
+            error!("{}, {}", err, e);
+            conn.route_reply(req, &*err)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn origin_check_owner(
     req: &mut Message,
     conn: &mut RouteConn,

--- a/components/builder-originsrv/src/server/mod.rs
+++ b/components/builder-originsrv/src/server/mod.rs
@@ -273,6 +273,10 @@ lazy_static! {
             MyOriginsRequest::descriptor_static(None),
             handlers::my_origins,
         );
+        map.register(
+            PackageChannelAudit::descriptor_static(None),
+            handlers::package_channel_audit,
+        );
         map
     };
 }

--- a/components/builder-protocol/protocols/originsrv.proto
+++ b/components/builder-protocol/protocols/originsrv.proto
@@ -15,6 +15,27 @@ message AccountInvitationListResponse {
   repeated OriginInvitation invitations = 2;
 }
 
+enum PackageChannelTrigger {
+  Unknown = 0;
+  BuilderUI = 1;
+  HabClient = 2;
+}
+
+enum PackageChannelOperation {
+  Promote = 0;
+  Demote = 1;
+}
+
+message PackageChannelAudit {
+  optional uint64 package_id = 1;
+  optional uint64 channel_id = 2;
+  optional PackageChannelOperation operation = 3;
+  optional PackageChannelTrigger trigger = 4;
+  optional uint64 requester_id = 5;
+  optional string requester_name = 6;
+  optional uint64 origin_id = 7;
+}
+
 message CheckOriginAccessRequest {
   oneof account_info {
     uint64 account_id = 1;

--- a/components/builder-protocol/src/error.rs
+++ b/components/builder-protocol/src/error.rs
@@ -24,6 +24,8 @@ pub enum ProtocolError {
     BadJobGroupProjectState(String),
     BadJobGroupState(String),
     BadJobState(String),
+    BadPackageChannelOperation(String),
+    BadPackageChannelTrigger(String),
     BadSearchEntity(String),
     BadSearchKey(String),
     Decode(protobuf::ProtobufError),
@@ -45,6 +47,12 @@ impl fmt::Display for ProtocolError {
             }
             ProtocolError::BadJobGroupState(ref e) => format!("Bad Job Group State {}", e),
             ProtocolError::BadJobState(ref e) => format!("Bad Job State {}", e),
+            ProtocolError::BadPackageChannelOperation(ref e) => {
+                format!("Bad Package Channel Operation {}", e)
+            }
+            ProtocolError::BadPackageChannelTrigger(ref e) => {
+                format!("Bad Package Channel Trigger {}", e)
+            }
             ProtocolError::BadSearchEntity(ref e) => {
                 format!("Search not implemented for entity, {}", e)
             }
@@ -78,6 +86,12 @@ impl error::Error for ProtocolError {
             ProtocolError::BadJobGroupProjectState(_) => "Job Group Project state cannot be parsed",
             ProtocolError::BadJobGroupState(_) => "Job Group state cannot be parsed",
             ProtocolError::BadJobState(_) => "Job state cannot be parsed",
+            ProtocolError::BadPackageChannelOperation(_) => {
+                "Package Channel Operation cannot be parsed"
+            }
+            ProtocolError::BadPackageChannelTrigger(_) => {
+                "Package Channel Trigger cannot be parsed"
+            }
             ProtocolError::BadSearchEntity(_) => "Search not implemented for entity.",
             ProtocolError::BadSearchKey(_) => "Entity not indexed by the given key.",
             ProtocolError::Decode(_) => "Unable to decode protocol message",


### PR DESCRIPTION
This writes an entry into an `audit` table every time a package is promoted or demoted.  It includes the package, the channel, what type of operation (promote/demote), the source that triggered the promotion/demotion (hab CLI, Builder UI, unknown), and the user that triggered it.  It mostly follows the pattern of audit logs from jobsrv, with a few slight tweaks.

![](https://media.giphy.com/media/baEBj7dzj7IRy/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>