### PR TITLE
Make latest calls work again

### DIFF
--- a/components/builder-web/app/client/depot-api.ts
+++ b/components/builder-web/app/client/depot-api.ts
@@ -115,7 +115,7 @@ export function getUnique(origin: string, nextRange: number = 0, token: string =
 }
 
 export function getLatest(origin: string, pkg: string) {
-  const url = `${urlPrefix}/depot/pkgs/${origin}/${pkg}/latest`;
+  const url = `${urlPrefix}/depot/pkgs/${origin}/${pkg}/latest?target=x86_64-linux`;
 
   return new Promise((resolve, reject) => {
     fetch(url, opts())
@@ -135,7 +135,7 @@ export function getLatest(origin: string, pkg: string) {
 }
 
 export function getLatestInChannel(origin: string, name: string, channel: string, version: string = undefined) {
-  const url = `${urlPrefix}/depot/channels/${origin}/${channel}/pkgs/${name}/${version ? version + '/' : ''}latest`;
+  const url = `${urlPrefix}/depot/channels/${origin}/${channel}/pkgs/${name}/${version ? version + '/' : ''}latest?target=x86_64-linux`;
 
   return new Promise((resolve, reject) => {
     fetch(url, opts())


### PR DESCRIPTION
Since we removed default fallback to x86_64-linux for the package latest calls, we need to add explicit target to the caller. Until we have a more permanent solution that is being worked on, this tweak adds a default target of x86_64-linux to the web UI so that things can continue to function at parity.

Signed-off-by: Salim Alam <salam@chef.io>