### PR TITLE
[ci,rustfmt] Formatting due to rustfmt-0.99.1-stable in Rust 1.29.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
         - COMPONENTS=bin
         - AFFECTED_FILES="Cargo.lock"
         - AFFECTED_DIRS="$_RUST_HAB_BIN_COMPONENTS"
-      rust: 1.29.0
+      rust: 1.29.1
       sudo: false
       services:
         - docker
@@ -84,7 +84,7 @@ matrix:
         - COMPONENTS=lib
         - AFFECTED_FILES="Cargo.lock"
         - AFFECTED_DIRS="$_RUST_BLDR_LIB_COMPONENTS"
-      rust: 1.29.0
+      rust: 1.29.1
       sudo: required
       addons:
         apt:
@@ -126,7 +126,7 @@ matrix:
         - COMPONENTS=srv
         - AFFECTED_FILES="Cargo.lock .travis.yml .envrc .studiorc"
         - AFFECTED_DIRS=".secrets support $_RUST_BLDR_BIN_COMPONENTS $_RUST_BLDR_LIB_COMPONENTS"
-      rust: 1.29.0
+      rust: 1.29.1
       sudo: required
       addons:
         apt:

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -365,7 +365,10 @@ mod tests {
         assert_eq!(&format!("{}", config.http.listen), "::1");
 
         assert_eq!(config.memcache.ttl, 11);
-        assert_eq!(&format!("{}", config.memcache.hosts[0]), "memcache://192.168.0.1:12345");
+        assert_eq!(
+            &format!("{}", config.memcache.hosts[0]),
+            "memcache://192.168.0.1:12345"
+        );
 
         assert_eq!(config.upstream.endpoint, String::from("http://example.com"));
         assert_eq!(

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -138,8 +138,7 @@ pub fn run(config: Config) -> Result<()> {
             RouteBroker::start(socket::srv_ident(), c.route_addrs())
                 .map_err(Error::Connection)
                 .unwrap();
-        })
-        .unwrap();
+        }).unwrap();
 
     UpstreamMgr::start(&config, S3Handler::new(config.s3.to_owned()))?;
 
@@ -178,10 +177,10 @@ pub fn run(config: Config) -> Result<()> {
                 r.head().f(status)
             })
     }).workers(cfg.handler_count())
-        .keep_alive(KeepAlive::Timeout(cfg.http.keep_alive))
-        .bind(cfg.http.clone())
-        .unwrap()
-        .start();
+    .keep_alive(KeepAlive::Timeout(cfg.http.keep_alive))
+    .bind(cfg.http.clone())
+    .unwrap()
+    .start();
 
     let _ = sys.run();
 

--- a/components/builder-protocol/src/originsrv.rs
+++ b/components/builder-protocol/src/originsrv.rs
@@ -1630,8 +1630,7 @@ mod tests {
                 opv.set_version(z.to_string());
                 opv.set_latest("haha".to_string());
                 opv
-            })
-            .collect::<Vec<OriginPackageVersion>>();
+            }).collect::<Vec<OriginPackageVersion>>();
 
         let mut y = b
             .iter()
@@ -1642,8 +1641,7 @@ mod tests {
                 opv.set_version(z.to_string());
                 opv.set_latest("haha".to_string());
                 opv
-            })
-            .collect::<Vec<OriginPackageVersion>>();
+            }).collect::<Vec<OriginPackageVersion>>();
 
         x.sort_by(|m, n| n.cmp(m));
         y.sort_by(|m, n| n.cmp(m));


### PR DESCRIPTION
https://blog.rust-lang.org/2018/09/25/Rust-1.29.1.html

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>