### PR TITLE
Sa/perf tuning

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -125,7 +125,9 @@ http {
       rewrite ^(.*)$ https://$host$1 permanent;
     }
 
+    {{~#if cfg.server.enable_access_log}}
     access_log {{pkg.svc_path}}/logs/host.access.log nginx;
+    {{~/if}}
     error_log {{pkg.svc_path}}/logs/host.error.log error;
 
     location = /health {

--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -41,6 +41,7 @@ http {
   tcp_nopush     {{cfg.http.tcp_nopush}};
   tcp_nodelay    {{cfg.http.tcp_nodelay}};
 
+  keepalive_requests {{cfg.http.keepalive_requests}};
   keepalive_timeout  {{cfg.http.keepalive_timeout}};
 
  {{~#if cfg.nginx.enable_gzip}}
@@ -88,6 +89,7 @@ http {
     {{#each bind.http.members as |member| ~}}
     server {{member.sys.ip}}:{{member.cfg.port}};
     {{/each ~}}
+    keepalive {{cfg.http.keepalive_connections}}
   }
 
   {{~#if cfg.server.listen_tls}}
@@ -170,9 +172,13 @@ http {
 
     location /v1/depot {
       client_max_body_size {{cfg.nginx.max_body_size}};
+      proxy_pass http://backend;      
       proxy_send_timeout {{cfg.nginx.proxy_send_timeout}};
       proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
-      proxy_pass http://backend;
+      proxy_connect_timeout  {{cfg.nginx.proxy_connect_timeout}};
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+
       {{~#if cfg.nginx.enable_caching}}
       proxy_no_cache $flag_cache_empty;
       proxy_cache_bypass $flag_cache_empty;
@@ -183,6 +189,11 @@ http {
     location /v1 {
       add_header Cache-Control "private, no-cache, no-store";
       proxy_pass http://backend;
+      proxy_send_timeout {{cfg.nginx.proxy_send_timeout}};
+      proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
+      proxy_connect_timeout  {{cfg.nginx.proxy_connect_timeout}};
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
     }
   }
 }

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -39,6 +39,7 @@ worker_rlimit_nofile      = 8192
 max_body_size             = "1024m"
 proxy_send_timeout        = 60
 proxy_read_timeout        = 60
+proxy_connect_timeout     = 60
 limit_req_zone_unknown    = "$limit_unknown zone=unknown:10m rate=2r/s"
 limit_req_zone_known      = "$http_x_forwarded_for zone=known:10m rate=20r/s"
 limit_req_unknown         = "burst=20 nodelay"
@@ -50,6 +51,8 @@ enable_caching            = false
 enable_gzip               = false
 
 [http]
+keepalive_connections     = 16
+keepalive_requests        = 128
 keepalive_timeout         = "20s"
 sendfile                  = "on"
 tcp_nopush                = "on"

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -69,3 +69,4 @@ ssl_ciphers               = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
 ssl_session_cache         = "shared:SSL:10m"
 ssl_session_timeout       = "10m"
 ssl_prefer_server_ciphers = "on"
+enable_access_log         = true

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -204,6 +204,7 @@ pub struct HttpCfg {
     pub listen: IpAddr,
     pub port: u16,
     pub handler_count: usize,
+    pub keep_alive: usize,
 }
 
 impl Default for HttpCfg {
@@ -212,6 +213,7 @@ impl Default for HttpCfg {
             listen: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             port: 9636,
             handler_count: Config::default_handler_count(),
+            keep_alive: 60,
         }
     }
 }
@@ -256,6 +258,7 @@ mod tests {
         listen = "0:0:0:0:0:0:0:1"
         port = 9636
         handler_count = 128
+        keep_alive = 30
 
         [ui]
         root = "/some/path"
@@ -310,6 +313,7 @@ mod tests {
 
         assert_eq!(config.http.port, 9636);
         assert_eq!(config.http.handler_count, 128);
+        assert_eq!(config.http.keep_alive, 30);
         assert_eq!(&format!("{}", config.routers[0]), "172.18.0.2:9632");
 
         assert_eq!(config.oauth.client_id, "0c2f738a7d0bd300de10");

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -26,7 +26,8 @@ use std::thread;
 
 use actix_web::http::StatusCode;
 use actix_web::middleware::Logger;
-use actix_web::{server, App, HttpRequest, HttpResponse, Result};
+use actix_web::server::{self, KeepAlive};
+use actix_web::{App, HttpRequest, HttpResponse, Result};
 
 use github_api_client::GitHubClient;
 use hab_net::socket;
@@ -162,6 +163,7 @@ pub fn run(config: Config) -> Result<()> {
                 r.head().f(status)
             })
     }).workers(cfg.handler_count())
+        .keep_alive(KeepAlive::Timeout(cfg.http.keep_alive))
         .bind(cfg.http.clone())
         .unwrap()
         .run();


### PR DESCRIPTION
Add some more perf tuning options to nginx config, and enable a keep-alive config for the builder-api.

![tenor-33570378](https://user-images.githubusercontent.com/13542112/45526747-4d4d8d80-b78d-11e8-9ee9-755d968224bb.gif)
