### PR TITLE
Remove hab-butterfly from bootstrap consumption

### DIFF
--- a/terraform/scripts/install_base_packages.sh
+++ b/terraform/scripts/install_base_packages.sh
@@ -57,8 +57,7 @@ s3_root_url="https://s3-us-west-2.amazonaws.com/habitat-builder-bootstrap"
 # Supervisor.
 sup_packages=(hab-launcher
               hab
-              hab-sup
-              hab-butterfly)
+              hab-sup)
 
 # Helper for syslog logging
 helper_packages=(nmap)


### PR DESCRIPTION
We no longer ship hab-butterfly in the bootstrap bundle, and need to remove it from the bootstrap consumption.

Signed-off-by: Salim Alam <salam@chef.io>