### PR TITLE
Add job metrics

### DIFF
--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -246,6 +246,21 @@ impl DataStore {
         Ok(jobs)
     }
 
+    /// Count the number of jobs in a given state
+    ///
+    /// # Errors
+    ///
+    /// * If a connection cannot be gotten from the pool
+    pub fn count_jobs(&self, job_state: jobsrv::JobState) -> Result<i64> {
+        let conn = self.pool.get()?;
+        let rows = &conn
+            .query("SELECT * FROM count_jobs_v1($1)", &[&job_state.to_string()])
+            .map_err(Error::JobGet)?;
+        assert!(rows.len() == 1);
+        let count: i64 = rows.get(0).get("count_jobs_v1");
+        Ok(count)
+    }
+
     /// Updates a job. Currently, this entails updating the state,
     /// build start and stop times, and recording the identifier of
     /// the package the job produced, if any.

--- a/components/builder-jobsrv/src/migrations/2018-09-26-223537_count_jobs/up.sql
+++ b/components/builder-jobsrv/src/migrations/2018-09-26-223537_count_jobs/up.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION count_jobs_v1(in_job_state text) RETURNS bigint
+    LANGUAGE plpgsql STABLE
+    AS $$
+  BEGIN
+    RETURN COUNT(*) FROM jobs WHERE job_state = in_job_state;
+  END
+$$;

--- a/components/builder-jobsrv/src/server/metrics.rs
+++ b/components/builder-jobsrv/src/server/metrics.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Centralized definition of all Builder API metrics that we
+//! wish to track.
+
+use bldr_core::metrics;
+use std::borrow::Cow;
+
+pub enum Counter {
+    CompletedJobs,
+    FailedJobs,
+}
+
+impl metrics::CounterMetric for Counter {}
+
+impl metrics::Metric for Counter {
+    fn id(&self) -> Cow<'static, str> {
+        match *self {
+            Counter::CompletedJobs => "jobsrv.completed".into(),
+            Counter::FailedJobs => "jobsrv.failed".into(),
+        }
+    }
+}
+
+pub enum Gauge {
+    WaitingJobs,
+    WorkingJobs,
+    Workers,
+    BusyWorkers,
+    ReadyWorkers,
+}
+
+impl metrics::GaugeMetric for Gauge {}
+
+impl metrics::Metric for Gauge {
+    fn id(&self) -> Cow<'static, str> {
+        match *self {
+            Gauge::WaitingJobs => "jobsrv.waiting".into(),
+            Gauge::WorkingJobs => "jobsrv.working".into(),
+            Gauge::Workers => "jobsrv.workers".into(),
+            Gauge::BusyWorkers => "jobsrv.workers.busy".into(),
+            Gauge::ReadyWorkers => "jobsrv.workers.ready".into(),
+        }
+    }
+}
+
+pub enum Histogram {
+    JobCompletionTime,
+}
+
+impl metrics::HistogramMetric for Histogram {}
+
+impl metrics::Metric for Histogram {
+    fn id(&self) -> Cow<'static, str> {
+        match *self {
+            Histogram::JobCompletionTime => "jobsrv.completion_time".into(),
+        }
+    }
+}

--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -16,6 +16,7 @@ mod handlers;
 pub mod log_archiver;
 mod log_directory;
 mod log_ingester;
+mod metrics;
 mod scheduler;
 mod worker_manager;
 


### PR DESCRIPTION
This PR adds several statsd metrics to job server, including job completion time, waiting jobs, working jobs, etc. This will allow us to have better visibility on the job server, as well as ability to add alerting on the job waiting queue.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-213048884](https://user-images.githubusercontent.com/13542112/46114285-c514b280-c1a6-11e8-8b30-791040c12c0a.gif)
