### PR TITLE
Fix id serialization for channel ID's coming from the database

### DIFF
--- a/components/builder-api/src/server/models/channel.rs
+++ b/components/builder-api/src/server/models/channel.rs
@@ -1,3 +1,4 @@
+use super::db_id_format;
 use actix_web::{actix::Message, Error};
 use chrono::NaiveDateTime;
 use diesel;
@@ -10,8 +11,11 @@ use server::schema::channel::*;
 #[derive(Debug, Serialize, QueryableByName)]
 #[table_name = "origin_channels"]
 pub struct Channel {
+    #[serde(with = "db_id_format")]
     pub id: i64,
+    #[serde(with = "db_id_format")]
     pub origin_id: i64,
+    #[serde(with = "db_id_format")]
     pub owner_id: i64,
     pub name: String,
     pub created_at: Option<NaiveDateTime>,

--- a/components/builder-api/src/server/models/mod.rs
+++ b/components/builder-api/src/server/models/mod.rs
@@ -3,3 +3,21 @@
 #![allow(proc_macro_derive_resolution_fallback)]
 
 pub mod channel;
+
+mod db_id_format {
+    use serde::{self, Deserialize, Deserializer, Serializer};
+    pub fn serialize<S>(id: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}", id.to_string());
+        serializer.serialize_str(&s)
+    }
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<i64>().map_err(serde::de::Error::custom)
+    }
+}

--- a/test/builder-api/src/channels.js
+++ b/test/builder-api/src/channels.js
@@ -53,7 +53,7 @@ describe('Channels API', function () {
     it('requires origin membership to promote a package', function (done) {
       request.put('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/20171205003213/promote')
         .set('Authorization', global.mystiqueBearer)
-        .expect(403)
+        .expect(401)
         .end(function (err, res) {
           done(err);
         });
@@ -312,7 +312,7 @@ describe('Channels API', function () {
     it('requires origin membership to delete a channel', function (done) {
       request.delete('/depot/channels/neurosis/foo')
         .set('Authorization', global.mystiqueBearer)
-        .expect(403)
+        .expect(401)
         .end(function (err, res) {
           expect(res.text).to.be.empty;
           done(err);


### PR DESCRIPTION
Fun fact: your browser can't handle 64 bit integers even though they are completely valid in json.
2nd fun fact: all of our db IDs are 64 bit integers.

Previously we implemented the serialize trait for each message struct that would get sent over the wire that converted u64 to string.
I hvae written a serialize function that you can use as a decorator in your structs to tell serde to convert an i64 to string.

Ex:

```
use server::model::db_id_format;

struct Foo {
  #[serde(with = "db_id_format")]
  id: i64,
  name: String,
  #[serde(with = "db_id_format")]
  owner_id: i64,
}

//initialize foo

json!(foo) -> renders quoted i64
```
![](https://media.giphy.com/media/3oFzm07GaxAxjTYedO/giphy-downsized.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>