### PR TITLE
Fix shellcheck lints for plan files

### DIFF
--- a/components/airlock/plan.sh
+++ b/components/airlock/plan.sh
@@ -1,4 +1,4 @@
-# shellcheck disable=SC2086,SC2154,SC2155
+# shellcheck disable=SC2034
 pkg_name=airlock
 pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
@@ -19,6 +19,7 @@ do_before() {
   update_pkg_version
 }
 
+# shellcheck disable=2154
 _common_prepare() {
   do_default_prepare
 
@@ -43,7 +44,8 @@ do_prepare() {
   # Used to find libgcc_s.so.1 when compiling `build.rs` in dependencies. Since
   # this used only at build time, we will use the version found in the gcc
   # package proper--it won't find its way into the final binaries.
-  export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
+  export LD_LIBRARY_PATH
+  LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
   build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 }
 
@@ -52,8 +54,9 @@ do_build() {
 }
 
 do_install() {
-  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
-    $pkg_prefix/bin/$bin
+  # shellcheck disable=2154
+  install -v -D "$CARGO_TARGET_DIR"/$rustc_target/${build_type#--}/$bin \
+    "$pkg_prefix"/bin/$bin
 }
 
 do_strip() {

--- a/components/builder-api-proxy/habitat-dev/plan.sh
+++ b/components/builder-api-proxy/habitat-dev/plan.sh
@@ -1,23 +1,24 @@
-# shellcheck disable=SC2046,SC2086,SC2154
 source ../habitat/plan.sh
 source ../../../support/ci/builder-dev-base-plan.sh
 
+# shellcheck disable=2034
 pkg_origin=habitat-dev
 
+# shellcheck disable=2154
 do_build() {
-  pushd $HAB_CACHE_SRC_PATH > /dev/null
+  pushd "$HAB_CACHE_SRC_PATH" > /dev/null
   export HOME=$HAB_CACHE_SRC_PATH
   export PATH=./node_modules/.bin:$PATH
   npm install
 
   for b in node_modules/.bin/*; do
-    fix_interpreter $(readlink -f -n $b) core/coreutils bin/env
+    fix_interpreter "$(readlink -f -n "$b")" core/coreutils bin/env
   done
 
   # NPM install creates an "etc' folder in the pkg_prefix dir
   # because we have a package that uses the PREFIX env var during install
   # We don't want pkg_prefix to have content, so delete the directory now
-  rm -rf ${pkg_prefix}
+  rm -rf "${pkg_prefix}"
 
   # Pass the release identifier to the bundle script to enable cache-busting
   # Create the dist with the currently installed package version number as we
@@ -25,7 +26,7 @@ do_build() {
   local pkg_path
   pkg_path=$(hab pkg path habitat/"$pkg_name")
   build_line "Creating the NPM dist with cache buster: ${pkg_path: -14}"
-  npm run dist -- ${pkg_path: -14}
+  npm run dist -- "${pkg_path: -14}"
 
   rm -rf dist/node_modules
   popd > /dev/null
@@ -34,7 +35,7 @@ do_build() {
 do_install() {
   # We don't want pkg_prefix to have content, so delete the directory before
   # install
-  rm -rf ${pkg_prefix}
+  rm -rf "${pkg_prefix}"
 
   local pkg_path
   pkg_path=$(hab pkg path habitat/"$pkg_name")

--- a/components/builder-api-proxy/habitat/plan.sh
+++ b/components/builder-api-proxy/habitat/plan.sh
@@ -1,4 +1,4 @@
-# shellcheck disable=SC2046,SC2086,SC2154
+# shellcheck disable=SC2034
 pkg_origin=habitat
 pkg_name=builder-api-proxy
 pkg_description="HTTP Proxy service fronting the Habitat Builder API service"
@@ -15,6 +15,7 @@ pkg_build_deps=(
   core/make
 )
 pkg_svc_user="root"
+# shellcheck disable=2154
 pkg_svc_run="nginx -c ${pkg_svc_config_path}/nginx.conf"
 pkg_exports=(
   [port]=server.listen_port
@@ -44,16 +45,17 @@ do_unpack() {
 }
 
 do_build() {
-  pushd $HAB_CACHE_SRC_PATH > /dev/null
+  pushd "$HAB_CACHE_SRC_PATH" > /dev/null
   export HOME=$HAB_CACHE_SRC_PATH
   export PATH=./node_modules/.bin:$PATH
   npm install
   for b in node_modules/.bin/*; do
-    fix_interpreter $(readlink -f -n $b) core/coreutils bin/env
+    fix_interpreter "$(readlink -f -n "$b")" core/coreutils bin/env
   done
 
   # Pass the release identifier to the bundle script to enable cache-busting
-  npm run dist -- ${pkg_prefix: -14}
+  # shellcheck disable=2154
+  npm run dist -- "${pkg_prefix: -14}"
 
   rm -rf dist/node_modules
   popd > /dev/null

--- a/components/builder-graph/habitat/plan.sh
+++ b/components/builder-graph/habitat/plan.sh
@@ -1,4 +1,4 @@
-# shellcheck disable=SC2155
+# shellcheck disable=SC2034
 source "../../../support/ci/builder-base-plan.sh"
 pkg_name=builder-graph
 pkg_origin=habitat
@@ -15,6 +15,7 @@ do_prepare() {
   do_builder_prepare
 
   # Used by libssh2-sys
-  export DEP_Z_ROOT="$(pkg_path_for zlib)"
-  export DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
+  export DEP_Z_ROOT DEP_Z_INCLUDE
+  DEP_Z_ROOT="$(pkg_path_for zlib)"
+  DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
 }

--- a/components/builder-worker/habitat-dev/plan.sh
+++ b/components/builder-worker/habitat-dev/plan.sh
@@ -1,4 +1,3 @@
-# shellcheck disable=SC2155
 source ../habitat/plan.sh
 source ../../../support/ci/builder-dev-plan.sh
 
@@ -6,8 +5,9 @@ do_prepare() {
   do_dev_prepare
 
   # Used by libssh2-sys
-  export DEP_Z_ROOT="$(pkg_path_for zlib)"
-  export DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
+  export DEP_Z_ROOT DEP_Z_INCLUDE
+  DEP_Z_ROOT="$(pkg_path_for zlib)"
+  DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
 
   # Compile the fully-qualified Studio package identifier into the binary
   PLAN_STUDIO_PKG_IDENT=$(pkg_path_for hab-studio | sed "s,^$HAB_PKG_PATH/,,")

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -1,4 +1,4 @@
-# shellcheck disable=SC2155
+# shellcheck disable=SC2034
 source "../../../support/ci/builder-base-plan.sh"
 pkg_name=builder-worker
 pkg_origin=habitat
@@ -22,8 +22,9 @@ do_prepare() {
   do_builder_prepare
 
   # Used by libssh2-sys
-  export DEP_Z_ROOT="$(pkg_path_for zlib)"
-  export DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
+  export DEP_Z_ROOT DEP_Z_INCLUDE
+  DEP_Z_ROOT="$(pkg_path_for zlib)"
+  DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
 
   # Compile the fully-qualified Studio package identifier into the binary
   PLAN_STUDIO_PKG_IDENT=$(pkg_path_for hab-studio | sed "s,^$HAB_PKG_PATH/,,")

--- a/support/ci/builder-base-plan.sh
+++ b/support/ci/builder-base-plan.sh
@@ -1,4 +1,3 @@
-# shellcheck disable=SC2154
 pkg_version() {
   # TED: After migrating the builder repo we needed to add to
   # the rev-count to keep version sorting working
@@ -36,10 +35,12 @@ do_builder_build() {
 }
 
 do_builder_install() {
+  # shellcheck disable=2154
   install -v -D "$CARGO_TARGET_DIR/$rustc_target/${builder_build_type#--}/$bin" \
     "$pkg_prefix/bin/$bin"
 }
 
+# shellcheck disable=2154
 do_builder_prepare() {
   export builder_build_type="${builder_build_type:---release}"
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/support/ci/builder-dev-base-plan.sh
+++ b/support/ci/builder-dev-base-plan.sh
@@ -1,4 +1,3 @@
-# shellcheck disable=SC2154
 # For dev purposes only - this bypasses artifact creation and other important
 # parts of the full plan build process
 
@@ -36,5 +35,6 @@ _build_metadata() {
 }
 
 do_end() {
+  # shellcheck disable=2154
   rm -rf "${pkg_prefix}/../../${pkg_version}"
 }

--- a/support/ci/builder-dev-plan.sh
+++ b/support/ci/builder-dev-plan.sh
@@ -1,14 +1,15 @@
-# shellcheck disable=SC2154,SC2155
 source ../../../support/ci/builder-dev-base-plan.sh
 
 pkg_build_deps+=(core/sccache)
+# shellcheck disable=2034
 pkg_origin=habitat-dev
 
 do_dev_prepare() {
   # Order matters here
   export CARGO_HOME="/tmp/cargo_cache"
   export builder_build_type="--debug"
-  export RUSTC_WRAPPER="$(pkg_path_for core/sccache)/bin/sccache"
+  export RUSTC_WRAPPER
+  RUSTC_WRAPPER="$(pkg_path_for core/sccache)/bin/sccache"
   export SCCACHE_DIR="/tmp/cargo_cache"
   export SCCACHE_START_SERVER=0
   do_builder_prepare
@@ -21,6 +22,7 @@ do_prepare() {
   do_dev_prepare
 }
 
+# shellcheck disable=2154
 do_builder_install() {
   local pkg_path
   pkg_path=$(hab pkg path habitat/"$pkg_name")


### PR DESCRIPTION
Continuing with the second least risky changes, this is another bite-sized step towards habitat-sh/habitat#4170.

This reverts the shellcheck suppressions in favor of actually fixing the lints.