### PR TITLE
Converts github service to use actix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,7 @@ dependencies = [
  "habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_net 0.0.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth-client 0.0.0",

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -22,6 +22,7 @@ env_logger = "*"
 features = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
 hex = "*"
+hyper = "*"
 log = "*"
 num_cpus = "*"
 openssl = "0.10"

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -30,6 +30,7 @@ extern crate habitat_core as hab_core;
 extern crate habitat_http_client as http_client;
 extern crate habitat_net as hab_net;
 extern crate hex;
+extern crate hyper;
 #[macro_use]
 extern crate log;
 extern crate oauth_client;

--- a/components/builder-api/src/main.rs
+++ b/components/builder-api/src/main.rs
@@ -15,52 +15,21 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
-extern crate actix_web;
-extern crate base64;
-#[macro_use]
-extern crate bitflags;
-extern crate builder_core as bldr_core;
-extern crate bytes;
-extern crate habitat_builder_api as bldr_api;
 #[macro_use]
 extern crate clap;
 extern crate env_logger;
-#[macro_use]
-extern crate features;
-extern crate futures;
-extern crate github_api_client;
-extern crate habitat_builder_protocol as protocol;
+extern crate habitat_builder_api as bldr_api;
 extern crate habitat_core as hab_core;
-extern crate habitat_net as hab_net;
 #[macro_use]
 extern crate log;
-extern crate num_cpus;
-extern crate protobuf;
-extern crate regex;
-extern crate rusoto_core as rusoto;
-extern crate rusoto_s3;
-extern crate segment_api_client;
-extern crate serde;
-extern crate tempfile;
-extern crate time;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate serde_json;
-extern crate oauth_client;
-extern crate url;
-extern crate uuid;
-extern crate zmq;
 
 use std::fmt;
 use std::path::PathBuf;
 use std::process;
 use std::str::FromStr;
 
-mod config;
-mod server;
-
-use config::Config;
+use bldr_api::config::Config;
+use bldr_api::server;
 use hab_core::config::ConfigFile;
 
 const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));

--- a/components/builder-api/src/server/framework/headers.rs
+++ b/components/builder-api/src/server/framework/headers.rs
@@ -27,6 +27,9 @@ pub fn cache(cache: bool) -> &'static str {
     }
 }
 
+pub const XGITHUBEVENT: &str = "X-GitHub-Event";
+pub const XHUBSIGNATURE: &str = "X-Hub-Signature";
+
 /*
 header! { (CacheControl, "Cache-Control") => [String] }
 header! { (ContentDisposition, "Content-Disposition") => [String] }

--- a/components/builder-api/src/server/resources/notify.rs
+++ b/components/builder-api/src/server/resources/notify.rs
@@ -12,17 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use actix_web::http::{self, StatusCode};
-use actix_web::FromRequest;
-use actix_web::{App, HttpRequest, HttpResponse, Json, Path};
-use protocol::originsrv::*;
+use actix_web::http::{Method, StatusCode};
+use actix_web::{App, HttpRequest, HttpResponse};
 
-use hab_core::package::ident;
-
-use server::error::{Error, Result};
 use server::framework::headers;
-use server::framework::middleware::route_message;
-use server::helpers;
+use server::services::github;
 use server::AppState;
 
 pub struct Notify;
@@ -32,18 +26,16 @@ impl Notify {
     // Route registration
     //
     pub fn register(app: App<AppState>) -> App<AppState> {
-        app
+        app.route("/notify", Method::POST, notify)
     }
 }
 
-// r.post("/notify", notify, "notify");
-
-/*
-pub fn notify(req: &mut Request) -> IronResult<Response> {
-    if req.headers.has::<XGitHubEvent>() {
-        return github::handle_event(req);
+pub fn notify((req, body): (HttpRequest<AppState>, String)) -> HttpResponse {
+    if req.headers().get(headers::XGITHUBEVENT).is_some() {
+        match github::handle_event(req, body) {
+            Ok(_) => HttpResponse::new(StatusCode::OK),
+            Err(err) => err.into(),
+        };
     }
-    Ok(Response::with(status::BadRequest))
+    return HttpResponse::new(StatusCode::BAD_REQUEST);
 }
-
-*/

--- a/components/builder-api/src/server/services/mod.rs
+++ b/components/builder-api/src/server/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod github;
 pub mod metrics;
 pub mod route_broker;
 pub mod s3;


### PR DESCRIPTION
This one is going to need a thorough review. It's not complicated but there's some weird stuff in here. The only thing that I think bears any significant explanation upfront is the changes to main.rs and lib.rs.

I'm sure @fnichol can do a better job explaining what we did than I can but I'll give you the 1k-ft view. Basically - adding in unecessary extern crate calls coupled with pub mod calls from the api library put cargo into a state where it was totally unable to compile some of the modules. Cargo would get confused because including those `pub mod` calls tricked it into a state where it couldn't determine whether the binary build or the library build required those crates. We removed and corrected the instantiation of the modules and refer to the lib.rs now as a crate rather than directly leveraging the modules in main.rs

Signed-off-by: Ian Henry <ihenry@chef.io>