### PR TITLE
Fix JWT token for github app

### DIFF
--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -276,8 +276,8 @@ where
     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     let expiration = now + Duration::from_secs(10 * 10);
     let payload = json!({
-        "iat" : now.as_secs().to_string(),
-        "exp" : expiration.as_secs().to_string(),
+        "iat" : now.as_secs(),
+        "exp" : expiration.as_secs(),
         "iss" : app_id.to_string()});
 
     let header = json!({});


### PR DESCRIPTION
Fixing a regression in JWT usage for github apps, which expects integer values for the issued and expiration timestamps, where we were encoding as strings.

Signed-off-by: Salim Alam <salam@chef.io>
![tenor-225873848](https://user-images.githubusercontent.com/13542112/43545660-5ad7a6b2-958b-11e8-932f-68d95aaf1d3a.gif)

