### PR TITLE
Fix shellcheck lints for support scripts

### DIFF
--- a/support/account_creation_report.sh
+++ b/support/account_creation_report.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2181
 
 set -eu
 
@@ -12,9 +11,7 @@ fi
 
 # Note that although the query below specifies shard_0, the function itself queries and aggregates results across all shards
 if command -v hab > /dev/null 2>&1; then
-  hab pkg exec core/postgresql psql -U hab -q -c "COPY (SELECT * FROM shard_0.account_creation_report('$1')) TO '$output' WITH (FORMAT CSV, HEADER TRUE, FORCE_QUOTE *)" builder_sessionsrv
-
-  if [ $? -eq 0 ]; then
+  if hab pkg exec core/postgresql psql -U hab -q -c "COPY (SELECT * FROM shard_0.account_creation_report('$1')) TO '$output' WITH (FORMAT CSV, HEADER TRUE, FORCE_QUOTE *)" builder_sessionsrv; then
     echo "The report ran successfully. The CSV file can be found at $output"
   else
     echo "There was an error running the report. Make sure you're passing a date as the sole argument to this script, e.g. 2017-09-01"

--- a/support/bash_completion.sh
+++ b/support/bash_completion.sh
@@ -1,4 +1,3 @@
-# shellcheck disable=SC2086,SC2128
 # Copyright:: Copyright (c) 2015-2016 The Habitat Maintainers
 #
 # The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
@@ -22,72 +21,72 @@ _hab()
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD-1]}
     len=${#COMP_WORDS[@]}
-    if [ $len -gt 2 ]
+    if [ "$len" -gt 2 ]
     then
         minus2=${COMP_WORDS[COMP_CWORD-2]}
     fi
 
-    if [ $COMP_CWORD -eq 1 ]; then
+    if [ "$COMP_CWORD" -eq 1 ]; then
         case $prev in
             hab)
                 COMPREPLY=( $( compgen -W "apply artifact config file help install origin pkg ring svc setup start studio sup user" -- "$cur" ) )
                 ;;
                    esac
-    elif [ $COMP_CWORD -eq 2 ]; then
+    elif [ "$COMP_CWORD" -eq 2 ]; then
         case "$prev" in
             artifact)
-                cmds=( "hash help sign upload verify" )
+                cmds="hash help sign upload verify"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             cli)
-                cmds=( "help setup" )
+                cmds="help setup"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             config)
-                cmds=( "apply help" )
+                cmds="apply help"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             file)
-                cmds=( "help upload" )
+                cmds="help upload"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             origin)
-                cmds=( "help key" )
+                cmds="help key"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             pkg)
-                cmds=( "binlink build exec export help install path" )
+                cmds="binlink build exec export help install path"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             ring)
-                cmds=( "help key" )
+                cmds="help key"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             svc)
-                cmds=( "help key" )
+                cmds="help key"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             studio)
-                cmds=( "build enter help new rm run version" )
+                cmds="build enter help new rm run version"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             sup)
-                cmds=( "bash config help sh start" )
+                cmds="bash config help sh start"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
             user)
-                cmds=( "help key" )
+                cmds="help key"
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
 
 
         esac
-    elif [ $COMP_CWORD -eq 3 ]; then
+    elif [ "$COMP_CWORD" -eq 3 ]; then
         case "$minus2" in
             origin)
                 case "$prev" in
                     key) #hab origin key
-                        cmds=( "download export generate help import upload" )
+                        cmds="download export generate help import upload"
                         COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                     ;;
                 esac
@@ -95,7 +94,7 @@ _hab()
             ring) # hab ring key
                 case "$prev" in
                     key)
-                        cmds=( "export generate help import" )
+                        cmds="export generate help import"
                         COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                     ;;
                 esac
@@ -103,7 +102,7 @@ _hab()
             svc) # hab svc key
                 case "$prev" in
                     key)
-                        cmds=( "generate help" )
+                        cmds="generate help"
                         COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                     ;;
                 esac
@@ -111,7 +110,7 @@ _hab()
             user) # hab user key
                 case "$prev" in
                     key)
-                        cmds=( "generate help" )
+                        cmds="generate help"
                         COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                     ;;
                 esac

--- a/support/ci/compile_libarchive.sh
+++ b/support/ci/compile_libarchive.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2046,SC2086
 set -eu
 
 version=3.2.0
@@ -14,12 +13,12 @@ if [ -d "$prefix" ]; then
   exit 0
 fi
 
-source $(dirname $0)/rust_env.sh
+source "$(dirname "$0")"/rust_env.sh
 
 echo "--> Compiling $nv"
 trap 'rm -rf /tmp/${nv}*; exit $?' INT TERM EXIT
-(cd /tmp && wget $source && tar xf /tmp/$(basename $source))
+(cd /tmp && wget $source && tar xf /tmp/"$(basename $source)")
 cd /tmp/$nv
-./configure --prefix=$prefix --without-xml2 --without-lzo2
+./configure --prefix="$prefix" --without-xml2 --without-lzo2
 make
 make install

--- a/support/ci/compile_libsodium.sh
+++ b/support/ci/compile_libsodium.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2046,SC2086
 set -eu
 
 version=1.0.13
@@ -14,12 +13,12 @@ if [ -d "$prefix" ]; then
   exit 0
 fi
 
-source $(dirname $0)/rust_env.sh
+source "$(dirname "$0")"/rust_env.sh
 
 echo "--> Compiling $nv"
 trap 'rm -rf /tmp/${nv}*; exit $?' INT TERM EXIT
-(cd /tmp && wget $source && tar xf /tmp/$(basename $source))
+(cd /tmp && wget $source && tar xf /tmp/"$(basename $source)")
 cd /tmp/$nv
-./configure --prefix=$prefix
+./configure --prefix="$prefix"
 make
 make install

--- a/support/ci/compile_zmq.sh
+++ b/support/ci/compile_zmq.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2046,SC2086
 set -eu
 
 version=4.1.4
@@ -13,12 +12,12 @@ if [ -d "$prefix" ]; then
   exit 0
 fi
 
-source $(dirname $0)/rust_env.sh
+source "$(dirname "$0")"/rust_env.sh
 
 echo "--> Compiling $nv"
 trap 'rm -rf /tmp/${nv}*; exit $?' INT TERM EXIT
-(cd /tmp && wget --no-check-certificate $source && tar xf /tmp/$(basename $source))
+(cd /tmp && wget --no-check-certificate $source && tar xf /tmp/"$(basename $source)")
 cd /tmp/$nv
-./autogen.sh && ./configure --prefix=$prefix --with-libsodium
+./autogen.sh && ./configure --prefix="$prefix" --with-libsodium
 make
 make install


### PR DESCRIPTION
The antepenultimate step towards https://github.com/habitat-sh/habitat/issues/4170.

This reverts the shellcheck suppressions in favor of actually fixing the lints.

All of these exact changes have already been made in the the [habitat repo](https://github.com/habitat-sh/habitat).