### PR TITLE
Centralize proxy directives

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -106,6 +106,12 @@ http {
     server_name  {{sys.hostname}};
     root         {{pkg.path}}/app;
 
+    proxy_send_timeout {{cfg.nginx.proxy_send_timeout}};
+    proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
+    proxy_connect_timeout  {{cfg.nginx.proxy_connect_timeout}};
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+
     {{~#if cfg.server.listen_tls}}
     listen                    *:{{cfg.server.listen_tls_port}} ssl;
     listen                    [::]:{{cfg.server.listen_tls_port}} ssl;
@@ -175,11 +181,6 @@ http {
     location /v1/depot {
       client_max_body_size {{cfg.nginx.max_body_size}};
       proxy_pass http://backend;
-      proxy_send_timeout {{cfg.nginx.proxy_send_timeout}};
-      proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
-      proxy_connect_timeout  {{cfg.nginx.proxy_connect_timeout}};
-      proxy_http_version 1.1;
-      proxy_set_header Connection "";
 
       {{~#if cfg.nginx.enable_caching}}
       proxy_no_cache $flag_cache_empty;
@@ -191,11 +192,6 @@ http {
     location /v1 {
       add_header Cache-Control "private, no-cache, no-store";
       proxy_pass http://backend;
-      proxy_send_timeout {{cfg.nginx.proxy_send_timeout}};
-      proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
-      proxy_connect_timeout  {{cfg.nginx.proxy_connect_timeout}};
-      proxy_http_version 1.1;
-      proxy_set_header Connection "";
     }
   }
 }


### PR DESCRIPTION
Centralize some proxy directives so they can be set at the server level - we were missing these for the /latest queries for example.

Signed-off-by: Salim Alam <salam@chef.io>