### PR TITLE
Bump to new core revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#a6f0fb04e692d82a2e1c84d596bec09bc3410518"
+source = "git+https://github.com/habitat-sh/core.git#d40b435ab72875a11519a64732cc2fd3e998d899"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1138,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#a6f0fb04e692d82a2e1c84d596bec09bc3410518"
+source = "git+https://github.com/habitat-sh/core.git#d40b435ab72875a11519a64732cc2fd3e998d899"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -1175,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#a6f0fb04e692d82a2e1c84d596bec09bc3410518"
+source = "git+https://github.com/habitat-sh/core.git#d40b435ab72875a11519a64732cc2fd3e998d899"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This enables us to take advantage of https://github.com/habitat-sh/core/pull/46

![](https://media.giphy.com/media/l8XYZYdlOHSrS/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>