### PR TITLE
Cache session tokens in memcache rather than a hashmap in originsrv.

### DIFF
--- a/components/builder-originsrv/src/server/mod.rs
+++ b/components/builder-originsrv/src/server/mod.rs
@@ -21,7 +21,7 @@ use self::session::Session;
 use hab_net::app::prelude::*;
 use protobuf::Message;
 use protocol::originsrv::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::RwLock;
 
 use config::Config;
@@ -314,10 +314,6 @@ lazy_static! {
             session_handlers::account_tokens_get,
         );
         map.register(
-            AccountTokenValidate::descriptor_static(),
-            session_handlers::account_token_validate,
-        );
-        map.register(
             SessionCreate::descriptor_static(),
             session_handlers::session_create,
         );
@@ -333,7 +329,6 @@ lazy_static! {
 pub struct ServerState {
     datastore: DataStore,
     sessions: Arc<Box<RwLock<HashSet<Session>>>>,
-    tokens: Arc<Box<RwLock<HashMap<u64, Option<String>>>>>,
 }
 
 impl ServerState {
@@ -343,7 +338,6 @@ impl ServerState {
         Ok(ServerState {
             datastore: datastore,
             sessions: Arc::new(Box::new(RwLock::new(HashSet::default()))),
-            tokens: Arc::new(Box::new(RwLock::new(HashMap::new()))), // TBD: Handle multiple tokens / account
         })
     }
 }

--- a/components/builder-protocol/protocols/originsrv.proto
+++ b/components/builder-protocol/protocols/originsrv.proto
@@ -741,11 +741,6 @@ message AccountTokenRevoke {
   optional uint64 id = 1;
 }
 
-message AccountTokenValidate {
-  optional uint64 account_id = 1;
-  optional string token = 2;
-}
-
 enum SessionType {
   User = 0;
   Builder = 1;

--- a/components/builder-protocol/src/originsrv.rs
+++ b/components/builder-protocol/src/originsrv.rs
@@ -1596,14 +1596,6 @@ impl Routable for AccountTokenRevoke {
     }
 }
 
-impl Routable for AccountTokenValidate {
-    type H = InstaId;
-
-    fn route_key(&self) -> Option<Self::H> {
-        Some(InstaId(self.get_account_id()))
-    }
-}
-
 impl Serialize for Session {
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
This change moves session token validation to the edge rather than routing messages all the way back to originsrv.
Performance city - here we come - CHOO CHOO

![](https://media.giphy.com/media/cfuL5gqFDreXxkWQ4o/giphy-downsized.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>