### PR TITLE
Fix to actually use the [memcache] section from config.toml

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -65,7 +65,7 @@ pub struct Config {
     pub segment: SegmentCfg,
     pub ui: UiCfg,
     pub upstream: UpstreamCfg,
-    pub memcached: MemcacheCfg,
+    pub memcache: MemcacheCfg,
     pub datastore: DataStoreCfg,
 }
 
@@ -81,7 +81,7 @@ impl Default for Config {
             segment: SegmentCfg::default(),
             ui: UiCfg::default(),
             upstream: UpstreamCfg::default(),
-            memcached: MemcacheCfg::default(),
+            memcache: MemcacheCfg::default(),
             datastore: DataStoreCfg::default(),
         }
     }
@@ -303,8 +303,11 @@ mod tests {
         handler_count = 128
         keep_alive = 30
 
-        [memcached]
+        [memcache]
         ttl = 11
+        [[memcache.hosts]]
+        host = "192.168.0.1"
+        port = 12345
 
         [ui]
         root = "/some/path"
@@ -326,7 +329,7 @@ mod tests {
 
         [github]
         api_url = "https://api.github.com"
-        
+
         [datastore]
         host = "1.1.1.1"
         port = 9000
@@ -361,7 +364,8 @@ mod tests {
 
         assert_eq!(&format!("{}", config.http.listen), "::1");
 
-        assert_eq!(config.memcached.ttl, 11);
+        assert_eq!(config.memcache.ttl, 11);
+        assert_eq!(&format!("{}", config.memcache.hosts[0]), "memcache://192.168.0.1:12345");
 
         assert_eq!(config.upstream.endpoint, String::from("http://example.com"));
         assert_eq!(

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -93,7 +93,7 @@ impl AppState {
             oauth: OAuth2Client::new(config.oauth.clone()),
             segment: SegmentClient::new(config.segment.clone()),
             upstream: UpstreamClient::default(),
-            memcache: RefCell::new(MemcacheClient::new(config.memcached.clone())),
+            memcache: RefCell::new(MemcacheClient::new(config.memcache.clone())),
             db: db,
         }
     }


### PR DESCRIPTION
The config wasn't being picked up from the config.toml due to a
mismatch between the section name in the toml (`memcache`) and the
key in the `Config` structure in `config.rs` (`memcached`).

Thinks were silently working due to the default being localhost:11211.
This showed up on k8s where `sys.ip` for memcached is different from
the host that builder-api is running on.

Added a test case for config.rs and consolidated on `memcache` as the name
that should be the section header.

Signed-off-by: James Casey <james@chef.io>