### PR TITLE
Don't auth webhook notification

### DIFF
--- a/components/builder-api/src/server/resources/notify.rs
+++ b/components/builder-api/src/server/resources/notify.rs
@@ -15,7 +15,6 @@
 use actix_web::http::{Method, StatusCode};
 use actix_web::{App, HttpRequest, HttpResponse};
 
-use server::authorize::authorize_session;
 use server::framework::headers;
 use server::services::github;
 use server::AppState;
@@ -32,10 +31,6 @@ impl Notify {
 }
 
 pub fn notify((req, body): (HttpRequest<AppState>, String)) -> HttpResponse {
-    if let Err(err) = authorize_session(&req, None) {
-        return err.into();
-    }
-
     if req.headers().get(headers::XGITHUBEVENT).is_some() {
         match github::handle_event(req, body) {
             Ok(_) => HttpResponse::new(StatusCode::OK),


### PR DESCRIPTION
Tweak the Github notification handler to not require an auth token - it was inadvertently added.

Signed-off-by: Salim Alam <salam@chef.io>