### PR TITLE
Fix a minor issue with finding the files to run shellcheck against

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -235,7 +235,7 @@ generate_bldr_keys() {
   keys=( $(find /hab/cache/keys -name "bldr-*.pub") )
 
   if [ "${#keys[@]}" -gt 0 ]; then
-    KEY_NAME=$(echo $keys[0] | grep -Po "bldr-\d+")
+    KEY_NAME=$(echo "${keys[0]}" | grep -Po "bldr-\d+")
     echo "Re-using existing builder key: $KEY_NAME"
   else
     KEY_NAME=$(hab user key generate bldr | grep -Po "bldr-\d+")

--- a/components/builder-api-proxy/habitat/hooks/health_check
+++ b/components/builder-api-proxy/habitat/hooks/health_check
@@ -2,7 +2,7 @@
 rc=0
 
 {{pkgPathFor "core/curl"}}/bin/curl --head --fail --max-time 1 -s \
-  http://{{sys.ip}}:{{cfg.http.listen_port}}/health > /dev/null
+  "http://{{sys.ip}}:{{cfg.http.listen_port}}/health" > /dev/null
 
 case $? in
   0)

--- a/components/builder-api-proxy/habitat/hooks/init
+++ b/components/builder-api-proxy/habitat/hooks/init
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-mkdir -p {{pkg.svc_var_path}}/nginx
+mkdir -p "{{pkg.svc_var_path}}/nginx"

--- a/components/builder-api/habitat/hooks/health_check
+++ b/components/builder-api/habitat/hooks/health_check
@@ -2,7 +2,7 @@
 rc=0
 
 {{pkgPathFor "core/curl"}}/bin/curl --head --fail --max-time 1 -s \
-  http://{{sys.ip}}:{{cfg.http.listen_port}}/v1/status > /dev/null
+  "http://{{sys.ip}}:{{cfg.http.listen_port}}/v1/status" > /dev/null
 
 case $? in
   0)

--- a/components/builder-api/habitat/hooks/run
+++ b/components/builder-api/habitat/hooks/run
@@ -1,17 +1,15 @@
-#!/bin/sh
-# shellcheck disable=1083
+#!/bin/bash
 
