### PR TITLE
Dont default target when not present

### DIFF
--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -512,9 +512,9 @@ fn do_get_channel_package(
     let target = match qtarget.target.clone() {
         Some(t) => {
             debug!("Query requested target = {}", t);
-            PackageTarget::from_str(&t).unwrap() // Unwrap Ok ?
+            PackageTarget::from_str(&t)?
         }
-        None => helpers::target_from_headers(req),
+        None => helpers::target_from_headers(req)?,
     };
 
     // Fully qualify the ident if needed

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -311,9 +311,15 @@ fn download_package((qtarget, req): (Query<Target>, HttpRequest<AppState>)) -> H
     let target = match qtarget.target.clone() {
         Some(t) => {
             debug!("Query requested target = {}", t);
-            PackageTarget::from_str(&t).unwrap() // Unwrap Ok ?
+            match PackageTarget::from_str(&t) {
+                Ok(t) => t,
+                Err(err) => return Error::HabitatCore(err).into(),
+            }
         }
-        None => helpers::target_from_headers(&req),
+        None => match helpers::target_from_headers(&req) {
+            Ok(t) => t,
+            Err(err) => return err.into(),
+        },
     };
 
     if !req.state().config.api.targets.contains(&target) {
@@ -1064,9 +1070,9 @@ fn do_get_package(
     let target = match qtarget.target.clone() {
         Some(t) => {
             debug!("Query requested target = {}", t);
-            PackageTarget::from_str(&t).unwrap() // Unwrap Ok ?
+            PackageTarget::from_str(&t)?
         }
-        None => helpers::target_from_headers(req),
+        None => helpers::target_from_headers(req)?,
     };
 
     // Fully qualify the ident if needed

--- a/test/builder-api/src/channels.js
+++ b/test/builder-api/src/channels.js
@@ -130,7 +130,7 @@ describe('Channels API', function () {
     });
 
     it('returns the package with the given name, version and release in a channel', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/20171205003213')
+      request.get('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/20171205003213?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -144,7 +144,7 @@ describe('Channels API', function () {
     });
 
     it('returns the latest package with the given name in a channel', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/testapp/latest')
+      request.get('/depot/channels/neurosis/foo/pkgs/testapp/latest?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -158,7 +158,7 @@ describe('Channels API', function () {
     });
 
     it('returns the latest package with the given name and version in a channel', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/latest')
+      request.get('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/latest?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -172,7 +172,7 @@ describe('Channels API', function () {
     });
 
     it('requires authentication to view private packages in a channel', function (done) {
-      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest')
+      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(404)
@@ -182,7 +182,7 @@ describe('Channels API', function () {
     });
 
     it('does not let members of other origins view private packages in a channel', function (done) {
-      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest')
+      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .set('Authorization', global.mystiqueBearer)
@@ -193,7 +193,7 @@ describe('Channels API', function () {
     });
 
     it('allows members of the origin to view private packages when they are authenticated', function (done) {
-      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest')
+      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .set('Authorization', global.boboBearer)

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -97,7 +97,7 @@ describe('Working with packages', function () {
 
   describe('Finding packages', function () {
     it('allows me to search for packages', function (done) {
-      request.get('/depot/pkgs/search/testapp')
+      request.get('/depot/pkgs/search/testapp?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -220,7 +220,7 @@ describe('Working with packages', function () {
     });
 
     it('returns the latest release of a package with the specified name', function (done) {
-      request.get('/depot/pkgs/neurosis/testapp/latest')
+      request.get('/depot/pkgs/neurosis/testapp/latest?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -256,7 +256,7 @@ describe('Working with packages', function () {
     });
 
     it('returns the latest release of a package with the spcified name and version', function (done) {
-      request.get('/depot/pkgs/neurosis/testapp/0.1.3/latest')
+      request.get('/depot/pkgs/neurosis/testapp/0.1.3/latest?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -270,7 +270,7 @@ describe('Working with packages', function () {
     });
 
     it('returns the specified release', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}?target=x86_64-linux`)
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -298,7 +298,7 @@ describe('Working with packages', function () {
     });
 
     it('downloads a package', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}/download`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}/download?target=x86_64-linux`)
         .expect(200)
         .buffer()
         .parse(binaryParser)
@@ -326,7 +326,7 @@ describe('Working with packages', function () {
     });
 
     it('requires authentication to view private packages', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}?target=x86_64-linux`)
         .type('application/json')
         .accept('application/json')
         .expect(404)
@@ -336,7 +336,7 @@ describe('Working with packages', function () {
     });
 
     it('does not let members of other origins view private packages', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}?target=x86_64-linux`)
         .type('application/json')
         .accept('application/json')
         .set('Authorization', global.mystiqueBearer)
@@ -347,7 +347,7 @@ describe('Working with packages', function () {
     });
 
     it('allows members of the origin to view private packages when they are authenticated', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}?target=x86_64-linux`)
         .type('application/json')
         .accept('application/json')
         .set('Authorization', global.boboBearer)


### PR DESCRIPTION
We no longer assume that the package target is "x86_64-linux" if it is not specified in by a valid target param, or in a parsable User Agent header on the request.  This resolves https://github.com/habitat-sh/builder/issues/612

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-26585737](https://user-images.githubusercontent.com/13542112/45396990-e3997c00-b5f2-11e8-8d83-f581e63f9061.gif)
