### PR TITLE
DB Merge - Accounts (profile)

### DIFF
--- a/components/builder-api/src/server/handlers/account.rs
+++ b/components/builder-api/src/server/handlers/account.rs
@@ -1,0 +1,52 @@
+use actix_web::{actix::Handler, error, Error};
+use server::db::DbExecutor;
+use server::models::account::{
+    Account, CreateAccount, FindOrCreateAccount, GetAccount, GetAccountById, UpdateAccount,
+};
+use std::ops::Deref;
+
+impl Handler<GetAccount> for DbExecutor {
+    type Result = Result<Account, Error>;
+
+    fn handle(&mut self, account: GetAccount, _: &mut Self::Context) -> Self::Result {
+        Account::get(account, self.get_conn()?.deref())
+            .map_err(|_| error::ErrorInternalServerError("Error fetching account"))
+    }
+}
+
+impl Handler<GetAccountById> for DbExecutor {
+    type Result = Result<Account, Error>;
+
+    fn handle(&mut self, id: GetAccountById, _: &mut Self::Context) -> Self::Result {
+        Account::get_by_id(id, self.get_conn()?.deref())
+            .map_err(|_| error::ErrorInternalServerError("Error fetching account by ID"))
+    }
+}
+
+impl Handler<CreateAccount> for DbExecutor {
+    type Result = Result<Account, Error>;
+
+    fn handle(&mut self, account: CreateAccount, _: &mut Self::Context) -> Self::Result {
+        Account::create(account, self.get_conn()?.deref())
+            .map_err(|_| error::ErrorInternalServerError("Error creating account"))
+    }
+}
+
+impl Handler<UpdateAccount> for DbExecutor {
+    type Result = Result<(), Error>;
+
+    fn handle(&mut self, account: UpdateAccount, _: &mut Self::Context) -> Self::Result {
+        Account::update(account, self.get_conn()?.deref())
+            .map(|_| ())
+            .map_err(|_| error::ErrorInternalServerError("Error updating account"))
+    }
+}
+
+impl Handler<FindOrCreateAccount> for DbExecutor {
+    type Result = Result<Account, Error>;
+
+    fn handle(&mut self, account: FindOrCreateAccount, _: &mut Self::Context) -> Self::Result {
+        Account::find_or_create(account, self.get_conn()?.deref())
+            .map_err(|_| error::ErrorInternalServerError("Error on FetchOrCreate account"))
+    }
+}

--- a/components/builder-api/src/server/handlers/mod.rs
+++ b/components/builder-api/src/server/handlers/mod.rs
@@ -1,1 +1,2 @@
+pub mod account;
 pub mod channel;

--- a/components/builder-api/src/server/models/account.rs
+++ b/components/builder-api/src/server/models/account.rs
@@ -1,0 +1,97 @@
+use actix_web::{actix::Message, Error};
+use diesel;
+use diesel::pg::PgConnection;
+use diesel::result::QueryResult;
+use diesel::sql_types::{BigInt, Text};
+use diesel::RunQueryDsl;
+use server::schema::account::*;
+
+// Accounts
+#[derive(Debug, Serialize, QueryableByName)]
+#[table_name = "accounts"]
+pub struct Account {
+    pub id: i64,
+    pub email: String,
+    pub name: String,
+}
+
+pub struct GetAccount {
+    pub name: String,
+}
+
+pub struct GetAccountById {
+    pub id: i64,
+}
+
+pub struct CreateAccount {
+    pub name: String,
+    pub email: String,
+}
+
+pub struct UpdateAccount {
+    pub id: i64,
+    pub email: String,
+}
+
+pub struct FindOrCreateAccount {
+    name: String,
+    email: String,
+}
+
+impl Message for GetAccount {
+    type Result = Result<Account, Error>;
+}
+
+impl Message for GetAccountById {
+    type Result = Result<Account, Error>;
+}
+
+impl Message for CreateAccount {
+    type Result = Result<Account, Error>;
+}
+
+impl Message for UpdateAccount {
+    type Result = Result<(), Error>;
+}
+
+impl Message for FindOrCreateAccount {
+    type Result = Result<Account, Error>;
+}
+
+impl Account {
+    pub fn get(account: GetAccount, conn: &PgConnection) -> QueryResult<Account> {
+        diesel::sql_query("SELECT * FROM get_account_by_name_v1($1)")
+            .bind::<Text, _>(account.name)
+            .get_result(conn)
+    }
+
+    pub fn get_by_id(account: GetAccountById, conn: &PgConnection) -> QueryResult<Account> {
+        diesel::sql_query("SELECT * FROM get_account_by_id_v1($1)")
+            .bind::<BigInt, _>(account.id)
+            .get_result(conn)
+    }
+
+    pub fn create(account: CreateAccount, conn: &PgConnection) -> QueryResult<Account> {
+        diesel::sql_query("SELECT * FROM select_or_insert_account_v1($1, $2)")
+            .bind::<Text, _>(account.name)
+            .bind::<Text, _>(account.email)
+            .get_result(conn)
+    }
+
+    pub fn find_or_create(
+        account: FindOrCreateAccount,
+        conn: &PgConnection,
+    ) -> QueryResult<Account> {
+        diesel::sql_query("SELECT * FROM select_or_insert_account_v1($1, $2)")
+            .bind::<Text, _>(account.name)
+            .bind::<Text, _>(account.email)
+            .get_result(conn)
+    }
+
+    pub fn update(account: UpdateAccount, conn: &PgConnection) -> QueryResult<usize> {
+        diesel::sql_query("SELECT update_account_v1($1, $2)")
+            .bind::<BigInt, _>(account.id)
+            .bind::<Text, _>(account.email)
+            .execute(conn)
+    }
+}

--- a/components/builder-api/src/server/models/mod.rs
+++ b/components/builder-api/src/server/models/mod.rs
@@ -2,6 +2,7 @@
 // https://github.com/rust-lang/rust/issues/50504
 #![allow(proc_macro_derive_resolution_fallback)]
 
+pub mod account;
 pub mod channel;
 
 mod db_id_format {

--- a/components/builder-api/src/server/schema/account.rs
+++ b/components/builder-api/src/server/schema/account.rs
@@ -1,0 +1,18 @@
+table! {
+    accounts (id) {
+        id -> BigInt,
+        name -> Text,
+        email -> Text,
+        created_at -> Nullable<Timestamptz>,
+        updated_at -> Nullable<Timestamptz>,
+    }
+}
+
+table! {
+    account_tokens (id) {
+        id -> BigInt,
+        account_id -> BigInt,
+        token -> Text,
+        created_at -> Nullable<Timestamptz>,
+    }
+}

--- a/components/builder-api/src/server/schema/mod.rs
+++ b/components/builder-api/src/server/schema/mod.rs
@@ -2,6 +2,7 @@
 // https://github.com/rust-lang/rust/issues/50504
 #![allow(proc_macro_derive_resolution_fallback)]
 
+pub mod account;
 pub mod channel;
 pub mod integration;
 pub mod invitation;


### PR DESCRIPTION
Initial merge of originsrv  account handling into api. Migrates only get_account and update_account though plumbing for others exists in the PR as well.

Signed-off-by: Ian Henry <ihenry@chef.io>