### PR TITLE
Fix shellcheck lints for miscellaneous scripts

### DIFF
--- a/components/builder-db/tests/db/start.sh
+++ b/components/builder-db/tests/db/start.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2086
 #
 # Oh habitat, how you bring me back to my most hack-worthy roots. I love you for it.
 #
@@ -19,15 +18,15 @@ if [ ! -f /bin/hab ]; then
 fi
 
 mkdir -p /hab/svc/postgresql
-cp $DB_TEST_DIR/pg_hba.conf /hab/svc/postgresql
-cp $DB_TEST_DIR/user.toml /hab/svc/postgresql
+cp "$DB_TEST_DIR"/pg_hba.conf /hab/svc/postgresql
+cp "$DB_TEST_DIR"/user.toml /hab/svc/postgresql
 hab sup run core/postgresql &
 hab_pid=$!
 
 sudo_ppid=$(ps -p $$ -o 'ppid=')
-original_gpid=$(ps -p $sudo_ppid -o 'ppid=')
+original_gpid=$(ps -p "$sudo_ppid" -o 'ppid=')
 while true; do
-  current_gpid=$(ps -p $sudo_ppid -o 'ppid=')
+  current_gpid=$(ps -p "$sudo_ppid" -o 'ppid=')
   if [ "$original_gpid" != "$current_gpid" ]; then
     echo "Stopping core/postgresql"
     kill $hab_pid

--- a/terraform/scripts/create_bootstrap_bundle.sh
+++ b/terraform/scripts/create_bootstrap_bundle.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2086,SC2129
 
 # Create a tarball of all the Habitat artifacts needed to run the
 # Habitat Supervisor on a system and upload it to S3. This includes
@@ -50,7 +49,7 @@ log "Version ${hab_version}"
 # Preliminaries, Helpers, Constants
 
 find_if_exists() {
-  command -v ${1} || { log "Required utility '${1}' cannot be found!  Aborting."; exit 1; }
+  command -v "${1}" || { log "Required utility '${1}' cannot be found!  Aborting."; exit 1; }
 }
 
 # These are the key utilities this script uses. If any are not present
@@ -118,12 +117,12 @@ this_bootstrap_bundle=hab_builder_bootstrap_$(date +%Y%m%d%H%M%S)
 # blindly copy everything in ${sandbox_dir}/hab/cache/artifacts, confident
 # that those artifacts are everything we need, and no more.
 sandbox_dir=${this_bootstrap_bundle}
-mkdir ${sandbox_dir}
+mkdir "${sandbox_dir}"
 log "Using ${sandbox_dir} as the Habitat root directory"
 
 for package in "${sup_packages[@]}" "${builder_packages[@]}" "${helper_packages[@]}"
 do
-  env FS_ROOT=${sandbox_dir} ${depot_flag} ${hab} pkg install --channel=stable ${package} >&2
+  env FS_ROOT="${sandbox_dir}" ${depot_flag} "${hab}" pkg install --channel=stable "${package}" >&2
 done
 
 ########################################################################
@@ -132,53 +131,55 @@ done
 artifact_dir=${sandbox_dir}/hab/cache/artifacts
 log "Creating TAR for all artifacts"
 
-sup_artifact=$(echo ${artifact_dir}/core-hab-sup-*)
+sup_artifact=$(echo "${artifact_dir}"/core-hab-sup-*)
 archive_name=${this_bootstrap_bundle}.tar
 log "Generating archive: ${archive_name}"
 
 tar --create \
        --verbose \
-       --file=${archive_name} \
-       --directory=${sandbox_dir}/hab/cache \
+       --file="${archive_name}" \
+       --directory="${sandbox_dir}"/hab/cache \
        artifacts >&2
 
 # We'll need a hab binary to bootstrap ourselves; let's take the one
 # we just downloaded, shall we?
