### PR TITLE
Change `hab start` to `hab sup run` in db test script

### DIFF
--- a/components/builder-db/tests/db/start.sh
+++ b/components/builder-db/tests/db/start.sh
@@ -20,7 +20,7 @@ fi
 mkdir -p /hab/svc/postgresql
 cp $DB_TEST_DIR/pg_hba.conf /hab/svc/postgresql
 cp $DB_TEST_DIR/user.toml /hab/svc/postgresql
-hab start core/postgresql &
+hab sup run core/postgresql &
 hab_pid=$!
 
 sudo_ppid=$(ps -p $$ -o 'ppid=')


### PR DESCRIPTION
As of v0.56, `hab start` (an alias for `hab svc start`), won't start a
supervisor, so we have to use `hab sup run` instead.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>