### PR TITLE
Fix the assignment of the various PID variables in the db test script

### DIFF
--- a/components/builder-db/tests/db/start.sh
+++ b/components/builder-db/tests/db/start.sh
@@ -23,10 +23,10 @@ cp "$DB_TEST_DIR"/user.toml /hab/svc/postgresql
 hab sup run core/postgresql &
 hab_pid=$!
 
-sudo_ppid=$(ps -p $$ -o 'ppid=')
-original_gpid=$(ps -p "$sudo_ppid" -o 'ppid=')
+read -r sudo_ppid < <(ps -p $$ -o 'ppid=')
+read -r original_gpid < <(ps -p "$sudo_ppid" -o 'ppid=')
 while true; do
-  current_gpid=$(ps -p "$sudo_ppid" -o 'ppid=')
+  read -r current_gpid < <(ps -p "$sudo_ppid" -o 'ppid=')
   if [ "$original_gpid" != "$current_gpid" ]; then
     echo "Stopping core/postgresql"
     kill $hab_pid


### PR DESCRIPTION
The `ps` command will justify the columns of its output with extra whitespace,
so a simple process substitution can result in the variable containing this
extra whitespace, which confuses `ps` when passed back as an argument. To avoid
this (and good practice in general), use the `read` command which strips
whitespace according to IFS. For example:

```
$ read -r good_pid < <(ps -p 690 -o 'ppid=')
$ echo "#$good_pid#"
#679#
$ bad_pid=$(ps -p 690 -o 'ppid=')
$ echo "#$bad_pid#"
#   679#
$ ps -p "$good_pid"
   PID TTY          TIME CMD
   679 ?        00:00:16 runsvdir
$ ps -p "$bad_pid"
error: improper list

Usage:
 ps [options]

 Try 'ps --help <simple|list|output|threads|misc|all>'
  or 'ps --help <s|l|o|t|m|a>'
 for additional help text.

For more details see ps(1).
```
See https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-read

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>