-
-export HOME={{pkg.svc_data_path}}
-export RUST_LOG={{cfg.log_level}}
+export HOME="{{pkg.svc_data_path}}"
+export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run="bldr-api start -c {{pkg.svc_config_path}}/config.toml"
+pkg_svc_run=(bldr-api start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
-    -U {{pkg.svc_user}}:{{pkg.svc_group}} \
-    -u {{pkg.svc_user}}:{{pkg.svc_group}} \
-    "${pkg_svc_run}" 2>&1
+    -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    "${pkg_svc_run[@]}" 2>&1
 else
-  exec "${pkg_svc_run}" 2>&1
+  exec "${pkg_svc_run[@]}" 2>&1
 fi

--- a/components/builder-api/habitat/hooks/run
+++ b/components/builder-api/habitat/hooks/run
@@ -1,15 +1,17 @@
 #!/bin/sh
+# shellcheck disable=1083
+
 
 export HOME={{pkg.svc_data_path}}
 export RUST_LOG={{cfg.log_level}}
 export RUST_BACKTRACE=1
 pkg_svc_run="bldr-api start -c {{pkg.svc_config_path}}/config.toml"
 
-if [ "\$(whoami)" = "root" ]; then
+if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U {{pkg.svc_user}}:{{pkg.svc_group}} \
     -u {{pkg.svc_user}}:{{pkg.svc_group}} \
-    ${pkg_svc_run} 2>&1
+    "${pkg_svc_run}" 2>&1
 else
-  exec ${pkg_svc_run} 2>&1
+  exec "${pkg_svc_run}" 2>&1
 fi

--- a/components/builder-datastore/hooks/init
+++ b/components/builder-datastore/hooks/init
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=1083
 set -e
 
 exec 2>&1
@@ -11,7 +12,7 @@ mkdir -p {{pkg.svc_var_path}}/pg_stat_tmp
 chown -R hab:hab {{pkg.svc_var_path}}
 touch $RANDFILE
 
-if [[ ! -f "{{pkg.svc_data_path}}/PG_VERSION" ]]; then
+if [ ! -f "{{pkg.svc_data_path}}/PG_VERSION" ]; then
   echo " Database does not exist, creating with 'initdb'"
   openssl rand -base64 32 > {{pkg.svc_config_path}}/pwfile
   initdb -U hab \

--- a/components/builder-datastore/hooks/run
+++ b/components/builder-datastore/hooks/run
@@ -1,11 +1,12 @@
 #!/bin/sh
 #
 
-export PGDATA={{pkg.svc_data_path}}
+export PGDATA="{{pkg.svc_data_path}}"
 
 exec 2>&1
 
-chmod 0700 {{pkg.svc_data_path}}
+chmod 0700 "{{pkg.svc_data_path}}"
 
+# shellcheck disable=1083
 exec {{pkgPathFor "core/postgresql"}}/bin/postmaster \
   -c config_file={{pkg.svc_config_path}}/postgresql.conf

--- a/components/builder-jobsrv/habitat/hooks/init
+++ b/components/builder-jobsrv/habitat/hooks/init
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=1083
 set -e
 
 export PGPASSWORD="{{cfg.datastore.password}}"

--- a/components/builder-jobsrv/habitat/hooks/run
+++ b/components/builder-jobsrv/habitat/hooks/run
@@ -1,15 +1,16 @@
 #!/bin/sh
+# shellcheck disable=1083
 
 export HOME={{pkg.svc_data_path}}
 export RUST_LOG={{cfg.log_level}}
 export RUST_BACKTRACE=1
 pkg_svc_run="bldr-jobsrv start -c {{pkg.svc_config_path}}/config.toml"
 
-if [ "\$(whoami)" = "root" ]; then
+if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U {{pkg.svc_user}}:{{pkg.svc_group}} \
     -u {{pkg.svc_user}}:{{pkg.svc_group}} \
-    ${pkg_svc_run} 2>&1
+    "${pkg_svc_run}" 2>&1
 else
-  exec ${pkg_svc_run} 2>&1
+  exec "${pkg_svc_run}" 2>&1
 fi

--- a/components/builder-jobsrv/habitat/hooks/run
+++ b/components/builder-jobsrv/habitat/hooks/run
@@ -1,16 +1,15 @@
-#!/bin/sh
-# shellcheck disable=1083
+#!/bin/bash
 
-export HOME={{pkg.svc_data_path}}
-export RUST_LOG={{cfg.log_level}}
+export HOME="{{pkg.svc_data_path}}"
+export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run="bldr-jobsrv start -c {{pkg.svc_config_path}}/config.toml"
+pkg_svc_run=(bldr-jobsrv start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
-    -U {{pkg.svc_user}}:{{pkg.svc_group}} \
-    -u {{pkg.svc_user}}:{{pkg.svc_group}} \
-    "${pkg_svc_run}" 2>&1
+    -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    "${pkg_svc_run[@]}" 2>&1
 else
-  exec "${pkg_svc_run}" 2>&1
+  exec "${pkg_svc_run[@]}" 2>&1
 fi

--- a/components/builder-minio/habitat/hooks/init
+++ b/components/builder-minio/habitat/hooks/init
@@ -3,7 +3,7 @@
 exec 2>&1
 
 {{#if cfg.use_ssl}}
-    mkdir -p {{pkg.svc_config_path}}/certs
-    cp {{pkg.svc_files_path}}/private.key {{pkg.svc_config_path}}/certs/private.key
-    cp {{pkg.svc_files_path}}/public.crt {{pkg.svc_config_path}}/certs/private.crt
+    mkdir -p "{{pkg.svc_config_path}}/certs"
+    cp "{{pkg.svc_files_path}}/private.key" "{{pkg.svc_config_path}}/certs/private.key"
+    cp "{{pkg.svc_files_path}}/public.crt" "{{pkg.svc_config_path}}/certs/private.crt"
 {{/if ~}}

--- a/components/builder-minio/habitat/hooks/run
+++ b/components/builder-minio/habitat/hooks/run
@@ -6,10 +6,10 @@ export MINIO_ACCESS_KEY="{{cfg.key_id}}"
 export MINIO_SECRET_KEY="{{cfg.secret_key}}"
 
 {{#if cfg.ssl_cert_pw}}
-    export MINIO_CERT_PASSWD={{cfg.ssl_cert_pw}}
+    export MINIO_CERT_PASSWD="{{cfg.ssl_cert_pw}}"
 {{/if ~}}
 
 exec minio server \
---config-dir {{pkg.svc_config_path}} \
-{{pkg.svc_data_path}}
+--config-dir "{{pkg.svc_config_path}}" \
+"{{pkg.svc_data_path}}"
 

--- a/components/builder-originsrv/habitat/hooks/init
+++ b/components/builder-originsrv/habitat/hooks/init
@@ -8,4 +8,4 @@ PSQL_ARGS="-w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.p
 # Create the DB or check that it exists
 createdb $PSQL_ARGS || psql -c ";" $PSQL_ARGS
 
-bldr-originsrv migrate -c {{pkg.svc_config_path}}/config.toml
+bldr-originsrv migrate -c "{{pkg.svc_config_path}}/config.toml"

--- a/components/builder-originsrv/habitat/hooks/run
+++ b/components/builder-originsrv/habitat/hooks/run
@@ -1,15 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run="bldr-originsrv start -c {{pkg.svc_config_path}}/config.toml"
+pkg_svc_run=(bldr-originsrv start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
     -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
-    "${pkg_svc_run}" 2>&1
+    "${pkg_svc_run[@]}" 2>&1
 else
-  exec "${pkg_svc_run}" 2>&1
+  exec "${pkg_svc_run[@]}" 2>&1
 fi

--- a/components/builder-originsrv/habitat/hooks/run
+++ b/components/builder-originsrv/habitat/hooks/run
@@ -1,15 +1,15 @@
 #!/bin/sh
 
-export HOME={{pkg.svc_data_path}}
-export RUST_LOG={{cfg.log_level}}
+export HOME="{{pkg.svc_data_path}}"
+export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
 pkg_svc_run="bldr-originsrv start -c {{pkg.svc_config_path}}/config.toml"
 
-if [ "\$(whoami)" = "root" ]; then
+if [ "$(whoami)" = "root" ]; then
   exec chpst \
-    -U {{pkg.svc_user}}:{{pkg.svc_group}} \
-    -u {{pkg.svc_user}}:{{pkg.svc_group}} \
-    ${pkg_svc_run} 2>&1
+    -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    "${pkg_svc_run}" 2>&1
 else
-  exec ${pkg_svc_run} 2>&1
+  exec "${pkg_svc_run}" 2>&1
 fi

--- a/components/builder-router/habitat/hooks/run
+++ b/components/builder-router/habitat/hooks/run
@@ -1,15 +1,15 @@
 #!/bin/sh
 
-export HOME={{pkg.svc_data_path}}
-export RUST_LOG={{cfg.log_level}}
+export HOME="{{pkg.svc_data_path}}"
+export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
 pkg_svc_run="bldr-router start -c {{pkg.svc_config_path}}/config.toml"
 
-if [ "\$(whoami)" = "root" ]; then
+if [ "$(whoami)" = "root" ]; then
   exec chpst \
-    -U {{pkg.svc_user}}:{{pkg.svc_group}} \
-    -u {{pkg.svc_user}}:{{pkg.svc_group}} \
-    ${pkg_svc_run} 2>&1
+    -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    "${pkg_svc_run}" 2>&1
 else
-  exec ${pkg_svc_run} 2>&1
+  exec "${pkg_svc_run}" 2>&1
 fi

--- a/components/builder-router/habitat/hooks/run
+++ b/components/builder-router/habitat/hooks/run
@@ -1,15 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run="bldr-router start -c {{pkg.svc_config_path}}/config.toml"
+pkg_svc_run=(bldr-router start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
     -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
-    "${pkg_svc_run}" 2>&1
+    "${pkg_svc_run[@]}" 2>&1
 else
-  exec "${pkg_svc_run}" 2>&1
+  exec "${pkg_svc_run[@]}" 2>&1
 fi

--- a/components/builder-sessionsrv/habitat/hooks/init
+++ b/components/builder-sessionsrv/habitat/hooks/init
@@ -8,4 +8,4 @@ PSQL_ARGS="-w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.p
 # Create the DB or check that it exists
 createdb $PSQL_ARGS || psql -c ";" $PSQL_ARGS
 
-bldr-sessionsrv migrate -c {{pkg.svc_config_path}}/config.toml
+bldr-sessionsrv migrate -c "{{pkg.svc_config_path}}/config.toml"

--- a/components/builder-sessionsrv/habitat/hooks/run
+++ b/components/builder-sessionsrv/habitat/hooks/run
@@ -1,15 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run="bldr-sessionsrv start -c {{pkg.svc_config_path}}/config.toml"
+pkg_svc_run=(bldr-sessionsrv start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
     -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
-    "${pkg_svc_run}" 2>&1
+    "${pkg_svc_run[@]}" 2>&1
 else
-  exec "${pkg_svc_run}" 2>&1
+  exec "${pkg_svc_run[@]}" 2>&1
 fi

--- a/components/builder-sessionsrv/habitat/hooks/run
+++ b/components/builder-sessionsrv/habitat/hooks/run
@@ -1,15 +1,15 @@
 #!/bin/sh
 
-export HOME={{pkg.svc_data_path}}
-export RUST_LOG={{cfg.log_level}}
+export HOME="{{pkg.svc_data_path}}"
+export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
 pkg_svc_run="bldr-sessionsrv start -c {{pkg.svc_config_path}}/config.toml"
 
-if [ "\$(whoami)" = "root" ]; then
+if [ "$(whoami)" = "root" ]; then
   exec chpst \
-    -U {{pkg.svc_user}}:{{pkg.svc_group}} \
-    -u {{pkg.svc_user}}:{{pkg.svc_group}} \
-    ${pkg_svc_run} 2>&1
+    -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
+    "${pkg_svc_run}" 2>&1
 else
-  exec ${pkg_svc_run} 2>&1
+  exec "${pkg_svc_run}" 2>&1
 fi

--- a/components/builder-web/bin/build-css
+++ b/components/builder-web/bin/build-css
@@ -12,5 +12,5 @@ node-sass \
   --recursive=true \
   --output=assets \
   --output-style=compressed \
-  $@ \
+  "$@" \
   app/app.scss

--- a/components/builder-worker/habitat/hooks/run
+++ b/components/builder-worker/habitat/hooks/run
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
 export HAB_STUDIO_BACKLINE_PKG=core/hab-backline
-pkg_svc_run="bldr-worker start -c {{pkg.svc_config_path}}/config.toml"
+pkg_svc_run=(bldr-worker start -c "{{pkg.svc_config_path}}/config.toml")
 
 # Wait for pem file before starting the service
 while ! [ -f "{{pkg.svc_files_path}}/builder-github-app.pem" ];
@@ -13,4 +13,4 @@ do
     sleep 30
 done
 
-exec "${pkg_svc_run}" 2>&1
+exec "${pkg_svc_run[@]}" 2>&1

--- a/components/builder-worker/habitat/hooks/run
+++ b/components/builder-worker/habitat/hooks/run
@@ -1,16 +1,16 @@
 #!/bin/sh
 
-export HOME={{pkg.svc_data_path}}
-export RUST_LOG={{cfg.log_level}}
+export HOME="{{pkg.svc_data_path}}"
+export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
 export HAB_STUDIO_BACKLINE_PKG=core/hab-backline
 pkg_svc_run="bldr-worker start -c {{pkg.svc_config_path}}/config.toml"
 
 # Wait for pem file before starting the service
-while ! [ -f {{pkg.svc_files_path}}/builder-github-app.pem ];
+while ! [ -f "{{pkg.svc_files_path}}/builder-github-app.pem" ];
 do
     echo "Waiting for builder-github-app.pem"
     sleep 30
 done
 
-exec ${pkg_svc_run} 2>&1
+exec "${pkg_svc_run}" 2>&1

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -18,7 +18,7 @@ shellcheck --version
 # https://github.com/koalaman/shellcheck/wiki/SC2034
 find . -type f \
   -and \( -name "*.*sh" \
-      -or -exec sh -c 'file -b "$1" | grep -q "shell script"' {} \; \) \
+      -or -exec sh -c 'file -b "$1" | grep -q "shell script"' -- {} \; \) \
   -and \! -path "*.sample" \
   -and \! -path "*.ps1" \
   -and \! -path "./test/builder-api/node_modules/*" \

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -22,6 +22,11 @@ find . -type f \
   -and \! -path "*.sample" \
   -and \! -path "*.ps1" \
   -and \! -path "./test/builder-api/node_modules/*" \
+  -and \! -path "./components/builder-api/habitat/hooks/health_check" \
+  -and \! -path "./components/builder-api-proxy/habitat/hooks/health_check" \
+  -and \! -path "./components/builder-api-proxy/habitat/hooks/init" \
+  -and \! -path "./components/builder-minio/habitat/hooks/init" \
+  -and \! -path "./components/builder-minio/habitat/hooks/run" \
   -print \
   | xargs shellcheck --external-sources --exclude=1090,1091,2148,2034
 


### PR DESCRIPTION
The builder version of https://github.com/habitat-sh/habitat/pull/5396

Pretty much all the changes are just double-quotes to suppress unwanted expansion. There is one legit bug (occurring in several places) that I've called out with a comment.