### PR TITLE
Check target when triggering build job

### DIFF
--- a/components/builder-jobsrv/src/server/handlers.rs
+++ b/components/builder-jobsrv/src/server/handlers.rs
@@ -391,6 +391,13 @@ pub fn job_group_create(
     let msg = req.parse::<jobsrv::JobGroupSpec>()?;
     debug!("job_group_create message: {:?}", msg);
 
+    // Check that the target is supported - currently only x86_64-linux buildable
+    if msg.get_target() != "x86_64-linux" {
+        let err = NetError::new(ErrCode::ENTITY_NOT_FOUND, "jb:job-group-create:1");
+        conn.route_reply(req, &*err)?;
+        return Ok(());
+    }
+
     let project_name = format!("{}/{}", msg.get_origin(), msg.get_package());
     let mut projects = Vec::new();
 


### PR DESCRIPTION
Currently builder only supports x86_64-linux targets, so we need to add in a check when a job is attempting to get scheduled.

Signed-off-by: Salim Alam <salam@chef.io>