### PR TITLE
Mount drive to /mnt, NOT /hab

### DIFF
--- a/terraform/scripts/foundation.sh
+++ b/terraform/scripts/foundation.sh
@@ -6,7 +6,7 @@
 set -eux
 
 sudo mount /dev/xvdf /mnt
-echo '/dev/xvdf /hab     ext4   defaults 0 0' | sudo tee -a /etc/fstab
+echo '/dev/xvdf /mnt     ext4   defaults 0 0' | sudo tee -a /etc/fstab
 sudo mkdir -p /mnt/hab
 sudo ln -s /mnt/hab /hab
 


### PR DESCRIPTION
This made for unhappy VMs after a restart.

Signed-off-by: Christopher Maier <cmaier@chef.io>