### PR TITLE
Pass --auth to integrations for private packages

### DIFF
--- a/components/builder-worker/src/runner/docker.rs
+++ b/components/builder-worker/src/runner/docker.rs
@@ -59,15 +59,22 @@ pub struct DockerExporter<'a> {
     spec: DockerExporterSpec,
     workspace: &'a Workspace,
     bldr_url: &'a str,
+    auth_token: &'a String,
 }
 
 impl<'a> DockerExporter<'a> {
     /// Creates a new Docker exporter for a given `Workspace` and Builder URL.
-    pub fn new(spec: DockerExporterSpec, workspace: &'a Workspace, bldr_url: &'a str) -> Self {
+    pub fn new(
+        spec: DockerExporterSpec,
+        workspace: &'a Workspace,
+        bldr_url: &'a str,
+        auth_token: &'a String,
+    ) -> Self {
         DockerExporter {
             spec,
             workspace,
             bldr_url,
+            auth_token,
         }
     }
 
@@ -99,6 +106,8 @@ impl<'a> DockerExporter<'a> {
         cmd.arg(&self.bldr_url);
         cmd.arg("--url");
         cmd.arg(&self.bldr_url);
+        cmd.arg("--auth");
+        cmd.arg(&self.auth_token);
         // TODO fn: Due to the flag regrssion in 0.53.0, this flag does not exist and triggers an
         // export failure. For the moment we will remove this flag which may result in some
         // `:latest` tags not being pushed to remote repositories.

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -461,6 +461,7 @@ impl Runner {
                     util::docker_exporter_spec(&self.workspace),
                     &self.workspace,
                     &self.config.bldr_url,
+                    &self.bldr_token,
                 ).export(streamer)?;
 
                 if !status.success() {


### PR DESCRIPTION
This should resolve #353. That being said - I'm not 100% certain if this is a safe behavior or not. I would assume that it is since we never flush this token to disk or logs or the like. But, it's probably worth being aware that the token we generate for the workspace is the token we pass through to the export command.
Signed-off-by: Ian Henry <ihenry@chef.io>