### PR TITLE
Add support for multiple API nodes

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "api" {
   instance_type = "${var.instance_size_api}"
   key_name      = "${var.aws_key_pair}"
   subnet_id     = "${var.public_subnet_id}"
-  count         = 1
+  count         = "${var.api_count}"
 
   vpc_security_group_ids = [
     "${var.aws_admin_sg}",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -100,6 +100,10 @@ variable "jobsrv_worker_count" {
   description = "Number of JobSrv workers to start"
 }
 
+variable "api_count" {
+  description = "Number of frontend/API nodes to start"
+}
+
 variable "connection_agent" {
   description = "Set to false to disable using ssh-agent to authenticate"
 }


### PR DESCRIPTION
Add support for multiple API nodes (defaults to 2).  

This should be merged with the corresponding change in the cloud-environments repo.

Signed-off-by: Salim Alam <salam@chef.io>