### PR TITLE
Revert default target change

### DIFF
--- a/components/builder-api/src/server/helpers.rs
+++ b/components/builder-api/src/server/helpers.rs
@@ -27,7 +27,7 @@ use protocol::jobsrv::*;
 use protocol::originsrv::*;
 
 use server::authorize::authorize_session;
-use server::error::{Error, Result};
+use server::error::Result;
 use server::framework::middleware::route_message;
 use server::AppState;
 
@@ -83,15 +83,15 @@ pub fn extract_pagination(pagination: &Query<Pagination>) -> (isize, isize) {
 }
 
 // TODO: Deprecate getting target from User Agent header
-pub fn target_from_headers(req: &HttpRequest<AppState>) -> Result<PackageTarget> {
+pub fn target_from_headers(req: &HttpRequest<AppState>) -> PackageTarget {
     let user_agent_header = match req.headers().get(header::USER_AGENT) {
         Some(s) => s,
-        None => return Err(Error::UnsupportedPlatform("".to_string())),
+        None => return PackageTarget::from_str("x86_64-linux").unwrap(),
     };
 
     let user_agent = match user_agent_header.to_str() {
         Ok(ref s) => s.to_string(),
-        Err(_) => return Err(Error::UnsupportedPlatform("".to_string())),
+        Err(_) => return PackageTarget::from_str("x86_64-linux").unwrap(),
     };
 
     debug!("Parsing target from UserAgent header: {}", &user_agent);
@@ -104,15 +104,21 @@ pub fn target_from_headers(req: &HttpRequest<AppState>) -> Result<PackageTarget>
             if let Some(target_match) = user_agent_capture.name("target") {
                 target_match.as_str().to_string()
             } else {
-                return Err(Error::UnsupportedPlatform(user_agent.to_owned()));
+                return PackageTarget::from_str("x86_64-linux").unwrap();
             }
         }
-        None => return Err(Error::UnsupportedPlatform(user_agent.to_owned())),
+        None => return PackageTarget::from_str("x86_64-linux").unwrap(),
     };
 
+    // All of our tooling that depends on this function to return a target will have a user
+    // agent that includes the platform, or will specify a target in the query.
+    // Therefore, if we can't find a valid target, it's safe to assume that some other kind of HTTP
+    // tool is being used, e.g. curl, with looser constraints. For those kinds of cases,
+    // let's default it to Linux instead of returning a bad request if we can't properly parse
+    // the inbound target.
     match PackageTarget::from_str(&target) {
-        Ok(t) => Ok(t),
-        Err(_) => Err(Error::UnsupportedPlatform(target)),
+        Ok(t) => t,
+        Err(_) => PackageTarget::from_str("x86_64-linux").unwrap(),
     }
 }
 

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -518,7 +518,7 @@ fn do_get_channel_package(
                 debug!("Query requested target = {}", t);
                 PackageTarget::from_str(&t)?
             }
-            None => helpers::target_from_headers(req)?,
+            None => helpers::target_from_headers(req),
         };
 
         let mut request = OriginChannelPackageLatestGet::new();

--- a/components/builder-api/src/server/resources/jobs.rs
+++ b/components/builder-api/src/server/resources/jobs.rs
@@ -94,10 +94,7 @@ fn get_rdeps((qtarget, req): (Query<Target>, HttpRequest<AppState>)) -> HttpResp
                 Err(err) => return Error::HabitatCore(err).into(),
             }
         }
-        None => match helpers::target_from_headers(&req) {
-            Ok(t) => t,
-            Err(err) => return err.into(),
-        },
+        None => helpers::target_from_headers(&req),
     };
 
     let mut rdeps_get = JobGraphPackageReverseDependenciesGet::new();

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -311,15 +311,9 @@ fn download_package((qtarget, req): (Query<Target>, HttpRequest<AppState>)) -> H
     let target = match qtarget.target.clone() {
         Some(t) => {
             debug!("Query requested target = {}", t);
-            match PackageTarget::from_str(&t) {
-                Ok(t) => t,
-                Err(err) => return Error::HabitatCore(err).into(),
-            }
+            PackageTarget::from_str(&t).unwrap() // Unwrap Ok ?
         }
-        None => match helpers::target_from_headers(&req) {
-            Ok(t) => t,
-            Err(err) => return err.into(),
-        },
+        None => helpers::target_from_headers(&req),
     };
 
     if !req.state().config.api.targets.contains(&target) {
@@ -1076,7 +1070,7 @@ fn do_get_package(
                 debug!("Query requested target = {}", t);
                 PackageTarget::from_str(&t)?
             }
-            None => helpers::target_from_headers(req)?,
+            None => helpers::target_from_headers(req),
         };
 
         let mut request = OriginPackageLatestGet::new();

