### PR TITLE
Nginx caching

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -68,8 +68,21 @@ http {
   add_header "X-UA-Compatible" "IE=Edge";
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
 
+  {{~#if cfg.nginx.enable_caching}}
   proxy_cache_path {{pkg.svc_var_path}}/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
   proxy_cache_key "$scheme$proxy_host$uri$is_args$args $http_user_agent";
+  proxy_cache_valid 10m; # this only caches 200, 301, 302
+
+  geo $purge_allowed {
+    127.0.0.1       1;  # allow from localhost
+    default         0;  # deny from everything else
+  }
+
+  map $request_method $purge_method {
+    PURGE $purge_allowed;
+    default 0;
+  }
+  {{~/if}}
 
   log_format nginx '$remote_addr - $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent $request_time '
@@ -161,8 +174,11 @@ http {
       client_max_body_size {{cfg.nginx.max_body_size}};
       proxy_send_timeout {{cfg.nginx.proxy_send_timeout}};
       proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
+      {{~#if cfg.nginx.enable_caching}}
       proxy_cache my_cache;
+      proxy_cache_purge $purge_method;
       proxy_pass http://backend;
+      {{~/if}}
     }
 
     location /v1 {

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -1,57 +1,58 @@
-app_url                 = "https://bldr.habitat.sh"
-cookie_domain           = ""
-demo_app_url            = "https://www.habitat.sh/demo/build-system/steps/1/"
-docs_url                = "https://www.habitat.sh/docs"
-enable_publisher_amazon = false
-enable_publisher_azure  = false
-enable_publisher_docker = false
-enable_builder          = false
-environment             = "production"
-hosted                  = false
-source_code_url         = "https://github.com/habitat-sh/habitat"
-status_url              = "https://status.habitat.sh/"
-tutorials_url           = "https://www.habitat.sh/learn"
-use_gravatar            = true
-www_url                 = "https://www.habitat.sh"
+app_url                   = "https://bldr.habitat.sh"
+cookie_domain             = ""
+demo_app_url              = "https://www.habitat.sh/demo/build-system/steps/1/"
+docs_url                  = "https://www.habitat.sh/docs"
+enable_publisher_amazon   = false
+enable_publisher_azure    = false
+enable_publisher_docker   = false
+enable_builder            = false
+environment               = "production"
+hosted                    = false
+source_code_url           = "https://github.com/habitat-sh/habitat"
+status_url                = "https://status.habitat.sh/"
+tutorials_url             = "https://www.habitat.sh/learn"
+use_gravatar              = true
+www_url                   = "https://www.habitat.sh"
 
 [analytics]
-company_id          = ""
-company_name        = ""
-enabled             = false
-write_key           = ""
+company_id                = ""
+company_name              = ""
+enabled                   = false
+write_key                 = ""
 
 [github]
-app_id       = 5565
-app_url      = "https://github.com/apps/habitat-builder"
-api_url      = "https://api.github.com"
+app_id                    = 5565
+app_url                   = "https://github.com/apps/habitat-builder"
+api_url                   = "https://api.github.com"
 
 [oauth]
-authorize_url  = "https://github.com/login/oauth/authorize"
-client_id      = ""
-provider       = "github"
-redirect_url   = ""
-signup_url     = "https://github.com/join"
+authorize_url             = "https://github.com/login/oauth/authorize"
+client_id                 = ""
+provider                  = "github"
+redirect_url              = ""
+signup_url                = "https://github.com/join"
 
 [nginx]
-worker_connections   = 8000
-worker_processes     = "auto"
-worker_rlimit_nofile = 8192
-max_body_size        = "1024m"
-proxy_send_timeout   = 60
-proxy_read_timeout   = 60
-limit_req_zone_unknown = "$limit_unknown zone=unknown:10m rate=2r/s"
-limit_req_zone_known = "$http_x_forwarded_for zone=known:10m rate=20r/s"
-limit_req_unknown   = "burst=20 nodelay"
-limit_req_known      = "burst=40 nodelay"
-limit_req_status     = 429
-limit_ua_known       = "hab|builder|Chef|Mozilla|Github"
-limit_ua_unknown_target = "$http_x_forwarded_for"
+worker_connections        = 8000
+worker_processes          = "auto"
+worker_rlimit_nofile      = 8192
+max_body_size             = "1024m"
+proxy_send_timeout        = 60
+proxy_read_timeout        = 60
+limit_req_zone_unknown    = "$limit_unknown zone=unknown:10m rate=2r/s"
+limit_req_zone_known      = "$http_x_forwarded_for zone=known:10m rate=20r/s"
+limit_req_unknown         = "burst=20 nodelay"
+limit_req_known           = "burst=40 nodelay"
+limit_req_status          = 429
+limit_ua_known            = "hab|builder|Chef|Mozilla|Github"
+limit_ua_unknown_target   = "$http_x_forwarded_for"
+enable_caching            = true
 
 [http]
-keepalive_timeout = "20s"
-sendfile          = "on"
-tcp_nopush        = "on"
-tcp_nodelay       = "on"
+keepalive_timeout         = "20s"
+sendfile                  = "on"
+tcp_nopush                = "on"
+tcp_nodelay               = "on"
 
 [server]
 listen_port               = 80

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -68,7 +68,7 @@ pub use self::config::Config;
 pub use self::error::{Error, Result};
 
 use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use hab_core::package::{PackageArchive, PackageIdent, PackageTarget};
@@ -91,7 +91,7 @@ impl DepotUtil for config::Config {
     }
 
     fn write_archive(filename: &PathBuf, body: &[u8]) -> Result<PackageArchive> {
-        let file = match File::create(&filename) {
+        let mut file = match File::create(&filename) {
             Ok(f) => f,
             Err(e) => {
                 warn!(
@@ -101,8 +101,7 @@ impl DepotUtil for config::Config {
                 return Err(Error::IO(e));
             }
         };
-        let mut write = BufWriter::new(file);
-        if let Err(e) = write.write_all(body) {
+        if let Err(e) = file.write_all(body) {
             warn!("Unable to write archive for {:?}, err={:?}", filename, e);
             return Err(Error::IO(e));
         }


### PR DESCRIPTION
This PR is mostly about tuning the nginx cache.

* There's now a config directive that can be set to `false` to disable caching completely.
* If caching is enabled, and we want to clear the cache, we can do that with e.g. `curl -v -X PURGE -D - "https://bldr.habitat.sh/*"`
* The above command will only work when run from the API node itself, so internet randos can't purge our caches for us.
* Only 200, 301 and 302 responses are cached, and only for 10 minutes.  Previously, everything was cached indefinitely.

I don't have a ton of experience modifying nginx configuration files, so if I messed something up, I'm not surprised.  Please do let me know.

Unrelated, but I noticed an extraneous `BufWriter` in the rust code to write files that wasn't necessary, so I removed that.  I'm not sure if that was related to the zero byte file issue or not, but I'm always a fan of removing code if possible.

Finally, the `default.toml` changes are almost entirely formatting.  The only real change of substance is the `enable_caching` line in the `nginx` section.

Closes https://github.com/habitat-sh/builder/issues/494

![](https://media.giphy.com/media/94EQmVHkveNck/giphy.gif)