### PR TITLE
Update bldr toml folders for builder-api

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -27,9 +27,11 @@ paths = [
   "components/builder-api/*",
   "components/builder-core/*",
   "components/builder-depot/*",
+  "components/github-api-client/*",
+  "components/segment-api-client/*",
+  "components/oauth-client/*",
   "components/builder-http-gateway/*",
   "components/builder-protocol/*",
-  "components/core/*",
   "components/net/*",
   "support/ci/builder-base-plan.sh",
 ]


### PR DESCRIPTION
This adds some missing folders to watch for builder-api webhook builds. Also removes a reference to a non-existent folder.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-83381628](https://user-images.githubusercontent.com/13542112/43344922-728c1516-91a0-11e8-864d-040a67b4f93c.gif)
