### PR TITLE
Restore the banner

### DIFF
--- a/components/builder-web/app/banner/banner.component.html
+++ b/components/builder-web/app/banner/banner.component.html
@@ -1,7 +1,7 @@
 <div [class.hidden]="!hidden">
   <span>
-    Base plans refresh is coming Tuesday, June 19th!
-    <a href="https://www.habitat.sh/blog/2018/06/base-plans-refresh/" target="_blank">Find out more here</a>.
+    Builder Depot is now available for on-premises installations!
+    <a href="https://www.habitat.sh/blog/2018/05/On-Prem-Builder/" target="_blank">Read the announcement</a>.
   </span>
   <hab-icon symbol="cancel" class="dismiss" (click)="dismiss()"></hab-icon>
 </div>


### PR DESCRIPTION
This change restores the banner that was in place prior to the base-plans refresh.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://media0.giphy.com/media/hQGATPbS2Ngje/200w.gif)