### PR TITLE
Remove shards from application

### DIFF
--- a/components/builder-protocol/protocols/routesrv.proto
+++ b/components/builder-protocol/protocols/routesrv.proto
@@ -6,6 +6,7 @@ message Disconnect {}
 message Heartbeat {}
 
 message Registration {
+  reserved 2;
+  reserved "shards";
   optional net.Protocol protocol = 1;
-  repeated uint32 shards = 2 [packed=true];
 }

--- a/components/net/src/app/mod.rs
+++ b/components/net/src/app/mod.rs
@@ -247,7 +247,7 @@ impl<T> Application<T>
 where
     T: Dispatcher,
 {
-    fn new(config: &T::Config) -> AppResult<Self, T::Error> {
+    fn new(_config: &T::Config) -> AppResult<Self, T::Error> {
         let router_sock = (**DEFAULT_CONTEXT).as_mut().socket(zmq::ROUTER)?;
         router_sock.set_identity(socket::srv_ident().as_bytes())?;
         router_sock.set_probe_router(true)?;
@@ -258,9 +258,6 @@ where
         let pipe_in = (**DEFAULT_CONTEXT).as_mut().socket(zmq::DEALER).unwrap();
         let mut registration = routesrv::Registration::new();
         registration.set_protocol(T::PROTOCOL);
-        if let Some(ref shards) = config.as_ref().shards {
-            registration.set_shards(shards.to_vec());
-        }
         Ok(Application {
             heartbeat: protocol::Message::build(&routesrv::Heartbeat::new())?,
             msg_buf: protocol::Message::default(),

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -90,9 +90,6 @@ mkdir -p /hab/svc/builder-originsrv
 cat <<EOT > /hab/svc/builder-originsrv/user.toml
 log_level = "info"
 
-[app]
-shards = [0]
-
 [datastore]
 password = "$PGPASSWORD"
 EOT


### PR DESCRIPTION
Remove leftover shard code from net/app.  Also makes a minor tweak to change the number of default workers to cpu * 2, instead of cpu * 8.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-167105300](https://user-images.githubusercontent.com/13542112/46509358-17814f00-c7f7-11e8-8fb8-a53a83974d9c.gif)
