### PR TITLE
Fix for Rust 1.28 incompatibility

### DIFF
--- a/components/builder-core/src/metrics.rs
+++ b/components/builder-core/src/metrics.rs
@@ -129,8 +129,11 @@ fn receive(rz: SyncSender<()>, rx: Receiver<MetricTuple>) {
             Some(ref mut cli) => match mtyp {
                 MetricType::Counter => {
                     match mop {
-                        MetricOperation::Increment => cli.incr(mid.borrow(), &mtags)
-                            .unwrap_or_else(|e| warn!("Could not increment metric; {:?}", e)),
+                        MetricOperation::Increment => {
+                            let mid_str: &str = mid.borrow();
+                            cli.incr(mid_str, &mtags)
+                                .unwrap_or_else(|e| warn!("Could not increment metric; {:?}", e))
+                        }
                     };
                 }
             },


### PR DESCRIPTION
Fix a breakage with Rust 1.28

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-104911940](https://user-images.githubusercontent.com/13542112/43608914-5531aca4-9657-11e8-9b01-75752c4810c5.gif)
