### PR TITLE
Tweak logger to exclude status call

### DIFF
--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -142,7 +142,7 @@ pub fn run(config: Config) -> Result<()> {
         let app_state = AppState::new(&config);
 
         App::with_state(app_state)
-            .middleware(Logger::default())
+            .middleware(Logger::default().exclude("/v1/status"))
             .middleware(XRouteClient)
             .middleware(Authentication)
             .middleware(Cors)

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -29,7 +29,7 @@ EOT
 
 mkdir -p /hab/svc/builder-api
 cat <<EOT > /hab/svc/builder-api/user.toml
-log_level = "debug,tokio_core=error,tokio_reactor=error"
+log_level = "debug,tokio_core=error,tokio_reactor=error,zmq=error"
 
 [oauth]
 provider = "$OAUTH_PROVIDER"


### PR DESCRIPTION
Minor tweak to exclude the "v1/status" calls from the logger, and set zmq to error logging in the dev config.

Signed-off-by: Salim Alam <salam@chef.io>