### PR TITLE
Add datadog service startup event

### DIFF
--- a/components/builder-api/habitat/hooks/run
+++ b/components/builder-api/habitat/hooks/run
@@ -4,6 +4,10 @@ export HOME="{{pkg.svc_data_path}}"
 export RUST_LOG="{{cfg.log_level}}"
 export RUST_BACKTRACE=1
 
+title="Service Start"
+text="builder-api starting"
+echo "_e{${#title},${#text}}:$title|$text|#shell,bash"  >/dev/udp/localhost/8125
+
 if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U "{{pkg.svc_user}}:{{pkg.svc_group}}" \


### PR DESCRIPTION
Adding a service startup event datadog event to builder-api.  This will be expanded to the other services eventually after we try this out in acceptance and prod.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-96861068](https://user-images.githubusercontent.com/13542112/46381579-c12bd900-c65b-11e8-8c7e-afc52d181cc1.gif)
