### PR TITLE
Pin everything to use pre-refresh core plans

### DIFF
--- a/components/airlock/plan.sh
+++ b/components/airlock/plan.sh
@@ -3,8 +3,17 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 # The result is a portable, static binary in a zero-dependency package.
-pkg_deps=(core/shadow core/iproute2)
-pkg_build_deps=(core/musl core/coreutils core/rust core/gcc core/git)
+pkg_deps=(
+  core/shadow/4.5/20180419152453
+  core/iproute2/4.16.0/20180426175334
+)
+pkg_build_deps=(
+  core/musl/1.1.18/20180310000919
+  core/coreutils/8.25/20170513213226
+  core/rust/1.26.2/20180606182054
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+)
 pkg_bin_dirs=(bin)
 
 bin="$pkg_name"

--- a/components/builder-api-proxy/habitat/plan.sh
+++ b/components/builder-api-proxy/habitat/plan.sh
@@ -3,15 +3,19 @@ pkg_name=builder-api-proxy
 pkg_description="HTTP Proxy service fronting the Habitat Builder API service"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
-pkg_deps=(core/nginx core/curl core/coreutils)
+pkg_deps=(
+  core/nginx/1.13.10/20180502174530
+  core/curl/7.54.1/20180419094759
+  core/coreutils/8.25/20170513213226
+)
 pkg_build_deps=(
-  core/node8
-  core/gcc
-  core/git
-  core/tar
-  core/phantomjs
-  core/python2
-  core/make
+  core/node8/8.6.0/20171102163558
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+  core/tar/1.29/20170513213607
+  core/phantomjs/2.1.1/20180423190907
+  core/python2/2.7.14/20180419094026
+  core/make/4.2.1/20170513214620
 )
 pkg_svc_user="root"
 pkg_svc_run="nginx -c ${pkg_svc_config_path}/nginx.conf"

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -4,10 +4,26 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(core/glibc core/openssl core/coreutils core/gcc-libs core/zeromq core/libsodium
-core/libarchive core/curl)
-pkg_build_deps=(core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
-core/rust core/gcc core/git core/pkg-config)
+pkg_deps=(
+  core/glibc/2.22/20170513201042
+  core/openssl/1.0.2l/20171014213633
+  core/coreutils/8.25/20170513213226
+  core/gcc-libs/5.2.0/20170513212920
+  core/zeromq/4.2.5/20180407102804
+  core/libsodium/1.0.13/20170905223149
+  core/libarchive/3.3.2/20171018164107
+  core/curl/7.54.1/20171014214153
+)
+pkg_build_deps=(
+  core/protobuf-cpp/3.5.0/20180418230816
+  core/protobuf-rust/1.4.4/20180418221745
+  core/coreutils/8.25/20170513213226
+  core/cacerts/2017.09.20/20171014212239
+  core/rust/1.26.2/20180606182054
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+  core/pkg-config/0.29/20170513212944
+)
 pkg_exports=(
   [port]=http.port
 )

--- a/components/builder-datastore/plan.sh
+++ b/components/builder-datastore/plan.sh
@@ -3,8 +3,12 @@ pkg_name=builder-datastore
 pkg_description="Datastore service for a Habitat Builder service"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
-pkg_deps=(core/postgresql)
-pkg_build_deps=(core/git)
+pkg_deps=(
+  core/postgresql/9.6.8/20180426174635
+)
+pkg_build_deps=(
+  core/git/2.14.2/20180416203520
+)
 pkg_exports=(
   [port]=port
 )

