### PR TITLE
Tune some queries to be a bit faster

### DIFF
--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -387,7 +387,7 @@ impl DataStore {
         let conn = self.pool.get_shard(0)?;
 
         let rows = conn.query(
-            "SELECT * FROM upsert_graph_package_v1($1, $2, $3)",
+            "SELECT * FROM upsert_graph_package_v2($1, $2, $3)",
             &[&msg.get_ident(), &msg.get_deps(), &msg.get_target()],
         ).map_err(Error::JobGraphPackageInsert)?;
 
@@ -439,23 +439,23 @@ impl DataStore {
         let conn = self.pool.get_shard(0)?;
 
         let origin = msg.get_origin();
-        let rows = &conn.query("SELECT * FROM count_graph_packages_v1($1)", &[&origin])
+        let rows = &conn.query("SELECT * FROM count_graph_packages_v2($1)", &[&origin])
             .map_err(Error::JobGraphPackageStats)?;
         assert!(rows.len() == 1); // should never have more than one
 
-        let package_count: i64 = rows.get(0).get("count_graph_packages_v1");
+        let package_count: i64 = rows.get(0).get("count_graph_packages_v2");
 
-        let rows = &conn.query("SELECT * FROM count_group_projects_v1($1)", &[&origin])
+        let rows = &conn.query("SELECT * FROM count_group_projects_v2($1)", &[&origin])
             .map_err(Error::JobGraphPackageStats)?;
         assert!(rows.len() == 1); // should never have more than one
-        let build_count: i64 = rows.get(0).get("count_group_projects_v1");
+        let build_count: i64 = rows.get(0).get("count_group_projects_v2");
 
         let rows = &conn.query(
-            "SELECT * FROM count_unique_graph_packages_v1($1)",
+            "SELECT * FROM count_unique_graph_packages_v2($1)",
             &[&origin],
         ).map_err(Error::JobGraphPackageStats)?;
         assert!(rows.len() == 1); // should never have more than one
-        let up_count: i64 = rows.get(0).get("count_unique_graph_packages_v1");
+        let up_count: i64 = rows.get(0).get("count_unique_graph_packages_v2");
 
         let mut package_stats = jobsrv::JobGraphPackageStats::new();
         package_stats.set_plans(package_count as u64);

--- a/components/builder-jobsrv/src/migrations/2018-07-09-232521_query_tuning/down.sql
+++ b/components/builder-jobsrv/src/migrations/2018-07-09-232521_query_tuning/down.sql
@@ -1,0 +1,4 @@
+DROP FUNCTION IF EXISTS count_group_projects_v2(text);
+DROP FUNCTION IF EXISTS count_graph_packages_v2(text);
+DROP FUNCTION IF EXISTS count_unique_graph_packages_v2(text);
+DROP FUNCTION IF EXISTS upsert_graph_package_v2(text, text[], text);

--- a/components/builder-jobsrv/src/migrations/2018-07-09-232521_query_tuning/up.sql
+++ b/components/builder-jobsrv/src/migrations/2018-07-09-232521_query_tuning/up.sql
@@ -1,0 +1,41 @@
+CREATE OR REPLACE FUNCTION count_group_projects_v2 (origin text) RETURNS bigint AS $$
+  BEGIN
+    RETURN COUNT(*) FROM group_projects WHERE project_ident LIKE (origin || '/%');
+  END
+$$ LANGUAGE plpgsql STABLE;
+
+ALTER TABLE IF EXISTS graph_packages ADD ident_array text[];
+CREATE INDEX IF NOT EXISTS graph_packages_ident_array ON graph_packages (ident_array);
+
+-- Normally I try to reserve migrations for schema changes only, but I think
+-- this is ok, since it's idempotent.
+UPDATE graph_packages SET ident_array=regexp_split_to_array(ident, '/');
+
+CREATE OR REPLACE FUNCTION count_graph_packages_v2 (origin text) RETURNS bigint AS $$
+BEGIN
+  RETURN COUNT(*) FROM graph_packages WHERE ident_array[1]=origin;
+END
+$$ LANGUAGE plpgsql STABLE;
+
+CREATE OR REPLACE FUNCTION count_unique_graph_packages_v2 (
+  op_origin text
+) RETURNS bigint
+LANGUAGE SQL STABLE AS $$
+  SELECT COUNT(DISTINCT ident_array[2]) AS total
+  FROM graph_packages
+  WHERE ident_array[1] = op_origin
+$$;
+
+CREATE OR REPLACE FUNCTION upsert_graph_package_v2 (
+  in_ident text,
+  in_deps text[],
+  in_target text
+) RETURNS SETOF graph_packages AS $$
+  BEGIN
+    RETURN QUERY INSERT INTO graph_packages (ident, deps, target, ident_array)
+    VALUES (in_ident, in_deps, in_target, regexp_split_to_array(in_ident, '/'))
+    ON CONFLICT(ident)
+    DO UPDATE SET deps=in_deps, target=in_target RETURNING *;
+    RETURN;
+  END
+$$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
It was difficult to come up with a comprehensive set of slow queries to test, because we don't get enough activity for `pg_activity` to show much, unless the db is under a lot of strain, and it hasn't been lately.

One way to track this over time would be to install the `pg_stat_statements` extension, but I didn't do that here.  Instead, I mostly tackled the queries that were represented in the GH issue.

There are 2 main changes worth noting here:

* Switching from matching via a regular expression to using `LIKE` resulted in roughly a 2x speed increase
* Rather than converting from a string to an array on the fly for every record in a result set, creating the array column and pre-populating it ahead of time, and using that, resulted in roughly a 10x speed increase.

![](https://media.giphy.com/media/uxu9m5XtlhRw4/giphy.gif)

Closes https://github.com/habitat-sh/builder/issues/517
Signed-off-by: Josh Black <raskchanky@gmail.com>