### PR TITLE
Tweak github api metric usage

### DIFF
--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -165,7 +165,7 @@ impl GitHubClient {
     pub fn contents(&self, token: &AppToken, repo: u32, path: &str) -> HubResult<Option<Contents>> {
         let url_path = format!("{}/repositories/{}/contents/{}", self.api_url, repo, path);
 
-        Counter::Api("contents").increment();
+        Counter::Contents.increment();
         let mut rep = self.http_get(&url_path, Some(&token.inner_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;
@@ -189,7 +189,7 @@ impl GitHubClient {
 
     pub fn repo(&self, token: &AppToken, repo: u32) -> HubResult<Option<Repository>> {
         let url_path = format!("{}/repositories/{}", self.api_url, repo);
-        Counter::Api("repo").increment();
+        Counter::Repo.increment();
         let mut rep = self.http_get(&url_path, Some(&token.inner_token))?;
         let mut body = String::new();
         rep.read_to_string(&mut body)?;

--- a/components/github-api-client/src/metrics.rs
+++ b/components/github-api-client/src/metrics.rs
@@ -22,10 +22,8 @@ pub type Endpoint = &'static str;
 
 pub enum Counter {
     InstallationToken,
-    // Github App-mediated API calls
-    Api(Endpoint),
-    // Github API calls, but using a user's personal Github token
-    UserApi(Endpoint),
+    Repo,
+    Contents,
 }
 
 impl metrics::CounterMetric for Counter {}
@@ -34,8 +32,8 @@ impl metrics::Metric for Counter {
     fn id(&self) -> Cow<'static, str> {
         match *self {
             Counter::InstallationToken => "github.installation-token".into(),
-            Counter::Api(ref endpoint) => format!("github.api.{}", endpoint).into(),
-            Counter::UserApi(ref endpoint) => format!("github.user-api.{}", endpoint).into(),
+            Counter::Repo => "github.api.repo".into(),
+            Counter::Contents => "github.api.contents".into(),
         }
     }
 }


### PR DESCRIPTION
Minor tweak to remove un-used GH metric, and convert the other two to a simpler enum type.

Resolves https://github.com/habitat-sh/builder/issues/281

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-13076026](https://user-images.githubusercontent.com/13542112/46375479-62109900-c648-11e8-9ef7-92cc74622395.gif)
