### PR TITLE
Clean up builder-api config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,12 +735,14 @@ name = "habitat_builder_api"
 version = "0.0.0"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bodyparser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.212 (registry+https://github.com/rust-lang/crates.io-index)",
  "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -13,10 +13,12 @@ doc = false
 
 [dependencies]
 base64 = "*"
+bitflags = "1"
 bodyparser = "*"
 clippy = {version = "*", optional = true}
 constant_time_eq = "*"
 env_logger = "*"
+features = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
 hex = "*"
 hyper = "0.10"

--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -1,7 +1,12 @@
-log_dir = "{{pkg.svc_var_path}}"
+[api]
+data_path = "{{pkg.svc_data_path}}"
+log_path = "{{pkg.svc_var_path}}"
+key_path = "{{pkg.svc_files_path}}"
+{{toToml cfg.api}}
 
-[ui]
-root = "{{pkg.svc_static_path}}"
+[github]
+app_private_key = "{{pkg.svc_files_path}}/builder-github-app.pem"
+{{toToml cfg.github}}
 
 [http]
 {{toToml cfg.http}}
@@ -9,24 +14,20 @@ root = "{{pkg.svc_static_path}}"
 [oauth]
 {{toToml cfg.oauth}}
 
-[github]
-app_private_key = "{{pkg.svc_files_path}}/builder-github-app.pem"
-{{toToml cfg.github}}
-
-[segment]
-{{toToml cfg.segment}}
-
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]
 host = "{{member.sys.ip}}"
 port = {{member.cfg.port}}
 {{~/eachAlive}}
 
-[depot]
-path = "{{pkg.svc_data_path}}"
-log_dir = "{{pkg.svc_var_path}}"
-key_dir = "{{pkg.svc_files_path}}"
-{{toToml cfg.depot}}
-
 [s3]
 {{toToml cfg.s3}}
+
+[segment]
+{{toToml cfg.segment}}
+
+[ui]
+root = "{{pkg.svc_static_path}}"
+
+[upstream]
+{{toToml cfg.upstream}}

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -1,5 +1,8 @@
 log_level = "info"
-jobsrv_enabled = true
+
+[api]
+features_enabled = "jobsrv"
+targets = ["x86_64-linux", "x86_64-windows"]
 
 [http]
 listen = "0.0.0.0"
@@ -18,12 +21,6 @@ api_url        = "https://api.github.com"
 app_id         = 5565
 webhook_secret = ""
 
-[depot]
-builds_enabled          = true
-non_core_builds_enabled = true
-events_enabled          = false
-jobsrv_enabled          = true
-
 [segment]
 url       = "https://api.segment.io"
 write_key = ""
@@ -34,3 +31,7 @@ key_id = "depot"
 secret_key = "password"
 endpoint = "http://localhost:9000"
 bucket_name = "habitat-builder-artifact-store.default"
+
+[upstream]
+endpoint = "http://localhost"
+origins = ["core"]

--- a/components/builder-api/src/handlers/integrations.rs
+++ b/components/builder-api/src/handlers/integrations.rs
@@ -36,14 +36,14 @@ use Config;
 pub fn encrypt(req: &mut Request, content: &str) -> Result<String, Status> {
     let depot = req.get::<persistent::Read<Config>>().unwrap();
 
-    bldr_core::integrations::encrypt(&depot.key_dir, content.as_bytes())
+    bldr_core::integrations::encrypt(&depot.api.key_path, content.as_bytes())
         .map_err(|_| status::InternalServerError)
 }
 
 pub fn decrypt(req: &mut Request, content: &str) -> Result<String, Status> {
     let depot = req.get::<persistent::Read<Config>>().unwrap();
 
-    let bytes = bldr_core::integrations::decrypt(&depot.key_dir, content)
+    let bytes = bldr_core::integrations::decrypt(&depot.api.key_path, content)
         .map_err(|_| status::InternalServerError)?;
     Ok(String::from_utf8(bytes).map_err(|_| status::InternalServerError)?)
 }

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -16,9 +16,13 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
 extern crate base64;
+#[macro_use]
+extern crate bitflags;
 extern crate bodyparser;
 extern crate builder_core as bldr_core;
 extern crate constant_time_eq;
+#[macro_use]
+extern crate features;
 extern crate github_api_client;
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;
@@ -83,6 +87,14 @@ pub mod upstream;
 pub use self::config::Config;
 pub use self::error::{Error, Result};
 
+features! {
+    pub mod feat {
+        const List = 0b00000001,
+        const Jobsrv = 0b00000010,
+        const Upstream = 0b00000100
+    }
+}
+
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -124,6 +136,6 @@ impl DepotUtil for config::Config {
     }
 
     fn packages_path(&self) -> PathBuf {
-        Path::new(&self.path).join("pkgs")
+        Path::new(&self.api.data_path).join("pkgs")
     }
 }

--- a/components/builder-api/src/main.rs
+++ b/components/builder-api/src/main.rs
@@ -79,7 +79,7 @@ fn config_from_args(matches: &clap::ArgMatches) -> Result<Config> {
         }
     }
     if let Some(path) = args.value_of("path") {
-        config.path = PathBuf::from(path);
+        config.api.data_path = PathBuf::from(path);
     }
     Ok(config)
 }

--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -240,8 +240,9 @@ pub fn generate_access_token(req: &mut Request) -> IronResult<Response> {
 
     let mut request = AccountTokenCreate::new();
     let cfg = req.get::<persistent::Read<Config>>().unwrap();
-    let token = bldr_core::access_token::generate_user_token(&cfg.key_dir, account.get_id(), flags)
-        .unwrap();
+    let token =
+        bldr_core::access_token::generate_user_token(&cfg.api.key_path, account.get_id(), flags)
+            .unwrap();
 
     request.set_account_id(account.get_id());
     request.set_token(token);
@@ -932,13 +933,6 @@ pub fn project_show(req: &mut Request) -> IronResult<Response> {
         Some(o) => o,
         None => return Ok(Response::with(status::BadRequest)),
     };
-
-    let cfg = req.get::<persistent::Read<Config>>().unwrap();
-    if !cfg.non_core_builds_enabled {
-        if origin != "core" {
-            return Ok(Response::with(status::Forbidden));
-        }
-    }
 
     let name = match get_param(req, "name") {
         Some(n) => n,

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -51,14 +51,14 @@ pub mod runner;
 pub mod server;
 pub mod vcs;
 
-pub use self::config::Config;
-pub use self::error::{Error, Result};
-
 features! {
     pub mod feat {
         const List = 0b00000001
     }
 }
+
+pub use self::config::Config;
+pub use self::error::{Error, Result};
 
 pub const PRODUCT: &'static str = "builder-worker";
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));


### PR DESCRIPTION
This change cleans up the builder-api config - it creates a new api section to consolidate some of the old depot configs, as well as others on the root.  Some configs that are not needed (such as events_enabled, etc) are removed. This change also now leverages the features crate and a features_enabled config - job server and upstream enablement are now done via the features_enabled flags.  This gives us a bunch of headroom to add new optional features without adding new config booleans directly. 

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-80903730](https://user-images.githubusercontent.com/13542112/43809413-e3d6c03a-9a66-11e8-85d1-6c57b0f245ee.gif)
