### PR TITLE
Remove nginx cache purge option

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -72,16 +72,6 @@ http {
   proxy_cache_path {{pkg.svc_var_path}}/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
   proxy_cache_key "$scheme$proxy_host$uri$is_args$args $http_user_agent";
   proxy_cache_valid 10m; # this only caches 200, 301, 302
-
-  geo $purge_allowed {
-    127.0.0.1       1;  # allow from localhost
-    default         0;  # deny from everything else
-  }
-
-  map $request_method $purge_method {
-    PURGE $purge_allowed;
-    default 0;
-  }
   {{~/if}}
 
   log_format nginx '$remote_addr - $remote_user [$time_local] '
@@ -176,7 +166,6 @@ http {
       proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
       {{~#if cfg.nginx.enable_caching}}
       proxy_cache my_cache;
-      proxy_cache_purge $purge_method;
       proxy_pass http://backend;
       {{~/if}}
     }


### PR DESCRIPTION
proxy_cache_purge is only available in Nginx Plus version, so we can't use it.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-255530023](https://user-images.githubusercontent.com/13542112/43220675-77a46c44-8fff-11e8-99ef-319df7e540fe.gif)
