### PR TITLE
 Add post-run hook to create bucket in minio 

### DIFF
--- a/components/builder-minio/habitat/default.toml
+++ b/components/builder-minio/habitat/default.toml
@@ -1,6 +1,5 @@
 key_id = "depot"
 secret_key = "password"
 use_ssl = false
-gen_cert = false
 ssl_cert_pw = ""
 bucket_name = "habitat-builder-artifact-store.default"

--- a/components/builder-minio/habitat/default.toml
+++ b/components/builder-minio/habitat/default.toml
@@ -3,3 +3,4 @@ secret_key = "password"
 use_ssl = false
 gen_cert = false
 ssl_cert_pw = ""
+bucket_name = "habitat-builder-artifact-store.default"

--- a/components/builder-minio/habitat/hooks/post-run
+++ b/components/builder-minio/habitat/hooks/post-run
@@ -11,9 +11,9 @@ MINIO_ENDPOINT="--endpoint-url https://localhost:9000 --no-verify-ssl"
 MINIO_ENDPOINT="--endpoint-url http://localhost:9000"
 {{ /if }}
 
-if {{pkgPathFor "core/aws-cli"}}/bin/aws $MINIO_ENDPOINT s3api list-buckets | grep "{{cfg.bucket_name}}" > /dev/null; then
+if aws $MINIO_ENDPOINT s3api list-buckets | grep "{{cfg.bucket_name}}" > /dev/null; then
   echo "Minio already configured"
 else
   echo "Creating bucket in Minio"
-  {{pkgPathFor "core/aws-cli"}}/bin/aws  $MINIO_ENDPOINT s3api create-bucket --bucket "{{cfg.bucket_name}}"
+  aws  $MINIO_ENDPOINT s3api create-bucket --bucket "{{cfg.bucket_name}}"
 fi

--- a/components/builder-minio/habitat/hooks/post-run
+++ b/components/builder-minio/habitat/hooks/post-run
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+exec 2>&1
+
+export AWS_ACCESS_KEY_ID="{{cfg.key_id}}"
+export AWS_SECRET_ACCESS_KEY="{{cfg.secret_key}}"
+
+{{ #if cfg.use_ssl }}
+MINIO_ENDPOINT="--endpoint-url https://localhost:9000 --no-verify-ssl"
+{{else ~}}
+MINIO_ENDPOINT="--endpoint-url http://localhost:9000"
+{{ /if }}
+
+if {{pkgPathFor "core/aws-cli"}}/bin/aws $MINIO_ENDPOINT s3api list-buckets | grep "{{cfg.bucket_name}}" > /dev/null; then
+  echo "Minio already configured"
+else
+  echo "Creating bucket in Minio"
+  {{pkgPathFor "core/aws-cli"}}/bin/aws  $MINIO_ENDPOINT s3api create-bucket --bucket "{{cfg.bucket_name}}"
+fi

--- a/components/builder-minio/habitat/plan.sh
+++ b/components/builder-minio/habitat/plan.sh
@@ -3,7 +3,7 @@ pkg_version="0.1.0"
 pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/minio core/cacerts core/openssl)
+pkg_deps=(core/minio core/cacerts core/openssl core/aws-cli)
 
 do_unpack() {
     return 0

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -27,6 +27,7 @@ find . -type f \
   -and \! -path "./components/builder-api-proxy/habitat/hooks/init" \
   -and \! -path "./components/builder-minio/habitat/hooks/init" \
   -and \! -path "./components/builder-minio/habitat/hooks/run" \
+  -and \! -path "./components/builder-minio/habitat/hooks/post-run" \
   -print \
   | xargs shellcheck --external-sources --exclude=1090,1091,2148,2034
 


### PR DESCRIPTION
This was currently done by the provision.sh but this means if you
fire up the minio service you end up with an unconfigured instance.

This puts the config into a post-run hook (and means a docker 
exported habitat/builder-minio now comes up properly configured)

Signed-off-by: James Casey <james@chef.io>