### PR TITLE
Don't use arrays in run hooks

### DIFF
--- a/components/builder-api/habitat/hooks/run
+++ b/components/builder-api/habitat/hooks/run
@@ -3,13 +3,12 @@
 export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run=(bldr-api start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
     -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
-    "${pkg_svc_run[@]}" 2>&1
+    bldr-api start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 else
-  exec "${pkg_svc_run[@]}" 2>&1
+  exec bldr-api start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 fi

--- a/components/builder-jobsrv/habitat/hooks/run
+++ b/components/builder-jobsrv/habitat/hooks/run
@@ -3,13 +3,12 @@
 export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run=(bldr-jobsrv start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
     -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
-    "${pkg_svc_run[@]}" 2>&1
+    bldr-jobsrv start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 else
-  exec "${pkg_svc_run[@]}" 2>&1
+  exec bldr-jobsrv start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 fi

--- a/components/builder-originsrv/habitat/hooks/run
+++ b/components/builder-originsrv/habitat/hooks/run
@@ -3,13 +3,12 @@
 export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run=(bldr-originsrv start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
     -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
-    "${pkg_svc_run[@]}" 2>&1
+    bldr-originsrv start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 else
-  exec "${pkg_svc_run[@]}" 2>&1
+  exec bldr-originsrv start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 fi

--- a/components/builder-router/habitat/hooks/run
+++ b/components/builder-router/habitat/hooks/run
@@ -3,13 +3,12 @@
 export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run=(bldr-router start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
     -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
-    "${pkg_svc_run[@]}" 2>&1
+    bldr-router start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 else
-  exec "${pkg_svc_run[@]}" 2>&1
+  exec bldr-router start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 fi

--- a/components/builder-sessionsrv/habitat/hooks/run
+++ b/components/builder-sessionsrv/habitat/hooks/run
@@ -3,13 +3,12 @@
 export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
-pkg_svc_run=(bldr-sessionsrv start -c "{{pkg.svc_config_path}}/config.toml")
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \
     -u "{{pkg.svc_user}}:{{pkg.svc_group}}" \
-    "${pkg_svc_run[@]}" 2>&1
+    bldr-sessionsrv start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 else
-  exec "${pkg_svc_run[@]}" 2>&1
+  exec bldr-sessionsrv start -c "{{pkg.svc_config_path}}/config.toml" 2>&1
 fi

--- a/components/builder-worker/habitat/hooks/run
+++ b/components/builder-worker/habitat/hooks/run
@@ -4,7 +4,6 @@ export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
 export HAB_STUDIO_BACKLINE_PKG=core/hab-backline
-pkg_svc_run=(bldr-worker start -c "{{pkg.svc_config_path}}/config.toml")
 
 # Wait for pem file before starting the service
 while ! [ -f "{{pkg.svc_files_path}}/builder-github-app.pem" ];
@@ -13,4 +12,4 @@ do
     sleep 30
 done
 
-exec "${pkg_svc_run[@]}" 2>&1
+exec bldr-worker start -c "{{pkg.svc_config_path}}/config.toml" 2>&1


### PR DESCRIPTION
When exported to a docker container `/bin/bash` is actually ash which
 doesn't support arrays.

Fix for #608

Signed-off-by: James Casey <james@chef.io>