### PR TITLE
Automate running shellcheck (part 1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,13 @@ matrix:
 ########################################################################
 
 #
+# Job for linting Habitat shell program components
+#
+    - sudo: false
+      script:
+        - ./test/shellcheck.sh
+
+#
 # Job for testing Habitat Rust program components
 #
     - language: rust

--- a/components/airlock/plan.sh
+++ b/components/airlock/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2086,SC2154,SC2155
 pkg_name=airlock
 pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"

--- a/components/builder-api-proxy/habitat-dev/plan.sh
+++ b/components/builder-api-proxy/habitat-dev/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2046,SC2086,SC2154
 source ../habitat/plan.sh
 source ../../../support/ci/builder-dev-base-plan.sh
 

--- a/components/builder-api-proxy/habitat/plan.sh
+++ b/components/builder-api-proxy/habitat/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2046,SC2086,SC2154
 pkg_origin=habitat
 pkg_name=builder-api-proxy
 pkg_description="HTTP Proxy service fronting the Habitat Builder API service"

--- a/components/builder-db/tests/db/start.sh
+++ b/components/builder-db/tests/db/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 #
 # Oh habitat, how you bring me back to my most hack-worthy roots. I love you for it.
 #

--- a/components/builder-graph/habitat/plan.sh
+++ b/components/builder-graph/habitat/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2155
 source "../../../support/ci/builder-base-plan.sh"
 pkg_name=builder-graph
 pkg_origin=habitat

--- a/components/builder-worker/habitat-dev/plan.sh
+++ b/components/builder-worker/habitat-dev/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2155
 source ../habitat/plan.sh
 source ../../../support/ci/builder-dev-plan.sh
 

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2155
 source "../../../support/ci/builder-base-plan.sh"
 pkg_name=builder-worker
 pkg_origin=habitat

--- a/support/account_creation_report.sh
+++ b/support/account_creation_report.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2181
 
 set -eu
 

--- a/support/bash_completion.sh
+++ b/support/bash_completion.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2086,SC2128
 # Copyright:: Copyright (c) 2015-2016 The Habitat Maintainers
 #
 # The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.

--- a/support/builder/s3migrate.sh
+++ b/support/builder/s3migrate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2162
 set -euo pipefail
 
 aggMsg() {

--- a/support/ci/builder-base-plan.sh
+++ b/support/ci/builder-base-plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2154
 pkg_version() {
   # TED: After migrating the builder repo we needed to add to
   # the rev-count to keep version sorting working

--- a/support/ci/builder-dev-base-plan.sh
+++ b/support/ci/builder-dev-base-plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2154
 # For dev purposes only - this bypasses artifact creation and other important
 # parts of the full plan build process
 

--- a/support/ci/builder-dev-plan.sh
+++ b/support/ci/builder-dev-plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2154,SC2155
 source ../../../support/ci/builder-dev-base-plan.sh
 
 pkg_build_deps+=(core/sccache)

--- a/support/ci/compile_libarchive.sh
+++ b/support/ci/compile_libarchive.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2046,SC2086
 set -eu
 
 version=3.2.0

--- a/support/ci/compile_libsodium.sh
+++ b/support/ci/compile_libsodium.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2046,SC2086
 set -eu
 
 version=1.0.13

--- a/support/ci/compile_zmq.sh
+++ b/support/ci/compile_zmq.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2046,SC2086
 set -eu
 
 version=4.1.4

--- a/support/ci/fast_pass.sh
+++ b/support/ci/fast_pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 #
 # Check to see what directories have been affected by a change. If directories
 # have not been affected, exit 0

--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2002,SC2059,SC2086,SC2154,SC2162
 
 # Fail if there are any unset variables and whenever a command returns a
 # non-zero exit code.

--- a/support/ci/rust_tests.sh
+++ b/support/ci/rust_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2046,SC2086
 
 git log HEAD~1..HEAD | grep -q '!!! Temporary Commit !!!'
 is_tmp_commit=$?

--- a/support/ci/what_changed.sh
+++ b/support/ci/what_changed.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 
 # Determine what changed since our last merge commit.
 #

--- a/terraform/scripts/create_bootstrap_bundle.sh
+++ b/terraform/scripts/create_bootstrap_bundle.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086,SC2129
 
 # Create a tarball of all the Habitat artifacts needed to run the
 # Habitat Supervisor on a system and upload it to S3. This includes

--- a/terraform/scripts/install_base_packages.sh
+++ b/terraform/scripts/install_base_packages.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2068,SC2071,SC2073,SC2086
 
 # Downloads the latest builder bootstrap tarball from S3 and installs
 # the desired packages into /hab/cache/artifacts. All

--- a/test/builder-api/bin/cleanup-integration-tests.sh
+++ b/test/builder-api/bin/cleanup-integration-tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 
 # You might be asking yourself "Why does this file even exist?" The answer to that question lies
 # in the amount of time it takes to run 'test.sh'. Since test.sh is designed to be run in CI,

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+shellcheck --version
+
+# Run shellcheck against any files that appear to be shell script based on
+# filename or `file` output
+#
+# Exclude *.sample files because they are automatically created by git
+#
+# Exclude *.ps1 files because shellcheck doesn't support them
+#
+# Exclude the following shellcheck issues since they're pervasive and innocuous:
+# https://github.com/koalaman/shellcheck/wiki/SC1090
+# https://github.com/koalaman/shellcheck/wiki/SC1091
+# https://github.com/koalaman/shellcheck/wiki/SC2148
+# https://github.com/koalaman/shellcheck/wiki/SC2034
+find . -type f \
+  -and \( -name "*.*sh" \
+      -or -exec sh -c 'file -b "$1" | grep -q "shell script"' {} \; \) \
+  -and \! -path "*.sample" \
+  -and \! -path "*.ps1" \
+  -and \! -path "./test/builder-api/node_modules/*" \
+  -print \
+  | xargs shellcheck --external-sources --exclude=1090,1091,2148,2034
+
+echo "shellcheck found no errors"

--- a/tools/bulk_promote/promote.sh
+++ b/tools/bulk_promote/promote.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 
 # This script takes as input a path to a file of idents, and a channel
 # and promotes all the packages listed in the file to the specified

--- a/tools/hab-channel-list-pkgs/hab-channel-list-pkgs.sh
+++ b/tools/hab-channel-list-pkgs/hab-channel-list-pkgs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2004,SC2086
 #
 # Returns a list of all fully qualified package identifiers that exist in an
 # origin's release channel. Prints the package identifiers to standard out, one

--- a/tools/ssh_helpers/airlock.sh
+++ b/tools/ssh_helpers/airlock.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2013,SC2029
 
 environment=${1}
 

--- a/tools/ssh_helpers/generate-habitat-env-tmuxinator.sh
+++ b/tools/ssh_helpers/generate-habitat-env-tmuxinator.sh
@@ -1,5 +1,5 @@
-
 #!/bin/bash
+# shellcheck disable=SC2013
 
 # Given an "environment", generates a tmuxinator YAML on STDOUT to
 # connect to all the Habitat Builder hosts in that environment.


### PR DESCRIPTION
The first stage is to add the automation to run [`shellcheck`](https://www.shellcheck.net) in travis with all the errors suppressed. Then, in small, non-bombastic, PRs, fix the lints and remove the suppressions.

See https://github.com/habitat-sh/habitat/issues/4170