### PR TITLE
Stops Nginx from caching 0 byte files

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -23,6 +23,10 @@ http {
           1       "";
           0       {{cfg.nginx.limit_ua_unknown_target}};
   }
+  map $upstream_http_content_length $flag_cache_empty {
+          default   0;
+          0         1;
+  }
 
   limit_req_zone  {{cfg.nginx.limit_req_zone_unknown}};
   limit_req_zone  {{cfg.nginx.limit_req_zone_known}};
@@ -165,6 +169,8 @@ http {
       proxy_send_timeout {{cfg.nginx.proxy_send_timeout}};
       proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
       {{~#if cfg.nginx.enable_caching}}
+      proxy_no_cache $flag_cache_empty;
+      proxy_bypass $flag_cache_empty;
       proxy_cache my_cache;
       proxy_pass http://backend;
       {{~/if}}


### PR DESCRIPTION
Full transparency I have no idea how to test this. But this should check and bypass caching of files that are 0 byte in size.


Signed-off-by: Ian Henry <ihenry@chef.io>