### PR TITLE
Update caching strategy for channel packages

### DIFF
--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -1310,7 +1310,7 @@ pub fn process_upload_for_package_archive(
     Ok(())
 }
 
-fn is_a_service(package: &OriginPackage) -> bool {
+pub fn is_a_service(package: &OriginPackage) -> bool {
     let m = package.get_manifest();
 
     // TODO: This is a temporary workaround until we plumb in a better solution for


### PR DESCRIPTION
This change updates the cache strategy for channel packages.  Previously we were caching only the origin package object, however that still left some backend calls uncovered. This change caches the full json response.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-94015203](https://user-images.githubusercontent.com/13542112/45848309-c34c7a00-bce2-11e8-9e66-5d85eecca12c.gif)
