### PR TITLE
Rearrange lines again, because I'm dumb

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,21 +1,21 @@
 * @chefsalim @raskchanky
+components/airlock @chefsalim @raskchanky @fnichol @elliott-davis
 components/airlock/src/command @apriofrost
 components/airlock/src/main.rs @apriofrost
-components/airlock @chefsalim @raskchanky @fnichol @elliott-davis
+components/builder-* @chefsalim @raskchanky @reset @elliott-davis @eeyun
+components/builder-web @chefsalim @cnunciato @raskchanky @mgamini @elliott-davis
+components/builder-worker @chefsalim @raskchanky @reset @elliott-davis @fnichol
+components/builder-worker/src/main.rs @apriofrost
 components/builder-api/src/main.rs @apriofrost
 components/builder-graph/src/main.rs @apriofrost
 components/builder-jobsrv/src/main.rs @apriofrost
 components/builder-originsrv/src/main.rs @apriofrost
 components/builder-router/src/main.rs @apriofrost
-components/builder-web @chefsalim @cnunciato @raskchanky @mgamini @elliott-davis
-components/builder-worker/src/main.rs @apriofrost
-components/builder-worker @chefsalim @raskchanky @reset @elliott-davis @fnichol
-components/builder-* @chefsalim @raskchanky @reset @elliott-davis @eeyun
 components/github-api-client @chefsalim @raskchanky
 components/net @chefsalim @raskchanky
 components/oauth-client @chefsalim @raskchanky
-components/op/src/main.rs @apriofrost
 components/op @chefsalim @raskchanky
+components/op/src/main.rs @apriofrost
 components/segment-api-client @chefsalim @raskchanky
 support @fnichol @chefsalim @raskchanky @baumanj @elliott-davis
 tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol


### PR DESCRIPTION
Awhile back, I submitted a PR to rearrange these lines so that the most specific ones (for UX and docs people) went first, and the most generic ones went last.  I did that because [the GH docs for the CODEOWNERS file](https://help.github.com/articles/about-codeowners/) mentions that the last match wins.  With the most specific lines last, PRs were requiring review from e.g. @apriofrost, simply because one of the files she's tagged on had a change, even though there was no UX related change in the file.  The only way to merge a PR in that state was to use admin privs to override it.

I thought this was a bad idea and set about to rectify it by making the most generic tagging the last one.  Those of you that are smarter than me have already realized the flaw in this logic, though, which is that the last match wins, so the generic tag always won, and @apriofrost would never get tagged on any PR.

The truth is that the logic around how GH treats CODEOWNERS file doesn't _exactly_ fit what we need it to do, but it seems better to have it notify people that it should and have a small minority of PRs require admin privs for merging, than not ping anyone on the UX or docs team.

I'll have matching PRs for the rest of the repos that have CODEOWNERS files.  Sorry for the noise.

![](https://media.giphy.com/media/d7fTn7iSd2ivS/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>