### PR TITLE
Use mouseup for Integration buttons

### DIFF
--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.html
@@ -12,7 +12,7 @@
       <div class="buttons">
         <ng-container *ngFor="let provider of providers">
           <div class="wrapper" *ngIf="provider.enabled">
-            <button mat-raised-button (click)="addIntegration(provider.key)">
+            <button mat-raised-button (mouseup)="addIntegration(provider.key)">
               <div class="tile {{ provider.key }}">
                 <hab-icon [symbol]="provider.key"></hab-icon>
               </div>


### PR DESCRIPTION
I can’t say I’m completely sure _why_ Angular Material is canceling the `click` event in Chrome for these buttons, but it is &mdash; so this fix has them use the `mouseup` event instead.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/Ll2fajzk9DgaY/200w.gif)