### PR TITLE
Fix the path to config.sh in the dev docs

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -161,7 +161,7 @@ Then, issue the following command:
 hab config apply builder-api.default $(date +%s) upstream.toml
 ```
 
-_Note: the config can also be added directly to the builder-api `user.toml` by modifying the `support/config.sh` file._
+_Note: the config can also be added directly to the builder-api `user.toml` by modifying the `support/builder/config.sh` file._
 
 After the config is successfully applied, the services should be configured to use the upstream.
 


### PR DESCRIPTION
The root-relative location of the file is `support/builder/config.sh`.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/hPPx8yk3Bmqys/200.gif)