### PR TITLE
Enable Linux kernel2 target

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -169,7 +169,11 @@ impl Default for ApiCfg {
             data_path: PathBuf::from("/hab/svc/builder-api/data"),
             log_path: env::temp_dir(),
             key_path: PathBuf::from("/hab/svc/builder-api/files"),
-            targets: vec![target::X86_64_LINUX, target::X86_64_WINDOWS],
+            targets: vec![
+                target::X86_64_LINUX,
+                target::X86_64_LINUX_KERNEL2,
+                target::X86_64_WINDOWS,
+            ],
             features_enabled: String::from("jobsrv"),
         }
     }

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -887,7 +887,7 @@ fn do_upload_package_finish(
             "Unsupported package platform or architecture {}.",
             target_from_artifact
         );
-        return HttpResponse::new(StatusCode::UNPROCESSABLE_ENTITY);
+        return HttpResponse::new(StatusCode::NOT_IMPLEMENTED);
     };
 
     let mut ident_req = OriginPackageGet::new();


### PR DESCRIPTION
This updates the builder-api config to add Linux kernel2 target to the default set of supported targets.  Also a minor tweak to the error code we return when a target is un-supported. This resolves https://github.com/habitat-sh/builder/issues/613

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-86340313](https://user-images.githubusercontent.com/13542112/45397829-9ddeb280-b5f6-11e8-883b-49dfef941dd8.gif)
