### PR TITLE
Add config for rate limit

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -14,6 +14,7 @@ http {
   proxy_temp_path {{pkg.svc_var_path}}/nginx/proxy;
   scgi_temp_path {{pkg.svc_var_path}}/nginx/scgi_temp_path;
   uwsgi_temp_path {{pkg.svc_var_path}}/nginx/uwsgi;
+  limit_req_zone  {{cfg.nginx.limit_req_zone}};
 
   include        mime.types;
   default_type   application/octet-stream;
@@ -139,6 +140,7 @@ http {
 
     location ~* ^/v1/depot/.*/latest$ {
       add_header Cache-Control "private, no-cache, no-store";
+      limit_req zone=mylimit;
       proxy_pass http://backend;
     }
 
@@ -148,10 +150,12 @@ http {
       proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
       proxy_cache my_cache;
       proxy_pass http://backend;
+      limit_req zone=mylimit;
     }
 
     location /v1 {
       add_header Cache-Control "private, no-cache, no-store";
+      limit_req zone=mylimit;
       proxy_pass http://backend;
     }
   }

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -39,6 +39,7 @@ worker_rlimit_nofile = 8192
 max_body_size        = "1024m"
 proxy_send_timeout   = 60
 proxy_read_timeout   = 60
+limit_req_zone       = "$binary_remote_addr zone=mylimit:10m rate=1r/s"
 
 [http]
 keepalive_timeout = "20s"


### PR DESCRIPTION
This change adds the basic capability to rate limit calls to the builder API.  The default rate limit value is 1 req/sec.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-176671406](https://user-images.githubusercontent.com/13542112/42400234-998c3492-8125-11e8-932d-c63decd5e2be.gif)
