### PR TITLE
Gzip off at origin; gzipping will be enabled at edge as needed

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -43,7 +43,8 @@ http {
 
   keepalive_timeout  {{cfg.http.keepalive_timeout}};
 
-  gzip  on;
+ {{~#if cfg.nginx.enable_gzip}}
+  gzip on;
   gzip_vary on;
   gzip_min_length 256;
   gzip_proxied expired no-cache no-store private auth;
@@ -58,7 +59,8 @@ http {
     text/css
 
   gzip_disable "MSIE [1-6]\.";
-
+  {{~/if}}
+  
   open_file_cache max=1000 inactive=20s;
   open_file_cache_valid 30s;
   open_file_cache_min_uses 2;

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -46,7 +46,8 @@ limit_req_known           = "burst=40 nodelay"
 limit_req_status          = 429
 limit_ua_known            = "hab|builder|Chef|Mozilla|Github"
 limit_ua_unknown_target   = "$http_x_forwarded_for"
-enable_caching            = true
+enable_caching            = false
+enable_gzip               = false
 
 [http]
 keepalive_timeout         = "20s"


### PR DESCRIPTION
This change adds an option for gzip enablement at the origin, and defaults it to off.   Also defaults the cache option to off by default. 

Signed-off-by: Salim Alam <salam@chef.io>