-hab_pkg_dir=$(echo ${sandbox_dir}/hab/pkgs/core/hab/${hab_version}/*)
+hab_pkg_dir=$(echo "${sandbox_dir}"/hab/pkgs/core/hab/"${hab_version}"/*)
 tar --append \
        --verbose \
-       --file=${archive_name} \
-       --directory=${hab_pkg_dir} \
+       --file="${archive_name}" \
+       --directory="${hab_pkg_dir}" \
        bin >&2
 
 # We're also going to need the public origin key(s)!
 tar --append \
        --verbose \
-       --file=${archive_name} \
-       --directory=${sandbox_dir}/hab/cache \
+       --file="${archive_name}" \
+       --directory="${sandbox_dir}"/hab/cache \
        keys >&2
 
 ########################################################################
 # Upload to S3
 
-checksum=$(sha256sum ${archive_name} | awk '{print $1}')
+checksum=$(sha256sum "${archive_name}" | awk '{print $1}')
 
 # Encapsulate the fact that we want our uploaded files to be publicly
 # accessible.
 s3_cp() {
-  aws s3 cp --acl=public-read ${1} ${2} >&2
+  aws s3 cp --acl=public-read "${1}" "${2}" >&2
 }
 
-s3_cp ${archive_name} s3://${s3_bucket}
+s3_cp "${archive_name}" s3://${s3_bucket}
 
 manifest_file=${this_bootstrap_bundle}_manifest.txt
-echo ${archive_name} > ${manifest_file}
-echo ${checksum} >> ${manifest_file}
-echo >> ${manifest_file}
-tar --list --file ${archive_name} | sort >> ${manifest_file}
+{
+  echo "${archive_name}"
+  echo "${checksum}"
+  echo
+  tar --list --file "${archive_name}" | sort
+} > "${manifest_file}"
 
-s3_cp ${manifest_file} s3://${s3_bucket}
-s3_cp s3://${s3_bucket}/${manifest_file} s3://${s3_bucket}/LATEST
+s3_cp "${manifest_file}" s3://${s3_bucket}
+s3_cp s3://${s3_bucket}/"${manifest_file}" s3://${s3_bucket}/LATEST
 
-rm -rdf $sandbox_dir
-rm -Rdf $archive_name
+rm -rdf "$sandbox_dir"
+rm -Rdf "$archive_name"

--- a/test/builder-api/bin/cleanup-integration-tests.sh
+++ b/test/builder-api/bin/cleanup-integration-tests.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2086
 
 # You might be asking yourself "Why does this file even exist?" The answer to that question lies
 # in the amount of time it takes to run 'test.sh'. Since test.sh is designed to be run in CI,
@@ -39,7 +38,7 @@ fi
 # cleanup origins
 for origin in "${origins[@]}"
 do
-  shard=$($dir/op shard --origin $origin)
+  shard=$("$dir"/op shard --origin "$origin")
   sql=$(cat <<EOF
 SET SEARCH_PATH TO shard_$shard;
 DELETE FROM origin_members WHERE origin_id=(SELECT id FROM origins WHERE name='$origin');
@@ -55,13 +54,13 @@ DELETE FROM origin_secret_keys WHERE origin_id=(SELECT id FROM origins WHERE nam
 DELETE FROM origins WHERE name='$origin';
 EOF
 )
-  echo $sql | hab pkg exec core/postgresql psql -U hab builder_originsrv
+  echo "$sql" | hab pkg exec core/postgresql psql -U hab builder_originsrv
 done
 
 # cleanup users
 for user in "${users[@]}"
 do
-  shard=$($dir/op shard --origin $user)
+  shard=$("$dir"/op shard --origin "$user")
   sql=$(cat <<EOF
 SET SEARCH_PATH TO shard_$shard;
 DELETE FROM account_invitations WHERE account_id=(SELECT id FROM accounts WHERE name='$user');
@@ -69,7 +68,7 @@ DELETE FROM account_origins WHERE account_id=(SELECT id FROM accounts WHERE name
 DELETE FROM accounts WHERE name='$user';
 EOF
 )
-  echo $sql | hab pkg exec core/postgresql psql -U hab builder_sessionsrv
+  echo "$sql" | hab pkg exec core/postgresql psql -U hab builder_sessionsrv
 done
 
 # cleanup jobs
@@ -84,7 +83,7 @@ DELETE FROM groups WHERE project_name LIKE '$origin%';
 DELETE FROM jobs WHERE project_name LIKE '$origin%';
 EOF
 )
-  echo $sql | hab pkg exec core/postgresql psql -U hab builder_jobsrv
+  echo "$sql" | hab pkg exec core/postgresql psql -U hab builder_jobsrv
 done
 
 # cleanup files


### PR DESCRIPTION
The final step to shellcheck 0.4.6. compliance in the builder repo!

Resolves https://github.com/habitat-sh/habitat/issues/4170

This reverts the shellcheck suppressions in favor of actually fixing the lints.
