### PR TITLE
Adjust for correct precedence.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 * @chefsalim @raskchanky
 components/airlock/src/command @apriofrost
 components/airlock/src/main.rs @apriofrost
-components/builder-* @chefsalim @raskchanky @reset @elliott-davis @eeyun
+components/airlock @chefsalim @raskchanky @fnichol @elliott-davis
 components/builder-api/src/main.rs @apriofrost
 components/builder-graph/src/main.rs @apriofrost
 components/builder-jobsrv/src/main.rs @apriofrost
@@ -9,13 +9,14 @@ components/builder-originsrv/src/main.rs @apriofrost
 components/builder-router/src/main.rs @apriofrost
 components/builder-sessionsrv/src/main.rs @apriofrost
 components/builder-web @chefsalim @cnunciato @raskchanky @mgamini @elliott-davis
-components/builder-worker @chefsalim @raskchanky @reset @elliott-davis @fnichol
 components/builder-worker/src/main.rs @apriofrost
+components/builder-worker @chefsalim @raskchanky @reset @elliott-davis @fnichol
+components/builder-* @chefsalim @raskchanky @reset @elliott-davis @eeyun
 components/github-api-client @chefsalim @raskchanky
 components/net @chefsalim @raskchanky
 components/oauth-client @chefsalim @raskchanky
-components/op @chefsalim @raskchanky
 components/op/src/main.rs @apriofrost
+components/op @chefsalim @raskchanky
 components/segment-api-client @chefsalim @raskchanky
 support @fnichol @chefsalim @raskchanky @baumanj @elliott-davis
 tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol


### PR DESCRIPTION
The last match has the highest precedence. Without this change, @apriofrost is required to approve many PRs that may not have any UX changes, simply because of the ordering of lines in the file. See https://help.github.com/articles/about-codeowners/ for full details.

![](https://media.giphy.com/media/3otPoozHaRw31DSqC4/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>