--- a/components/builder-graph/habitat/plan.sh
+++ b/components/builder-graph/habitat/plan.sh
@@ -4,10 +4,30 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive
-  core/zlib core/hab-studio core/curl core/postgresql)
-pkg_build_deps=(core/make core/cmake core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
-  core/rust core/gcc core/git core/pkg-config)
+pkg_deps=(
+  core/glibc/2.22/20170513201042
+  core/openssl/1.0.2l/20180419014054
+  core/gcc-libs/5.2.0/20170513212920
+  core/zeromq/4.2.5/20180407102804
+  core/libsodium/1.0.13/20170905223149
+  core/libarchive/3.3.2/20171018164107
+  core/zlib/1.2.8/20170513201911
+  core/hab-studio
+  core/curl/7.54.1/20180419094759
+  core/postgresql/9.6.8/20180426174635
+)
+pkg_build_deps=(
+  core/make/4.2.1/20170513214620
+  core/cmake/3.10.2/20180418232649
+  core/protobuf-cpp/3.5.0/20180418230816
+  core/protobuf-rust/1.4.4/20180418221745
+  core/coreutils/8.25/20170513213226
+  core/cacerts/2017.09.20/20171014212239
+  core/rust/1.26.2/20180606182054
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+  core/pkg-config/0.29/20170513212944
+)
 bin="bldr-graph"
 
 do_prepare() {

--- a/components/builder-jobsrv/habitat/plan.sh
+++ b/components/builder-jobsrv/habitat/plan.sh
@@ -4,10 +4,25 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive
-  core/postgresql)
-pkg_build_deps=(core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
-  core/rust core/gcc core/git core/pkg-config)
+pkg_deps=(
+  core/glibc/2.22/20170513201042
+  core/openssl/1.0.2l/20171014213633
+  core/gcc-libs/5.2.0/20170513212920
+  core/zeromq/4.2.5/20180407102804
+  core/libsodium/1.0.13/20170905223149
+  core/libarchive/3.3.2/20171018164107
+  core/postgresql/9.6.8/20180426174635
+)
+pkg_build_deps=(
+  core/protobuf-cpp/3.5.0/20180418230816
+  core/protobuf-rust/1.4.4/20180418221745
+  core/coreutils/8.25/20170513213226
+  core/cacerts/2017.09.20/20171014212239
+  core/rust/1.26.2/20180606182054
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+  core/pkg-config/0.29/20170513212944
+)
 pkg_exports=(
   [worker_port]=net.worker_command_port
   [worker_heartbeat]=net.worker_heartbeat_port

--- a/components/builder-minio/habitat/plan.sh
+++ b/components/builder-minio/habitat/plan.sh
@@ -3,7 +3,11 @@ pkg_version="0.1.0"
 pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/minio core/cacerts core/openssl)
