### PR TITLE
Make builder-minio version consistent with other bldr svcs

### DIFF
--- a/components/builder-minio/habitat/plan.sh
+++ b/components/builder-minio/habitat/plan.sh
@@ -1,9 +1,18 @@
 pkg_name=builder-minio
-pkg_version="0.1.0"
 pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_deps=(core/minio core/cacerts core/openssl core/aws-cli)
+
+pkg_version() {
+  # TED: After migrating the builder repo we needed to add to
+  # the rev-count to keep version sorting working
+  echo "$(($(git rev-list master --count) + 5000))"
+}
+
+do_before() {
+  update_pkg_version
+}
 
 do_unpack() {
     return 0


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/builder/issues/676

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-89715262](https://user-images.githubusercontent.com/13542112/45986336-c49ddf80-c01f-11e8-82aa-1c28830efb67.gif)
