### PR TITLE
Fix parsing for A2 OAuth provider

### DIFF
--- a/components/builder-http-gateway/src/http/middleware.rs
+++ b/components/builder-http-gateway/src/http/middleware.rs
@@ -308,7 +308,10 @@ pub fn session_create_oauth(
     match provider.parse::<OAuthProvider>() {
         Ok(p) => request.set_provider(p),
         Err(e) => {
-            warn!("Error parsing oauth provider: {:?}", e);
+            warn!(
+                "Error parsing oauth provider: provider={}, err={:?}",
+                provider, e
+            );
             let err = NetError::new(ErrCode::BUG, "session_create_oauth:1");
             return Err(IronError::new(err, Status::Forbidden));
         }

--- a/components/builder-protocol/protocols/sessionsrv.proto
+++ b/components/builder-protocol/protocols/sessionsrv.proto
@@ -9,6 +9,7 @@ enum OAuthProvider {
   GitLab = 4;
   Okta = 5;
   ActiveDirectory = 6;
+  ChefAutomate = 7;
 }
 
 message Account {

--- a/components/builder-protocol/src/sessionsrv.rs
+++ b/components/builder-protocol/src/sessionsrv.rs
@@ -57,6 +57,7 @@ impl FromStr for OAuthProvider {
             "gitlab" => Ok(OAuthProvider::GitLab),
             "bitbucket" => Ok(OAuthProvider::Bitbucket),
             "okta" => Ok(OAuthProvider::Okta),
+            "chef-automate" => Ok(OAuthProvider::ChefAutomate),
             "none" => Ok(OAuthProvider::None),
             "" => Ok(OAuthProvider::None),
             _ => Err(Error::BadOAuthProvider),


### PR DESCRIPTION
Fixing up a missed case for the A2 OAuth provider.

Signed-off-by: Salim Alam <salam@chef.io>