### PR TITLE
Add auditing for job groups.

### DIFF
--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -120,7 +120,7 @@ impl DataStore {
         let conn = self.pool.get(pca)?;
 
         &conn.query(
-            "SELECT * FROM add_audit_entry_v1($1, $2, $3, $4, $5, $6, $7)",
+            "SELECT * FROM add_audit_package_entry_v1($1, $2, $3, $4, $5, $6, $7)",
             &[
                 &(pca.get_origin_id() as i64),
                 &(pca.get_package_id() as i64),
@@ -131,6 +131,35 @@ impl DataStore {
                 &pca.get_requester_name().to_string(),
             ],
         ).map_err(SrvError::PackageChannelAudit)?;
+
+        Ok(())
+    }
+
+    pub fn package_group_channel_audit(
+        &self,
+        pgca: &originsrv::PackageGroupChannelAudit,
+    ) -> SrvResult<()> {
+        let conn = self.pool.get(pgca)?;
+
+        let pkg_ids: Vec<i64> = pgca.get_package_ids()
+            .to_vec()
+            .iter()
+            .map(|&x| x as i64)
+            .collect();
+
+        &conn.query(
+            "SELECT * FROM add_audit_package_group_entry_v1($1, $2, $3, $4, $5, $6, $7, $8)",
+            &[
+                &(pgca.get_origin_id() as i64),
+                &(pgca.get_channel_id() as i64),
+                &pkg_ids,
+                &(pgca.get_operation() as i16),
+                &(pgca.get_trigger() as i16),
+                &(pgca.get_requester_id() as i64),
+                &pgca.get_requester_name().to_string(),
+                &(pgca.get_group_id() as i64),
+            ],
+        ).map_err(SrvError::PackageGroupChannelAudit)?;
 
         Ok(())
     }

--- a/components/builder-originsrv/src/error.rs
+++ b/components/builder-originsrv/src/error.rs
@@ -109,6 +109,7 @@ pub enum SrvError {
     OriginAccountList(postgres::error::Error),
     OriginAccountInOrigin(postgres::error::Error),
     PackageChannelAudit(postgres::error::Error),
+    PackageGroupChannelAudit(postgres::error::Error),
     Protocol(protocol::ProtocolError),
     SyncInvitations(postgres::error::Error),
     SyncInvitationsUpdate(postgres::error::Error),
@@ -354,6 +355,9 @@ impl fmt::Display for SrvError {
             SrvError::PackageChannelAudit(ref e) => {
                 format!("Error auditing package channel rank change, {}", e)
             }
+            SrvError::PackageGroupChannelAudit(ref e) => {
+                format!("Error auditing package group channel rank change, {}", e)
+            }
             SrvError::Protocol(ref e) => format!("{}", e),
             SrvError::SyncInvitations(ref e) => {
                 format!("Error syncing invitations for account, {}", e)
@@ -455,6 +459,7 @@ impl error::Error for SrvError {
             SrvError::OriginAccountInOrigin(ref err) => err.description(),
             SrvError::OriginUpdate(ref err) => err.description(),
             SrvError::PackageChannelAudit(ref err) => err.description(),
+            SrvError::PackageGroupChannelAudit(ref err) => err.description(),
             SrvError::Protocol(ref err) => err.description(),
             SrvError::SyncInvitations(ref err) => err.description(),
             SrvError::SyncInvitationsUpdate(ref err) => err.description(),

--- a/components/builder-originsrv/src/migrations/2018-07-02-232814_add_package_group_audit/down.sql
+++ b/components/builder-originsrv/src/migrations/2018-07-02-232814_add_package_group_audit/down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS audit_package;
+DROP TABLE IF EXISTS audit_package_group;
+DROP FUNCTION IF EXISTS add_audit_package_entry_v1(bigint, bigint, bigint, smallint, smallint, bigint, text);
+DROP FUNCTION IF EXISTS add_audit_package_group_entry_v1(bigint, bigint, bigint[], smallint, smallint, bigint, text, bigint);

--- a/components/builder-originsrv/src/migrations/2018-07-02-232814_add_package_group_audit/up.sql
+++ b/components/builder-originsrv/src/migrations/2018-07-02-232814_add_package_group_audit/up.sql
@@ -1,0 +1,53 @@
+-- Creating the audit table again, because calling it "audit" was short-sighted
+CREATE TABLE IF NOT EXISTS audit_package (
+  origin_id bigint,
+  package_id bigint,
+  channel_id bigint,
+  operation smallint,
+  trigger smallint,
+  requester_id bigint,
+  requester_name text,
+  created_at timestamptz DEFAULT now()
+);
+
+-- This is our new table
+CREATE TABLE IF NOT EXISTS audit_package_group (
+  origin_id bigint,
+  channel_id bigint,
+  package_ids bigint[],
+  operation smallint,
+  trigger smallint,
+  requester_id bigint,
+  requester_name text,
+  group_id bigint,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION add_audit_package_entry_v1 (
+  p_origin_id bigint,
+  p_package_id bigint,
+  p_channel_id bigint,
+  p_operation smallint,
+  p_trigger smallint,
+  p_requester_id bigint,
+  p_requester_name text
+) RETURNS SETOF audit_package AS $$
+INSERT INTO audit_package (origin_id, package_id, channel_id, operation, trigger, requester_id, requester_name)
+VALUES (p_origin_id, p_package_id, p_channel_id, p_operation, p_trigger, p_requester_id, p_requester_name)
+RETURNING *;
+$$ LANGUAGE SQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION add_audit_package_group_entry_v1 (
+  p_origin_id bigint,
+  p_channel_id bigint,
+  p_package_ids bigint[],
+  p_operation smallint,
+  p_trigger smallint,
+  p_requester_id bigint,
+  p_requester_name text,
+  p_group_id bigint
+) RETURNS SETOF audit_package_group AS $$
+INSERT INTO audit_package_group (origin_id, channel_id, package_ids, operation, trigger, requester_id, requester_name, group_id)
+VALUES (p_origin_id, p_channel_id, p_package_ids, p_operation, p_trigger, p_requester_id, p_requester_name, p_group_id)
+RETURNING *;
+$$ LANGUAGE SQL VOLATILE;

--- a/components/builder-originsrv/src/server/handlers.rs
+++ b/components/builder-originsrv/src/server/handlers.rs
@@ -50,6 +50,23 @@ pub fn package_channel_audit(
     Ok(())
 }
 
+pub fn package_group_channel_audit(
+    req: &mut Message,
+    conn: &mut RouteConn,
+    state: &mut ServerState,
+) -> SrvResult<()> {
+    let msg = req.parse::<proto::PackageGroupChannelAudit>()?;
+    match state.datastore.package_group_channel_audit(&msg) {
+        Ok(()) => conn.route_reply(req, &net::NetOk::new())?,
+        Err(e) => {
+            let err = NetError::new(ErrCode::DATA_STORE, "vt:package-group-channel-audit:1");
+            error!("{}, {}", err, e);
+            conn.route_reply(req, &*err)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn origin_check_owner(
     req: &mut Message,
     conn: &mut RouteConn,

--- a/components/builder-originsrv/src/server/mod.rs
+++ b/components/builder-originsrv/src/server/mod.rs
@@ -277,6 +277,10 @@ lazy_static! {
             PackageChannelAudit::descriptor_static(None),
             handlers::package_channel_audit,
         );
+        map.register(
+            PackageGroupChannelAudit::descriptor_static(None),
+            handlers::package_group_channel_audit,
+        );
         map
     };
 }

--- a/components/builder-protocol/protocols/originsrv.proto
+++ b/components/builder-protocol/protocols/originsrv.proto
@@ -26,6 +26,17 @@ enum PackageChannelOperation {
   Demote = 1;
 }
 
+message PackageGroupChannelAudit {
+  optional uint64 origin_id = 1;
+  optional uint64 channel_id = 2;
+  repeated uint64 package_ids = 3 [packed=true];
+  optional PackageChannelOperation operation = 4;
+  optional PackageChannelTrigger trigger = 5;
+  optional uint64 requester_id = 6;
+  optional string requester_name = 7;
+  optional uint64 group_id = 8;
+}
+
 message PackageChannelAudit {
   optional uint64 package_id = 1;
   optional uint64 channel_id = 2;

--- a/components/builder-protocol/src/originsrv.rs
+++ b/components/builder-protocol/src/originsrv.rs
@@ -109,6 +109,14 @@ impl Routable for PackageChannelAudit {
     }
 }
 
+impl Routable for PackageGroupChannelAudit {
+    type H = u64;
+
+    fn route_key(&self) -> Option<Self::H> {
+        Some(self.get_origin_id())
+    }
+}
+
 pub trait Pageable {
     fn get_range(&self) -> [u64; 2];
 


### PR DESCRIPTION
I also added some new tables and functions for package auditing, which
effectively abandons the existing tables. This felt like the right move,
though, given the need for multiple auditing tables. Having one called
just "audit" seemed like a bad idea in hindsight. We can leave the old
stuff around for awhile and delete it later on down the road.

It's also worth noting that this code hasn't been tested yet. I spent the entire day trying to get builds working in my local dev env and couldn't.  If someone has builds working in their env, maybe they can test this, or alternatively, we could test it in acceptance.

![](https://media.giphy.com/media/OongkSFTbly8w/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>