### PR TITLE
[BREAKING/depot] Updates due to PackageTarget changes in habitat-sh/core#37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#f51c3d8f87564ce0c9286864d57bfc4401259ddd"
+source = "git+https://github.com/habitat-sh/core.git#190e03c432b230baee2ccda7406e5f0e84b1c91a"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#f51c3d8f87564ce0c9286864d57bfc4401259ddd"
+source = "git+https://github.com/habitat-sh/core.git#190e03c432b230baee2ccda7406e5f0e84b1c91a"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -1193,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#f51c3d8f87564ce0c9286864d57bfc4401259ddd"
+source = "git+https://github.com/habitat-sh/core.git#190e03c432b230baee2ccda7406e5f0e84b1c91a"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -20,8 +20,7 @@ use std::path::PathBuf;
 
 use github_api_client::GitHubCfg;
 use hab_core::config::ConfigFile;
-use hab_core::os::system::{Architecture, Platform};
-use hab_core::package::PackageTarget;
+use hab_core::package::target::{self, PackageTarget};
 use http_gateway::config::prelude::*;
 use segment_api_client::SegmentCfg;
 
@@ -48,7 +47,7 @@ pub struct Config {
     pub log_dir: PathBuf,
     /// Filepath to where the builder encryption keys can be found
     pub key_dir: PathBuf,
-    /// A list of package platform and architecture combinations which can be uploaded and hosted
+    /// A list of package targets which can be uploaded and hosted
     pub targets: Vec<PackageTarget>,
     /// Whether jobsrv is present or not
     pub jobsrv_enabled: bool,
@@ -77,10 +76,7 @@ impl Default for Config {
             non_core_builds_enabled: true,
             log_dir: PathBuf::from(env::temp_dir().to_string_lossy().into_owned()),
             key_dir: PathBuf::from("/hab/svc/builder-api/files"),
-            targets: vec![
-                PackageTarget::new(Platform::Linux, Architecture::X86_64),
-                PackageTarget::new(Platform::Windows, Architecture::X86_64),
-            ],
+            targets: vec![target::X86_64_LINUX, target::X86_64_WINDOWS],
             jobsrv_enabled: true,
             upstream_depot: None,
             upstream_origins: vec!["core".to_string()],
@@ -175,14 +171,7 @@ mod tests {
         jobsrv_enabled = false
         upstream_depot = "http://example.com"
         upstream_origins = ["foo", "bar"]
-
-        [[targets]]
-        platform = "linux"
-        architecture = "x86_64"
-
-        [[targets]]
-        platform = "windows"
-        architecture = "x86_64"
+        targets = ["x86_64-linux", "x86_64-windows"]
 
         [http]
         listen = "127.0.0.1"
@@ -224,10 +213,8 @@ mod tests {
         assert_eq!(config.http.port, 9000);
         assert_eq!(&format!("{}", config.routers[0]), "172.18.0.2:9001");
         assert_eq!(config.targets.len(), 2);
-        assert_eq!(config.targets[0].platform, Platform::Linux);
-        assert_eq!(config.targets[0].architecture, Architecture::X86_64);
-        assert_eq!(config.targets[1].platform, Platform::Windows);
-        assert_eq!(config.targets[1].architecture, Architecture::X86_64);
+        assert_eq!(config.targets[0], target::X86_64_LINUX);
+        assert_eq!(config.targets[1], target::X86_64_WINDOWS);
     }
 
     #[test]

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -71,11 +71,11 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
-use hab_core::package::{Identifiable, PackageArchive, PackageTarget};
+use hab_core::package::{PackageArchive, PackageIdent, PackageTarget};
 use iron::typemap;
 
 pub trait DepotUtil {
-    fn archive_name<T: Identifiable>(ident: &T, target: &PackageTarget) -> PathBuf;
+    fn archive_name(ident: &PackageIdent, target: &PackageTarget) -> PathBuf;
     fn write_archive(filename: &PathBuf, body: &[u8]) -> Result<PackageArchive>;
     fn packages_path(&self) -> PathBuf;
 }
@@ -83,16 +83,11 @@ pub trait DepotUtil {
 impl DepotUtil for config::Config {
     // Return a formatted string representing the filename of an archive for the given package
     // identifier pieces.
-    fn archive_name<T: Identifiable>(ident: &T, target: &PackageTarget) -> PathBuf {
-        PathBuf::from(format!(
-            "{}-{}-{}-{}-{}-{}.hart",
-            ident.origin(),
-            ident.name(),
-            ident.version().unwrap(),
-            ident.release().unwrap(),
-            target.architecture,
-            target.platform
-        ))
+    fn archive_name(ident: &PackageIdent, target: &PackageTarget) -> PathBuf {
+        PathBuf::from(ident.archive_name_with_target(target).expect(&format!(
+            "Package ident should be fully qualified, ident={}",
+            &ident
+        )))
     }
 
     fn write_archive(filename: &PathBuf, body: &[u8]) -> Result<PackageArchive> {

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -873,7 +873,10 @@ fn upload_package(req: &mut Request) -> IronResult<Response> {
         }
     }
 
-    let filename = file_path.join(Config::archive_name(&ident, &target_from_artifact));
+    let filename = file_path.join(Config::archive_name(
+        &(&ident).into(),
+        &target_from_artifact,
+    ));
     let temp_ident = ident.to_owned().into();
 
     match fs::rename(&temp_path, &filename) {
@@ -1267,7 +1270,7 @@ fn download_package(req: &mut Request) -> IronResult<Response> {
         Ok(package) => {
             let dir = tempdir_in(depot.packages_path()).expect("Unable to create a tempdir!");
             let file_path = dir.path()
-                .join(Config::archive_name(package.get_ident(), &target));
+                .join(Config::archive_name(&(&package).into(), &target));
             let temp_ident = ident.to_owned().into();
             match s3handler.download(&file_path, &temp_ident, &target) {
                 Ok(archive) => download_response_for_archive(archive, dir),

--- a/components/builder-protocol/src/originsrv.rs
+++ b/components/builder-protocol/src/originsrv.rs
@@ -756,6 +756,26 @@ impl From<hab_core::package::PackageIdent> for OriginPackageIdent {
     }
 }
 
+impl<'a> From<&'a OriginPackage> for package::PackageIdent {
+    fn from(value: &'a OriginPackage) -> package::PackageIdent {
+        value.get_ident().into()
+    }
+}
+
+impl<'a> From<&'a OriginPackageIdent> for package::PackageIdent {
+    fn from(value: &'a OriginPackageIdent) -> package::PackageIdent {
+        let mut ident =
+            package::PackageIdent::new(value.get_origin(), value.get_name(), None, None);
+        if !value.get_version().is_empty() {
+            ident.version = Some(value.get_version().into());
+        }
+        if !value.get_release().is_empty() {
+            ident.release = Some(value.get_release().into());
+        }
+        ident
+    }
+}
+
 impl FromStr for OriginPackageIdent {
     type Err = hab_core::Error;
 
@@ -1442,5 +1462,98 @@ mod tests {
             q
         );
         assert_eq!(vec!["3.6.12", "3.6.10", "3.6.6", "3.6.5"], r);
+    }
+
+    #[test]
+    fn convert_origin_package_ref_to_package_ident_fully_qualified() {
+        let mut origin_ident = OriginPackageIdent::new();
+        origin_ident.set_origin(String::from("acme"));
+        origin_ident.set_name(String::from("catapult"));
+        origin_ident.set_version(String::from("9000"));
+        origin_ident.set_release(String::from("20180628120102"));
+
+        let mut origin_pkg = OriginPackage::new();
+        origin_pkg.set_ident(origin_ident);
+
+        // ensure that we're using a ref of an `OriginPackage`
+        assert_eq!(
+            package::PackageIdent::from_str("acme/catapult/9000/20180628120102").unwrap(),
+            (&origin_pkg).into(),
+        )
+    }
+
+    #[test]
+    fn convert_origin_package_ref_to_package_ident_no_release() {
+        let mut origin_ident = OriginPackageIdent::new();
+        origin_ident.set_origin(String::from("acme"));
+        origin_ident.set_name(String::from("catapult"));
+        origin_ident.set_version(String::from("9000"));
+
+        let mut origin_pkg = OriginPackage::new();
+        origin_pkg.set_ident(origin_ident);
+
+        // ensure that we're using a ref of an `OriginPackage`
+        assert_eq!(
+            package::PackageIdent::from_str("acme/catapult/9000").unwrap(),
+            (&origin_pkg).into(),
+        )
+    }
+
+    #[test]
+    fn convert_origin_package_ref_to_package_ident_no_version() {
+        let mut origin_ident = OriginPackageIdent::new();
+        origin_ident.set_origin(String::from("acme"));
+        origin_ident.set_name(String::from("catapult"));
+
+        let mut origin_pkg = OriginPackage::new();
+        origin_pkg.set_ident(origin_ident);
+
+        // ensure that we're using a ref of an `OriginPackage`
+        assert_eq!(
+            package::PackageIdent::from_str("acme/catapult").unwrap(),
+            (&origin_pkg).into(),
+        )
+    }
+
+    #[test]
+    fn convert_origin_package_ident_ref_to_package_ident_fully_qualified() {
+        let mut origin_ident = OriginPackageIdent::new();
+        origin_ident.set_origin(String::from("acme"));
+        origin_ident.set_name(String::from("catapult"));
+        origin_ident.set_version(String::from("9000"));
+        origin_ident.set_release(String::from("20180628120102"));
+
+        // ensure that we're using a ref of an `OriginPackageIdent`
+        assert_eq!(
+            package::PackageIdent::from_str("acme/catapult/9000/20180628120102").unwrap(),
+            (&origin_ident).into(),
+        )
+    }
+
+    #[test]
+    fn convert_origin_package_ident_ref_to_package_ident_no_release() {
+        let mut origin_ident = OriginPackageIdent::new();
+        origin_ident.set_origin(String::from("acme"));
+        origin_ident.set_name(String::from("catapult"));
+        origin_ident.set_version(String::from("9000"));
+
+        // ensure that we're using a ref of an `OriginPackage`
+        assert_eq!(
+            package::PackageIdent::from_str("acme/catapult/9000").unwrap(),
+            (&origin_ident).into(),
+        )
+    }
+
+    #[test]
+    fn convert_origin_package_ident_ref_to_package_ident_no_version() {
+        let mut origin_ident = OriginPackageIdent::new();
+        origin_ident.set_origin(String::from("acme"));
+        origin_ident.set_name(String::from("catapult"));
+
+        // ensure that we're using a ref of an `OriginPackage`
+        assert_eq!(
+            package::PackageIdent::from_str("acme/catapult").unwrap(),
+            (&origin_ident).into(),
+        )
     }
 }


### PR DESCRIPTION
Breaking config.toml update
---------------------------

There is a potential user-impacting breaking change included with this
change. That is, prior to this change an operator of a
`habitat/builder-api` service would override the default `targets`
section of their configuration with a form similar to this:

```toml

[[targets]]
architecture = "x86_64"
platform = "windows"

[[targets]]
architecture = "x86_64"
platform = "linux"
```

(Note that the above example is *exactly* the defaults for the service
and therefore it would be extremely unlikely to see this in the wild)

With this change, an operator would want to update their configuration
with a form similar to this:

```toml

targets = ["x86_64-linux", "x86_64-windows"]
```

Scope of breaking change
------------------------

Given how our software is built and configured, there are likely **no**
impacted users, including the Habitat team operating the public Builder
service. Overriding the default supported package targets is likely
under-documented and would require a very unusual use case to even
warrant this. However, the chance of impacting a running service is
non-zero, hence why this is called out.

---

Here is a high level summary of all the other resulting changes:

* Exploit the newly available iterators on `PackageIdent` and
`PackageTarget` and the `PackageIdent.archive_name_with_target()`
implementation to generate the same S3 key strings in `s3_key()`. The
behavior of `s3_key()` didn't require internal knowledge of a struct,
hence it was moved into a private module function where adding unit
tests was made easier too.
* Update `s3_key()` to return a `Result<String>` rather than a `PathBuf`
so that its successful return could be used directly as a key and so
that any relevant failures could be tracked with Rust error propagation.
* Update the default `Config` to use the newly available supported
`PackageTarget` constants for `x86_64-linux` and `x86_64-windows`.
* Update the `DepotUtil::archive_name()` trait function signature to
operate directly with `PackageIdent`s rather than with generic
`Identifiable`s to gain access to some of `PackageIdent`'s behavior. So
rather than using generics, this change uses type conversion from a
`&OriginPackage` to a `PackageIdent` and from a `&OriginPackageIdent`
to a `PackageIdent`. Several unit tests were added to test the type
conversions.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>