### PR TITLE
Shut down a Supervisor properly in systemd unit file

### DIFF
--- a/terraform/templates/hab-sup.service
+++ b/terraform/templates/hab-sup.service
@@ -6,7 +6,7 @@ Environment=RUST_LOG=${log_level}
 Environment=HAB_STATS_ADDR=localhost:8125
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem"
 ExecStart=/bin/hab run ${flags}
-ExecStop=/bin/hab sup term
+KillMode=process
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Ideally, we would use `ExecStop` to issue a `hab sup term`
command. However, according to the [documentation](https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStop=),
the command specified for `ExecStop` should be a synchronous one;
currently `hab sup term` is _not_ synchronous.

Additionally, I have noticed issues shutting down services via
`systemd`, where the Launcher itself is not shutting down, but
individual Habitat services get killed and restarted. Then, 90 seconds
later, `systemd` determines that the stop didn't take, and it brutally
kills everything.

A bit of digging shows that we can specify [KillMode](https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=)
to control how `systemd` terminates our process. The default is
`control-group` where it sends a `TERM` signal to "remaining processes
in the control group" after the main process has been stopped. In
contrast, setting this to `process` only sends the `TERM` signal to
the main process. This is what we want to do, as the Launcher will
shut everything down properly once it receives the `TERM` signal.

The `systemd` documentation is a little unclear on the interactions
between `ExecStop` and `KillMode` when `KillMode=control-group` and
`ExecStop` isn't defined (I think if it's not defined, `systemd` will
send a `TERM` to the main process, followed by a `TERM` to the rest of
the processes). If that understanding is correct, there may be some
issue in how the Launcher's signal handling is set up, such that it
seems to not get this `TERM` signal. Alternatively, I may not
understand exactly what `systemd` is doing in this situation.

When I make this change, though, I can reliably get a clean Supervisor
shutdown.

Signed-off-by: Christopher Maier <cmaier@chef.io>