### PR TITLE
Convert user invitations to Direct DB access

### DIFF
--- a/components/builder-api/src/server/models/invitations.rs
+++ b/components/builder-api/src/server/models/invitations.rs
@@ -1,0 +1,37 @@
+use super::db_id_format;
+use chrono::NaiveDateTime;
+use diesel;
+use diesel::pg::PgConnection;
+use diesel::result::QueryResult;
+use diesel::sql_types::BigInt;
+use diesel::RunQueryDsl;
+use server::schema::invitation::*;
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName)]
+#[table_name = "origin_invitations"]
+pub struct OriginInvitation {
+    #[serde(with = "db_id_format")]
+    pub id: i64,
+    #[serde(with = "db_id_format")]
+    pub origin_id: i64,
+    pub origin_name: String,
+    #[serde(with = "db_id_format")]
+    pub account_id: i64,
+    pub account_name: String,
+    #[serde(with = "db_id_format")]
+    pub owner_id: i64,
+    pub ignored: bool,
+    pub created_at: Option<NaiveDateTime>,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+impl OriginInvitation {
+    pub fn list_by_account(
+        owner_id: i64,
+        conn: &PgConnection,
+    ) -> QueryResult<Vec<OriginInvitation>> {
+        diesel::sql_query("select * from get_origin_invitations_for_account_v1($1)")
+            .bind::<BigInt, _>(owner_id)
+            .get_results(conn)
+    }
+}

--- a/components/builder-api/src/server/models/mod.rs
+++ b/components/builder-api/src/server/models/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod account;
 pub mod channel;
+pub mod invitations;
 pub mod origins;
 
 mod db_id_format {

--- a/components/builder-api/src/server/schema/invitation.rs
+++ b/components/builder-api/src/server/schema/invitation.rs
@@ -1,12 +1,12 @@
 table! {
-    origin_invitations (id) {
+    origin_invitations {
         id -> BigInt,
-        origin_id -> Nullable<BigInt>,
-        origin_name -> Nullable<Text>,
-        account_id -> Nullable<BigInt>,
-        account_name -> Nullable<Text>,
-        owner_id -> Nullable<BigInt>,
-        ignored -> Nullable<Bool>,
+        origin_id -> BigInt,
+        origin_name -> Text,
+        account_id -> BigInt,
+        account_name -> Text,
+        owner_id -> BigInt,
+        ignored -> Bool,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
     }

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -441,9 +441,11 @@ export class BuilderApiClient {
       })
         .then(response => this.handleUnauthorized(response, reject))
         .then(response => {
-          response.json().then(data => {
-            resolve(data['invitations']);
-          });
+          if (response.ok) {
+            resolve(response.json());
+          } else {
+            reject(new Error(response.statusText));
+          }
         })
         .catch(error => this.handleError(error, reject));
     });

--- a/test/builder-api/src/invitations.js
+++ b/test/builder-api/src/invitations.js
@@ -56,12 +56,12 @@ describe('Origin Invitations API', function () {
         .set('Authorization', global.boboBearer)
         .expect(200)
         .end(function (err, res) {
-          expect(res.body.invitations[0].id).to.equal(global.inviteBoboToXmen.id);
-          expect(res.body.invitations[0].account_id).to.equal(global.sessionBobo.id);
-          expect(res.body.invitations[0].account_name).to.equal('bobo');
-          expect(res.body.invitations[0].origin_id).to.equal(global.originXmen.id);
-          expect(res.body.invitations[0].origin_name).to.equal('xmen');
-          expect(res.body.invitations[0].owner_id).to.equal(global.sessionMystique.id);
+          expect(res.body[0].id).to.equal(global.inviteBoboToXmen.id);
+          expect(res.body[0].account_id).to.equal(global.sessionBobo.id);
+          expect(res.body[0].account_name).to.equal('bobo');
+          expect(res.body[0].origin_id).to.equal(global.originXmen.id);
+          expect(res.body[0].origin_name).to.equal('xmen');
+          expect(res.body[0].owner_id).to.equal(global.sessionMystique.id);
           done(err);
         });
     });
@@ -102,7 +102,7 @@ describe('Origin Invitations API', function () {
         .set('Authorization', global.boboBearer)
         .expect(200)
         .end(function (err, res) {
-          expect(res.body.invitations.length).to.equal(0);
+          expect(res.body.length).to.equal(0);
           done(err);
         });
     });


### PR DESCRIPTION
This breaks the existing API by removing the `invitations` key for the list of invitations

![](https://media.giphy.com/media/l0ErE1PQZg1JEBvaw/200w_d.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>