### PR TITLE
Fix shellcheck lints for CI supporting scripts

### DIFF
--- a/support/ci/fast_pass.sh
+++ b/support/ci/fast_pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2086
 #
 # Check to see what directories have been affected by a change. If directories
 # have not been affected, exit 0
@@ -37,16 +36,19 @@ else
   echo
   echo "Checking for changed files since last merge commit:"
   echo
+  # shellcheck disable=2086
   echo_indented $CHANGED_FILES
   echo
 
   echo "Among the affected files:"
   echo
+  # shellcheck disable=2086
   echo_indented $AFFECTED_FILES
   echo
 
   echo "And in the affected directories:"
   echo
+  # shellcheck disable=2086
   echo_indented $AFFECTED_DIRS
   echo
 

--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2002,SC2059,SC2086,SC2154,SC2162
 
 # Fail if there are any unset variables and whenever a command returns a
 # non-zero exit code.
@@ -14,10 +13,10 @@ fi
 info() {
   case "${TERM:-}" in
     *term | xterm-* | rxvt | screen | screen-*)
-      printf -- "   \033[1;32m${program}: \033[1;37m$1\033[0m\n"
+      printf -- "   \033[1;32m%s: \033[1;37m%s\033[0m\n" "${program}" "$1"
       ;;
     *)
-      printf -- "   ${program}: $1\n"
+      printf -- "   %s: %s\n" "${program}" "$1"
       ;;
   esac
   return 0
@@ -29,7 +28,7 @@ warn() {
       >&2 echo -e "   \033[1;32m${program}: \033[1;33mWARN \033[1;37m$1\033[0m"
       ;;
     *)
-      >&2 echo "   ${pkg_name}: WARN $1"
+      >&2 echo "   ${program}: WARN $1"
       ;;
   esac
   return 0
@@ -38,16 +37,16 @@ warn() {
 exit_with() {
   case "${TERM:-}" in
     *term | xterm-* | rxvt | screen | screen-*)
-      >&2 printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
+      >&2 printf -- "\033[1;31mERROR: \033[1;37m%s\033[0m\n" "$1"
       ;;
     *)
-      >&2 printf -- "ERROR: $1\n"
+      >&2 printf -- "ERROR: %s\n" "$1"
       ;;
   esac
-  exit $2
+  exit "$2"
 }
 
-program=$(basename $0)
+program=$(basename "$0")
 
 # Fix commit range in Travis, if set.
 # See: https://github.com/travis-ci/travis-ci/issues/4596
@@ -71,8 +70,9 @@ if ! command -v rustfmt >/dev/null; then
   exit_with "Program \`rustfmt' not found on PATH, aborting" 1
 fi
 
-failed="$(mktemp -t "$(basename $0)-failed-XXXX")"
-trap 'code=$?; rm -f $failed; exit $code' INT TERM EXIT
+failed="$(mktemp -t "$(basename "$0")-failed-XXXX")"
+# shellcheck disable=2154
+trap 'code=$?; rm -f "$failed"; exit $code' INT TERM EXIT
 
 if [[ -n "${LINT_ALL:-}" ]]; then
   cmd="find components -type f -name '*.rs'"
@@ -89,7 +89,7 @@ else
   info "Selecting files from Git via: '$cmd'"
 fi
 
-eval "$cmd" | while read file; do
+eval "$cmd" | while read -r file; do
   case "${file##*.}" in
     rs)
       if [ ! -e "$file" ]; then
@@ -108,7 +108,7 @@ eval "$cmd" | while read file; do
       case $rf_exit in
         0|3)
           if echo "$output" | grep -q "Diff at line " >/dev/null; then
-            warn "File $file generates a diff after running rustfmt $rf_version"
+            warn "File $file generates a diff after running rustfmt"
             warn "Perhaps you forgot to run \`rustfmt' or \`cargo fmt'?"
             warn "Diff for $file:"
             echo "$output"
@@ -132,13 +132,13 @@ eval "$cmd" | while read file; do
   esac
 done
 
-if [[ $(cat "$failed" | wc -l) -gt 0 ]]; then
+if [[ -s "$failed" ]]; then
   echo
   echo
   warn "Summary: One or more files failed linting:"
-  cat "$failed" | while read file; do
+  while read -r file; do
     warn "  * $file"
-  done
+  done < "$failed"
   exit_with "File(s) failed linting" 10
 else
   info "Summary: All checked files passed their lints."

--- a/support/ci/rust_tests.sh
+++ b/support/ci/rust_tests.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2046,SC2086
 
 git log HEAD~1..HEAD | grep -q '!!! Temporary Commit !!!'
 is_tmp_commit=$?
@@ -11,7 +10,7 @@ fi
 
 echo "--> Running $0"
 
-source $(dirname $0)/rust_env.sh
+source "$(dirname "$0")"/rust_env.sh
 
 set -e
-make unit-${COMPONENTS:-all}
+make unit-"${COMPONENTS:-all}"

--- a/support/ci/what_changed.sh
+++ b/support/ci/what_changed.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2086
 
 # Determine what changed since our last merge commit.
 #
@@ -18,4 +17,4 @@ if [ "${CURRENT_SHA}" == "${LATEST_MERGE_COMMIT}" ] ; then
     LATEST_MERGE_COMMIT="$(git log --merges --max-count=1 --skip=1 --pretty=format:%H)"
 fi
 
-git diff --name-only ${LATEST_MERGE_COMMIT}
+git diff --name-only "${LATEST_MERGE_COMMIT}"


### PR DESCRIPTION
Starting with the least risky changes, this is another bite-sized step towards https://github.com/habitat-sh/habitat/issues/4170.

This reverts the `shellcheck` suppressions in favor of actually fixing the lints.