### PR TITLE
Enable linux kernel2 in target graph

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -245,7 +245,7 @@ mod tests {
         data_path = "/hab/svc/hab-depot/data"
         log_path = "/hab/svc/hab-depot/var/log"
         key_path = "/hab/svc/hab-depot/files"
-        targets = ["x86_64-linux", "x86_64-windows"]
+        targets = ["x86_64-linux", "x86_64-linux-kernel2", "x86_64-windows"]
         features_enabled = "foo, bar"
 
         [upstream]
@@ -293,9 +293,10 @@ mod tests {
             PathBuf::from("/hab/svc/hab-depot/files")
         );
 
-        assert_eq!(config.api.targets.len(), 2);
+        assert_eq!(config.api.targets.len(), 3);
         assert_eq!(config.api.targets[0], target::X86_64_LINUX);
-        assert_eq!(config.api.targets[1], target::X86_64_WINDOWS);
+        assert_eq!(config.api.targets[1], target::X86_64_LINUX_KERNEL2);
+        assert_eq!(config.api.targets[2], target::X86_64_WINDOWS);
 
         assert_eq!(&config.api.features_enabled, "foo, bar");
 

--- a/components/builder-core/src/target_graph.rs
+++ b/components/builder-core/src/target_graph.rs
@@ -34,7 +34,7 @@ impl TargetGraph {
         let mut graphs = HashMap::new();
 
         // We only support the following targets currently
-        for target_str in &["x86_64-linux", "x86_64-windows"] {
+        for target_str in &["x86_64-linux", "x86_64-linux-kernel2", "x86_64-windows"] {
             graphs.insert(
                 PackageTarget::from_str(target_str).unwrap(),
                 PackageGraph::new(),

--- a/test/builder-api/src/jobs.js
+++ b/test/builder-api/src/jobs.js
@@ -48,8 +48,20 @@ describe('Jobs API', function () {
         });
     });
 
-    it('only works for linux', function (done) {
+    it('does not schedule a build for Windows', function (done) {
       request.post('/depot/pkgs/schedule/neurosis/testapp?target=x86_64-windows')
+        .type('application/json')
+        .accept('application/json')
+        .set('Authorization', global.boboBearer)
+        .expect(400)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('does not schedule a build for Linux kernel2', function (done) {
+      request.post('/depot/pkgs/schedule/neurosis/testapp?target=x86_64-linux-kernel2')
         .type('application/json')
         .accept('application/json')
         .set('Authorization', global.boboBearer)

--- a/test/builder-api/src/misc.js
+++ b/test/builder-api/src/misc.js
@@ -5,14 +5,14 @@ const fs = require('fs');
 
 const hookPayload = fs.readFileSync(__dirname + '/../fixtures/ping-hook.json');
 
-describe('Miscellanenous API', function() {
-  describe('Retrieving the API status', function() {
-    it('succeeds', function(done) {
+describe('Miscellanenous API', function () {
+  describe('Retrieving the API status', function () {
+    it('succeeds', function (done) {
       request.get('/status')
         .type('application/json')
         .accept('application/json')
         .expect(200)
-        .end(function(err, res) {
+        .end(function (err, res) {
           expect(res.text).to.be.empty;
           done(err);
         });
@@ -20,8 +20,8 @@ describe('Miscellanenous API', function() {
   });
 
   // We're going to simulate receiving a GH ping hook
-  describe('Receiving a GitHub webhook', function() {
-    it('succeeds', function(done) {
+  describe('Receiving a GitHub webhook', function () {
+    it('succeeds', function (done) {
       this.skip(); // don't run in master until passing
 
       request.post('/notify')
@@ -31,7 +31,7 @@ describe('Miscellanenous API', function() {
         .set('X-Hub-Signature', 'sha1=6e30dd2c021bdb935f98a827a3d31a2fbdab69d6')
         .send(hookPayload)
         .expect(200)
-        .end(function(err, res) {
+        .end(function (err, res) {
           expect(res.text).to.be.empty;
           done(err);
         });
@@ -40,13 +40,13 @@ describe('Miscellanenous API', function() {
 
   // This isn't the greatest test because our testapp doesn't have any
   // dependencies :(
-  describe('Retrieving reverse dependencies', function() {
-    it('returns all reverse dependencies for an origin and package name', function(done) {
-      request.get('/rdeps/neurosis/testapp')
+  describe('Retrieving reverse dependencies', function () {
+    it('returns all reverse dependencies for an origin and package name', function (done) {
+      request.get('/rdeps/neurosis/testapp?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(200)
-        .end(function(err, res) {
+        .end(function (err, res) {
           expect(res.body.origin).to.equal('neurosis');
           expect(res.body.name).to.equal('testapp');
           expect(res.body.rdeps).to.deep.equal([]);


### PR DESCRIPTION
This change adds more enablement for Linux kernel2 targets - 1) enables kernel2 in the package graph 2) adds target awareness to the rdeps API 3) updates some tests.  

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-177388940](https://user-images.githubusercontent.com/13542112/45450393-f8c2e900-b68c-11e8-8a85-6bc672949d1c.gif)
