### PR TITLE
Update API node terraform for S3

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -120,10 +120,6 @@ variable "instance_size_worker" {
   description = "AWS instance size for builder-worker server(s)"
 }
 
-variable "api_ebs_volume_id" {
-  description = "ID for EBS volume to attach to the API server"
-}
-
 variable "database_ebs_volume_id" {
   description = "ID for EBS volume to attach to the database server"
 }

--- a/terraform/volumes.tf
+++ b/terraform/volumes.tf
@@ -1,9 +1,3 @@
-resource "aws_volume_attachment" "api" {
-  device_name = "/dev/xvdf"
-  volume_id   = "${var.api_ebs_volume_id}"
-  instance_id = "${aws_instance.api.id}"
-}
-
 resource "aws_volume_attachment" "database" {
   device_name = "/dev/xvdf"
   volume_id   = "${var.database_ebs_volume_id}"


### PR DESCRIPTION
This removes the need for Terraform to attach a volume for artifacts to the API node.  

This should only be merged when the corresponding change in cloud-environments is also merged, and after validation is complete.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-114339315](https://user-images.githubusercontent.com/13542112/41803799-bf9adc0e-7641-11e8-896f-c4feb2e8828a.gif)
