### PR TITLE
Remove shard usage from router

### DIFF
--- a/components/builder-router/src/server/handlers.rs
+++ b/components/builder-router/src/server/handlers.rs
@@ -37,18 +37,15 @@ pub fn on_heartbeat(conn: &SrvConn, message: &mut Message, servers: &mut ServerM
 }
 
 pub fn on_registration(
-    conn: &SrvConn,
+    _conn: &SrvConn,
     message: &mut Message,
     servers: &mut ServerMap,
 ) -> Result<()> {
-    let mut body = message.parse::<routesrv::Registration>()?;
+    let body = message.parse::<routesrv::Registration>()?;
     debug!("OnRegistration, {:?}", body);
     let protocol = body.get_protocol();
-    let shards = body.take_shards();
-    if !servers.add(protocol, message.sender().unwrap().to_vec(), shards) {
-        let err = NetError::new(ErrCode::REG_CONFLICT, "rt:register:1");
-        warn!("{}", err);
-        conn.route_reply(message, &*err)?;
+    if !servers.add(protocol, message.sender().unwrap().to_vec()) {
+        debug!("Server already registered - no op");
     }
     Ok(())
 }


### PR DESCRIPTION
This change removes all knowledge of shards from builder-router.  This is mostly removal of left-over dead code without any functional change.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-95957027](https://user-images.githubusercontent.com/13542112/46447041-aa0cea00-c734-11e8-81e2-49338043c99c.gif)
