### PR TITLE
Allow builder-api to run on non-localhost

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -83,7 +83,7 @@ http {
                    '"$http_referer" "$http_user_agent" - $http_x_forwarded_for';
 
   upstream backend {
-    server 127.0.0.1:{{bind.http.first.cfg.port}};
+    server {{bind.http.first.sys.ip}}:{{bind.http.first.cfg.port}};
   }
 
   {{~#if cfg.server.listen_tls}}


### PR DESCRIPTION
builder-api and buider-api-proxy are on different IPs when run in
containers.  Stop binding to only localhost

Signed-off-by: James Casey <james@chef.io>