### PR TITLE
Fix private-key downloads in the UI

### DIFF
--- a/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.ts
@@ -90,8 +90,8 @@ export class OriginKeysTabComponent implements OnInit, OnDestroy {
       .then((response: any) => {
         response.blob().then((blob) => {
           let header = response.headers.get('content-disposition');
-          let filename = header.split('; filename=')[1].trim().replace(/"/g, '');
-          this.download(blob, filename);
+          let filename = header.split(`''`).slice(-1);
+          this.download(blob, unescape(filename));
         });
       });
   }


### PR DESCRIPTION
With the recent API framework changes, the `Content-Disposition` header sent back with the call to `/depot/origins/:origin/secret_keys/latest` was modified slightly, causing the download button (which parses the header value to obtain a proper filename) to fail. This fixes that.

https://tools.ietf.org/html/rfc6266#section-5

Fixes #668.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/26ufmo6lG3JPVxyPS/giphy.gif)