### PR TITLE
Clarify the wording around job cancellation

### DIFF
--- a/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.html
@@ -59,7 +59,7 @@
               <span class="jobgroup-actions">
                 <a *ngIf="pendingCount > 0" class="cancel" (click)="cancel(id)">
                   <hab-icon symbol="no"></hab-icon>
-                  Cancel unfinished jobs
+                  Cancel remaining jobs
                 </a>
               </span>
             </div>

--- a/components/builder-web/app/package/job-list/job-list.component.html
+++ b/components/builder-web/app/package/job-list/job-list.component.html
@@ -21,7 +21,7 @@
           {{ dateFor(job.created_at) }}
         </span>
         <span class="column icons">
-          <hab-job-status-icon [job]="job"></hab-job-status-icon>
+          <hab-job-status-icon [job]="job" [animate]="true"></hab-job-status-icon>
           <hab-icon symbol="chevron-right"></hab-icon>
         </span>
       </a>

--- a/components/builder-web/app/package/job-list/job-list.component.spec.ts
+++ b/components/builder-web/app/package/job-list/job-list.component.spec.ts
@@ -32,7 +32,7 @@ describe('JobListComponent', () => {
       ],
       declarations: [
         MockComponent({ selector: 'hab-icon', inputs: ['symbol'] }),
-        MockComponent({ selector: 'hab-job-status-icon', inputs: ['job'] }),
+        MockComponent({ selector: 'hab-job-status-icon', inputs: ['job', 'animate'] }),
         JobListComponent
       ]
     });

--- a/components/builder-web/app/shared/dialog/job-cancel/job-cancel.dialog.html
+++ b/components/builder-web/app/shared/dialog/job-cancel/job-cancel.dialog.html
@@ -5,16 +5,16 @@
   </section>
   <section class="body">
     <p>
-      Completed build jobs will remain in the <b>unstable</b> channel. Pending jobs will not be processed.
+      Completed packages will remain in the <b>unstable</b> channel. Remaining jobs will be canceled.
     </p>
     <p>
-      Build jobs to be canceled: <b>{{ pendingCount }}</b>
+      Remaining build jobs: <b>{{ pendingCount }}</b>
     </p>
   </section>
   <section class="controls">
     <button mat-raised-button color="primary" class="button" (click)="ok()">
-      Yes, cancel jobs
+      Cancel remaining jobs
     </button>
-    <a (click)="cancel()">Cancel</a>
+    <a (click)="cancel()">Don't cancel</a>
   </section>
 </div>


### PR DESCRIPTION
The wording we’re using now is a bit inconsistent; this uses the word “remaining” to include jobs that have either not yet begun or are in progress, and changes the Cancel button to use something other than “cancel”, because the thing you’re confirming happens to be a cancellation.

Also ensures we animate the icon in the jobs list when applicable.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/VDNiBNPaoegzS/200w.gif)