### PR TITLE
Add sup_release_channel

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -781,7 +781,7 @@ data "template_file" "sup_service" {
   template = "${file("${path.module}/templates/hab-sup.service")}"
 
   vars {
-    flags     = "--auto-update --peer ${join(" ", var.peers)} --channel ${var.release_channel} --events hab-eventsrv.default --listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port}"
+    flags     = "--auto-update --peer ${join(" ", var.peers)} --channel ${var.sup_release_channel} --events hab-eventsrv.default --listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port}"
     log_level = "${var.log_level}"
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,6 +52,11 @@ variable "release_channel" {
   default     = "stable"
 }
 
+variable "sup_release_channel" {
+  description = "Release channel in Builder to receive Supervisor package updates from"
+  default     = "builder-live"
+}
+
 variable "log_level" {
   description = "Logging level for the Habitat Supervisor"
   default     = "info"


### PR DESCRIPTION
Add sup_release_channel var to control where Supervisor updates will be coming from.
Works in conjunction with updated cloud-environments infra.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-88803436](https://user-images.githubusercontent.com/13542112/43976291-f7e2849e-9c94-11e8-8d7e-2f7a83ab8ea8.gif)