+pkg_deps=(
+  core/minio/2018-05-11T00-29-24Z/20180515134704
+  core/cacerts/2017.09.20/20171014212239
+  core/openssl/1.0.2l/20180419014054
+)
 
 do_unpack() {
     return 0

--- a/components/builder-originsrv/habitat/plan.sh
+++ b/components/builder-originsrv/habitat/plan.sh
@@ -4,10 +4,25 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive
-  core/postgresql)
-pkg_build_deps=(core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
-  core/rust core/gcc core/git core/pkg-config)
+pkg_deps=(
+  core/glibc/2.22/20170513201042
+  core/openssl/1.0.2l/20171014213633
+  core/gcc-libs/5.2.0/20170513212920
+  core/zeromq/4.2.5/20180407102804
+  core/libsodium/1.0.13/20170905223149
+  core/libarchive/3.3.2/20171018164107
+  core/postgresql/9.6.8/20180426174635
+)
+pkg_build_deps=(
+  core/protobuf-cpp/3.5.0/20180418230816
+  core/protobuf-rust/1.4.4/20180418221745
+  core/coreutils/8.25/20170513213226
+  core/cacerts/2017.09.20/20171014212239
+  core/rust/1.26.2/20180606182054
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+  core/pkg-config/0.29/20170513212944
+)
 pkg_binds=(
   [router]="port"
   [datastore]="port"

--- a/components/builder-router/habitat/plan.sh
+++ b/components/builder-router/habitat/plan.sh
@@ -4,9 +4,24 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
-pkg_build_deps=(core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
-  core/rust core/gcc core/git core/pkg-config)
+pkg_deps=(
+  core/glibc/2.22/20170513201042
+  core/openssl/1.0.2l/20171014213633
+  core/gcc-libs/5.2.0/20170513212920
+  core/zeromq/4.2.5/20180407102804
+  core/libsodium/1.0.13/20170905223149
+  core/libarchive/3.3.2/20171018164107
+)
+pkg_build_deps=(
+  core/protobuf-cpp/3.5.0/20180418230816
+  core/protobuf-rust/1.4.4/20180418221745
+  core/coreutils/8.25/20170513213226
+  core/cacerts/2017.09.20/20171014212239
+  core/rust/1.26.2/20180606182054
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+  core/pkg-config/0.29/20170513212944
+)
 pkg_exports=(
   [port]=port
 )

--- a/components/builder-sessionsrv/habitat/plan.sh
+++ b/components/builder-sessionsrv/habitat/plan.sh
@@ -4,10 +4,25 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive
-  core/postgresql)
-pkg_build_deps=(core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
-  core/rust core/gcc core/git core/pkg-config)
+pkg_deps=(
+  core/glibc/2.22/20170513201042
+  core/openssl/1.0.2l/20171014213633
+  core/gcc-libs/5.2.0/20170513212920
+  core/zeromq/4.2.5/20180407102804
+  core/libsodium/1.0.13/20170905223149
+  core/libarchive/3.3.2/20171018164107
+  core/postgresql/9.6.8/20180426174635
+)
+pkg_build_deps=(
+  core/protobuf-cpp/3.5.0/20180418230816
+  core/protobuf-rust/1.4.4/20180418221745
+  core/coreutils/8.25/20170513213226
+  core/cacerts/2017.09.20/20171014212239
+  core/rust/1.26.2/20180606182054
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+  core/pkg-config/0.29/20170513212944
+)
 pkg_binds=(
   [router]="port"
   [datastore]="port"

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -4,11 +4,32 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(habitat/airlock core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
-  core/libarchive core/zlib core/hab-studio core/hab-pkg-export-docker
-  core/docker core/curl)
-pkg_build_deps=(core/make core/cmake core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
-  core/rust core/gcc core/git core/pkg-config)
+pkg_deps=(
+  habitat/airlock/2374/20180530003916
+  core/hab-studio
+  core/hab-pkg-export-docker
+  core/docker/18.03.0/20180403182455
+  core/curl/7.54.1/20171014214153
+  core/glibc/2.22/20170513201042
+  core/openssl/1.0.2l/20171014213633
+  core/gcc-libs/5.2.0/20170513212920
+  core/zeromq/4.2.5/20180407102804
+  core/libsodium/1.0.13/20170905223149
+  core/libarchive/3.3.2/20171018164107
+  core/zlib/1.2.8/20170513201911
+)
+pkg_build_deps=(
+  core/make/4.2.1/20170513214620
+  core/cmake/3.10.2/20180418232649
+  core/protobuf-cpp/3.5.0/20180418230816
+  core/protobuf-rust/1.4.4/20180418221745
+  core/coreutils/8.25/20170513213226
+  core/cacerts/2017.09.20/20171014212239
+  core/rust/1.26.2/20180606182054
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+  core/pkg-config/0.29/20170513212944
+)
 pkg_binds=(
   [jobsrv]="worker_port worker_heartbeat log_port"
   [depot]="url"

--- a/components/op/habitat/plan.sh
+++ b/components/op/habitat/plan.sh
@@ -4,8 +4,23 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive
-  core/postgresql)
-pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts
-  core/rust core/gcc core/git core/pkg-config)
+pkg_deps=(
+  core/glibc/2.22/20170513201042
+  core/openssl/1.0.2l/20180419014054
+  core/gcc-libs/5.2.0/20170513212920
+  core/zeromq/4.2.5/20180407102804
+  core/libsodium/1.0.13/20170905223149
+  core/libarchive/3.3.2/20171018164107
+  core/postgresql/9.6.8/20180426174635
+)
+pkg_build_deps=(
+  core/protobuf/2.6.1/20180418230751
+  core/protobuf-rust/1.4.4/20180418221745
+  core/coreutils/8.25/20170513213226
+  core/cacerts/2017.09.20/20171014212239
+  core/rust/1.26.2/20180606182054
+  core/gcc/5.2.0/20170513202244
+  core/git/2.14.2/20180416203520
+  core/pkg-config/0.29/20170513212944
+)
 bin="op"


### PR DESCRIPTION
This is the builder equivalent of https://github.com/habitat-sh/habitat/pull/5238

With this change, the builder dev env works again.

![](https://media.giphy.com/media/mBaNKEmk9SUKs/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>