### PR TITLE
Invalidate package cache on channel deletion

### DIFF
--- a/components/builder-api/src/server/handlers/channel.rs
+++ b/components/builder-api/src/server/handlers/channel.rs
@@ -26,7 +26,7 @@ impl Handler<CreateChannel> for DbExecutor {
         match Channel::create(channel, self.get_conn()?.deref()) {
             Ok(channel) => Ok(channel),
             Err(DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => {
-                Err(error::ErrorConflict("channel already Exists"))
+                Err(error::ErrorConflict("channel already exists"))
             }
             Err(_) => Err(error::ErrorInternalServerError("Error creating channel")),
         }

--- a/components/builder-api/src/server/models/channel.rs
+++ b/components/builder-api/src/server/models/channel.rs
@@ -23,7 +23,7 @@ pub struct Channel {
 }
 
 pub struct CreateChannel {
-    pub name: String,
+    pub channel: String,
     pub owner_id: i64,
     pub origin: String,
 }
@@ -78,7 +78,7 @@ impl Channel {
         diesel::sql_query("select * from insert_origin_channel_v2($1, $2, $3)")
             .bind::<Text, _>(channel.origin)
             .bind::<BigInt, _>(channel.owner_id)
-            .bind::<Text, _>(channel.name)
+            .bind::<Text, _>(channel.channel)
             .get_result(conn)
     }
 

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -142,7 +142,7 @@ fn create_channel(req: HttpRequest<AppState>) -> FutureResponse<HttpResponse> {
     req.state()
         .db
         .send(CreateChannel {
-            name: channel,
+            channel: channel,
             origin: origin,
             owner_id: session_id,
         }).from_err()
@@ -164,6 +164,11 @@ fn delete_channel(req: HttpRequest<AppState>) -> FutureResponse<HttpResponse> {
     if channel == "stable" || channel == "unstable" {
         return future::err(error::ErrorForbidden(format!("{} is protected", channel))).responder();
     }
+
+    req.state()
+        .memcache
+        .borrow_mut()
+        .clear_cache_for_channel(&origin, &channel);
 
     req.state()
         .db

--- a/components/builder-core/src/integrations.rs
+++ b/components/builder-core/src/integrations.rs
@@ -61,7 +61,7 @@ where
         Ok(bytes) => bytes,
         Err(err) => {
             let e = format!("Unable to decrypt with bldr key pair, err={:?}", &err);
-            error!("Unable to decrypt with bldr key pair, err={:?}", err);
+            debug!("Unable to decrypt with bldr key pair, err={:?}", err);
             return Err(Error::DecryptError(e));
         }
     };


### PR DESCRIPTION
This update adds a channel namespace to memcache. This allows the packages in a particular origin/channel to be invalidated when a channel is deleted.

Resolves https://github.com/habitat-sh/builder/issues/691

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-196928002](https://user-images.githubusercontent.com/13542112/46318911-f0bfe000-c58c-11e8-823f-fed8e41b95aa.gif)