--- a/test/builder-api/src/channels.js
+++ b/test/builder-api/src/channels.js
@@ -130,7 +130,7 @@ describe('Channels API', function () {
     });
 
     it('returns the package with the given name, version and release in a channel', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/20171205003213?target=x86_64-linux')
+      request.get('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/20171205003213')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -144,7 +144,7 @@ describe('Channels API', function () {
     });
 
     it('returns the latest package with the given name in a channel', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/testapp/latest?target=x86_64-linux')
+      request.get('/depot/channels/neurosis/foo/pkgs/testapp/latest')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -158,7 +158,7 @@ describe('Channels API', function () {
     });
 
     it('returns the latest package with the given name and version in a channel', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/latest?target=x86_64-linux')
+      request.get('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/latest')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -172,7 +172,7 @@ describe('Channels API', function () {
     });
 
     it('requires authentication to view private packages in a channel', function (done) {
-      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest?target=x86_64-linux')
+      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest')
         .type('application/json')
         .accept('application/json')
         .expect(404)
@@ -182,7 +182,7 @@ describe('Channels API', function () {
     });
 
     it('does not let members of other origins view private packages in a channel', function (done) {
-      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest?target=x86_64-linux')
+      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest')
         .type('application/json')
         .accept('application/json')
         .set('Authorization', global.mystiqueBearer)
@@ -193,7 +193,7 @@ describe('Channels API', function () {
     });
 
     it('allows members of the origin to view private packages when they are authenticated', function (done) {
-      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest?target=x86_64-linux')
+      request.get('/depot/channels/neurosis/bar/pkgs/testapp/0.1.3/latest')
         .type('application/json')
         .accept('application/json')
         .set('Authorization', global.boboBearer)

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -97,7 +97,7 @@ describe('Working with packages', function () {
 
   describe('Finding packages', function () {
     it('allows me to search for packages', function (done) {
-      request.get('/depot/pkgs/search/testapp?target=x86_64-linux')
+      request.get('/depot/pkgs/search/testapp')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -220,7 +220,7 @@ describe('Working with packages', function () {
     });
 
     it('returns the latest release of a package with the specified name', function (done) {
-      request.get('/depot/pkgs/neurosis/testapp/latest?target=x86_64-linux')
+      request.get('/depot/pkgs/neurosis/testapp/latest')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -256,7 +256,7 @@ describe('Working with packages', function () {
     });
 
     it('returns the latest release of a package with the spcified name and version', function (done) {
-      request.get('/depot/pkgs/neurosis/testapp/0.1.3/latest?target=x86_64-linux')
+      request.get('/depot/pkgs/neurosis/testapp/0.1.3/latest')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -270,7 +270,7 @@ describe('Working with packages', function () {
     });
 
     it('returns the specified release', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}?target=x86_64-linux`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -298,7 +298,7 @@ describe('Working with packages', function () {
     });
 
     it('downloads a package', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}/download?target=x86_64-linux`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}/download`)
         .expect(200)
         .buffer()
         .parse(binaryParser)
@@ -326,7 +326,7 @@ describe('Working with packages', function () {
     });
 
     it('requires authentication to view private packages', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}?target=x86_64-linux`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
         .type('application/json')
         .accept('application/json')
         .expect(404)
@@ -336,7 +336,7 @@ describe('Working with packages', function () {
     });
 
     it('does not let members of other origins view private packages', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}?target=x86_64-linux`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
         .type('application/json')
         .accept('application/json')
         .set('Authorization', global.mystiqueBearer)
@@ -347,7 +347,7 @@ describe('Working with packages', function () {
     });
 
     it('allows members of the origin to view private packages when they are authenticated', function (done) {
-      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}?target=x86_64-linux`)
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
         .type('application/json')
         .accept('application/json')
         .set('Authorization', global.boboBearer)


### PR DESCRIPTION
This reverts a change that was made to error out on some APIs if no target was explicitly specified (or parsable via User Agent) - this potentially breaks backward compatibility, so it is best to revert that change. Since we have now unblocked the paths for linux-kernel2 which was the original reason for making the change, we should be safe to do the revert.

Signed-off-by: Salim Alam <salam@chef.io>