### PR TITLE
Remove/replace set_{permissions,owner} calls which aren't supported on windows

### DIFF
--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -401,7 +401,11 @@ impl Runner {
                 let dst = res.unwrap();
                 debug!("Imported origin secret key, dst={:?}.", dst);
                 if self.config.airlock_enabled {
-                    perm::set_owner(dst, STUDIO_USER, STUDIO_GROUP)?;
+                    if cfg!(linux) {
+                        perm::set_owner(dst, STUDIO_USER, STUDIO_GROUP)?;
+                    } else {
+                        unreachable!();
+                    }
                 }
                 Ok(())
             }
@@ -507,7 +511,11 @@ impl Runner {
                     .as_str(),
                 STUDIO_GROUP,
             )?;
-            perm::set_permissions(&self.config.data_path, 0o750)?;
+            if cfg!(linux) {
+                perm::set_permissions(&self.config.data_path, 0o750)?;
+            } else {
+                unreachable!();
+            }
         }
 
         if self.workspace.src().exists() {
@@ -527,8 +535,12 @@ impl Runner {
         }
 
         if self.config.airlock_enabled {
-            perm::set_owner(self.workspace.root(), STUDIO_USER, STUDIO_GROUP)?;
-            perm::set_owner(self.workspace.src(), STUDIO_USER, STUDIO_GROUP)?;
+            if cfg!(linux) {
+                perm::set_owner(self.workspace.root(), STUDIO_USER, STUDIO_GROUP)?;
+                perm::set_owner(self.workspace.src(), STUDIO_USER, STUDIO_GROUP)?;
+            } else {
+                unreachable!();
+            }
         }
 
         if let Some(err) = fs::create_dir_all(key_path()).err() {

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -401,7 +401,7 @@ impl Runner {
                 let dst = res.unwrap();
                 debug!("Imported origin secret key, dst={:?}.", dst);
                 if self.config.airlock_enabled {
-                    if cfg!(linux) {
+                    if cfg!(not(windows)) {
                         perm::set_owner(dst, STUDIO_USER, STUDIO_GROUP)?;
                     } else {
                         unreachable!();
@@ -511,7 +511,7 @@ impl Runner {
                     .as_str(),
                 STUDIO_GROUP,
             )?;
-            if cfg!(linux) {
+            if cfg!(not(windows)) {
                 perm::set_permissions(&self.config.data_path, 0o750)?;
             } else {
                 unreachable!();
@@ -535,7 +535,7 @@ impl Runner {
         }
 
         if self.config.airlock_enabled {
-            if cfg!(linux) {
+            if cfg!(not(windows)) {
                 perm::set_owner(self.workspace.root(), STUDIO_USER, STUDIO_GROUP)?;
                 perm::set_owner(self.workspace.src(), STUDIO_USER, STUDIO_GROUP)?;
             } else {

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -232,7 +232,7 @@ impl Server {
     fn prepare_dirs(&self) -> Result<()> {
         // Ensure that data path group ownership is set to the build user and directory perms are
         // `0750`. This allows the namespace files to be accessed and read by the build user
-        if cfg!(linux) {
+        if cfg!(not(windows)) {
             perm::set_owner(
                 &self.config.data_path,
                 users::get_current_username()
@@ -255,7 +255,7 @@ impl Server {
             fs::create_dir_all(parent_path)
                 .map_err(|e| Error::CreateDirectory(parent_path.to_path_buf(), e))?;
         }
-        if cfg!(linux) {
+        if cfg!(not(windows)) {
             perm::set_owner(&parent_path, studio::STUDIO_USER, studio::STUDIO_GROUP)?;
             perm::set_permissions(&parent_path, 0o750)?;
         } else {

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -232,14 +232,18 @@ impl Server {
     fn prepare_dirs(&self) -> Result<()> {
         // Ensure that data path group ownership is set to the build user and directory perms are
         // `0750`. This allows the namespace files to be accessed and read by the build user
-        perm::set_owner(
-            &self.config.data_path,
-            users::get_current_username()
-                .unwrap_or(String::from("root"))
-                .as_str(),
-            studio::STUDIO_GROUP,
-        )?;
-        perm::set_permissions(&self.config.data_path, 0o750)?;
+        if cfg!(linux) {
+            perm::set_owner(
+                &self.config.data_path,
+                users::get_current_username()
+                    .unwrap_or(String::from("root"))
+                    .as_str(),
+                studio::STUDIO_GROUP,
+            )?;
+            perm::set_permissions(&self.config.data_path, 0o750)?;
+        } else {
+            unreachable!();
+        }
 
         // Set parent directory of ns_dir to be owned by the build user so that the appropriate
         // directories, files, and bind-mounts can be created for the build user
@@ -251,8 +255,12 @@ impl Server {
             fs::create_dir_all(parent_path)
                 .map_err(|e| Error::CreateDirectory(parent_path.to_path_buf(), e))?;
         }
-        perm::set_owner(&parent_path, studio::STUDIO_USER, studio::STUDIO_GROUP)?;
-        perm::set_permissions(&parent_path, 0o750)?;
+        if cfg!(linux) {
+            perm::set_owner(&parent_path, studio::STUDIO_USER, studio::STUDIO_GROUP)?;
+            perm::set_permissions(&parent_path, 0o750)?;
+        } else {
+            unreachable!();
+        }
 
         Ok(())
     }


### PR DESCRIPTION
(NB: This will be easier to review with whitespace changes hidden)

These are misleading since the core implementation doesn't actually do what the
function names imply, so replace with more illustrative code on a per-platform
basis. Long-term, we should implement the appropriate windows FFI calls, but
the current situation is dangerously misleading.

See https://github.com/habitat-sh/core/blob/master/components/core/src/os/filesystem/windows.rs#L28-L34

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>