### PR TITLE
Add chef-automate auth provider for on-premise builder

### DIFF
--- a/components/oauth-client/src/a2.rs
+++ b/components/oauth-client/src/a2.rs
@@ -1,0 +1,111 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use reqwest::header::{qitem, Accept, Authorization, Bearer, ContentType, Headers};
+use reqwest::mime;
+use reqwest::Client;
+use serde_json;
+
+use config::OAuth2Cfg;
+use error::{Error, Result};
+use types::*;
+
+pub struct A2;
+
+#[derive(Deserialize)]
+struct AuthOk {
+    pub access_token: String,
+}
+
+#[derive(Deserialize)]
+struct User {
+    pub sub: String,
+    pub preferred_username: String,
+    pub email: Option<String>,
+}
+
+impl A2 {
+    fn user(&self, config: &OAuth2Cfg, client: &Client, token: &str) -> Result<OAuth2User> {
+        let mut headers = Headers::new();
+        headers.set(Accept(vec![qitem(mime::APPLICATION_JSON)]));
+        headers.set(Authorization(Bearer {
+            token: token.to_string(),
+        }));
+
+        let mut resp = client
+            .get(&config.userinfo_url)
+            .headers(headers)
+            .send()
+            .map_err(Error::HttpClient)?;
+
+        let body = resp.text().map_err(Error::HttpClient)?;
+        debug!("A2 response body: {}", body);
+
+        if resp.status().is_success() {
+            let user = match serde_json::from_str::<User>(&body) {
+                Ok(msg) => msg,
+                Err(e) => return Err(Error::Serialization(e)),
+            };
+
+            Ok(OAuth2User {
+                id: user.sub,
+                username: user.preferred_username,
+                email: user.email,
+            })
+        } else {
+            Err(Error::HttpResponse(resp.status(), body))
+        }
+    }
+}
+
+impl OAuth2Provider for A2 {
+    fn authenticate(
+        &self,
+        config: &OAuth2Cfg,
+        client: &Client,
+        code: &str,
+    ) -> Result<(String, OAuth2User)> {
+        let url = format!("{}", config.token_url);
+        let params = format!(
+            "client_id={}&client_secret={}&grant_type=authorization_code&code={}&redirect_uri={}",
+            config.client_id, config.client_secret, code, config.redirect_url
+        );
+
+        let mut headers = Headers::new();
+        headers.set(Accept(vec![qitem(mime::APPLICATION_JSON)]));
+        headers.set(ContentType::form_url_encoded());
+
+        let mut resp = client
+            .post(&url)
+            .headers(headers)
+            .body(params)
+            .send()
+            .map_err(Error::HttpClient)?;
+
+        let body = resp.text().map_err(Error::HttpClient)?;
+        debug!("A2 response body: {}", body);
+
+        let token = if resp.status().is_success() {
+            match serde_json::from_str::<AuthOk>(&body) {
+                Ok(msg) => msg.access_token,
+                Err(e) => return Err(Error::Serialization(e)),
+            }
+        } else {
+            return Err(Error::HttpResponse(resp.status(), body));
+        };
+
+        let user = self.user(config, client, &token)?;
+        Ok((token, user))
+    }
+}

--- a/components/oauth-client/src/client.rs
+++ b/components/oauth-client/src/client.rs
@@ -26,6 +26,7 @@ use github::GitHub;
 use gitlab::GitLab;
 use metrics::Counter;
 use okta::Okta;
+use a2::A2;
 
 pub struct OAuth2Client {
     inner: reqwest::Client,
@@ -67,6 +68,7 @@ impl OAuth2Client {
             "gitlab" => Box::new(GitLab),
             "bitbucket" => Box::new(Bitbucket),
             "okta" => Box::new(Okta),
+            "chef-automate" => Box::new(A2),
             _ => panic!("Unknown OAuth provider: {}", config.provider),
         };
 

--- a/components/oauth-client/src/lib.rs
+++ b/components/oauth-client/src/lib.rs
@@ -31,4 +31,5 @@ pub mod github;
 pub mod gitlab;
 pub mod metrics;
 pub mod okta;
+pub mod a2;
 pub mod types;


### PR DESCRIPTION
This change adds the backend for the A2 auth provider for on-premise builder.  The provider is essentially identical to the Okta provider that was used to successfully authenticate with A2 in a POC.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-161250339](https://user-images.githubusercontent.com/13542112/43104146-470c04aa-8e85-11e8-950e-21d337baca71.gif)
