### PR TITLE
Fix travis test failure

### DIFF
--- a/test/builder-api/test.sh
+++ b/test/builder-api/test.sh
@@ -101,7 +101,12 @@ cd /src/test/builder-api
 npm install mocha
 hab pkg binlink core/coreutils -d /usr/bin env
 
-hab sup status
+while hab sup status | grep --quiet down;
+do
+  echo "Waiting for services to start..."
+  sleep 10
+done
+
 npm run mocha
 exit \$?
 EOT


### PR DESCRIPTION
Travis runs have been failing because we are starting the tests even though a couple of services are still in down state initializing - this change makes it wait until all services are up.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-24102425](https://user-images.githubusercontent.com/13542112/45580723-45ebba00-b849-11e8-848b-b7325671074f.gif)
