### PR TITLE
Update JWT to use latest frank_jwt crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,11 +694,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "frank_jwt"
-version = "2.5.1"
-source = "git+https://github.com/habitat-sh/frank_jwt?branch=habitat#48572b57b8c7a81e54d951724ef6c038b0423a49"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -767,7 +769,7 @@ version = "0.0.0"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",
- "frank_jwt 2.5.1 (git+https://github.com/habitat-sh/frank_jwt?branch=habitat)",
+ "frank_jwt 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3299,7 +3301,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-"checksum frank_jwt 2.5.1 (git+https://github.com/habitat-sh/frank_jwt?branch=habitat)" = "<none>"
+"checksum frank_jwt 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2debb36c032c3e19cf8803666963a509034cc80f277d690b711b0acf6dbbf366"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"

--- a/components/github-api-client/Cargo.toml
+++ b/components/github-api-client/Cargo.toml
@@ -6,7 +6,7 @@ workspace = "../../"
 
 [dependencies]
 base64 = "*"
-frank_jwt = { git = "https://github.com/habitat-sh/frank_jwt", branch = "habitat" }
+frank_jwt = "*"
 reqwest = "*"
 log = "*"
 regex = "*"

--- a/components/github-api-client/src/error.rs
+++ b/components/github-api-client/src/error.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use std::io;
 
 use base64;
+use jwt;
 use reqwest;
 use serde_json;
 
@@ -32,6 +33,7 @@ pub enum HubError {
     ContentDecode(base64::DecodeError),
     HttpClient(reqwest::Error),
     IO(io::Error),
+    JWT(jwt::Error),
     Serialization(serde_json::Error),
 }
 
@@ -46,6 +48,7 @@ impl fmt::Display for HubError {
             HubError::ContentDecode(ref e) => format!("{}", e),
             HubError::HttpClient(ref e) => format!("{}", e),
             HubError::IO(ref e) => format!("{}", e),
+            HubError::JWT(ref e) => format!("JWT generation error {:?}", e),
             HubError::Serialization(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
@@ -60,6 +63,7 @@ impl error::Error for HubError {
             HubError::ContentDecode(ref err) => err.description(),
             HubError::HttpClient(ref err) => err.description(),
             HubError::IO(ref err) => err.description(),
+            HubError::JWT(_) => "Unable to generate JWT token",
             HubError::Serialization(ref err) => err.description(),
         }
     }

--- a/components/github-api-client/src/lib.rs
+++ b/components/github-api-client/src/lib.rs
@@ -22,6 +22,7 @@ extern crate regex;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
 extern crate serde_json;
 extern crate time;
 


### PR DESCRIPTION
This migrates us away from a one-off, year old JWT crate to the current latest version of the original JWT crate.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-19364684](https://user-images.githubusercontent.com/13542112/43342638-532a5b0e-9198-11e8-8e2b-c55dd61d8d6c.gif)
