### PR TITLE
Expose and use router-less HTTP-based RPC interface to Job server

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -205,7 +205,7 @@ start-cache() {
 }
 
 declare -A svc_params=(
-  [api]="        -s at-once --bind router:builder-router.default --bind memcached:builder-memcached.default --bind datastore:builder-datastore.default"
+  [api]="        -s at-once --bind router:builder-router.default --bind memcached:builder-memcached.default --bind datastore:builder-datastore.default --bind jobsrv:builder-jobsrv.default"
   [api-proxy]="             --bind http:builder-api.default"
   [jobsrv]="     -s at-once --bind router:builder-router.default --bind datastore:builder-datastore.default"
   [originsrv]="  -s at-once --bind router:builder-router.default --bind datastore:builder-datastore.default"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,8 @@ dependencies = [
 name = "habitat_builder_jobsrv"
 version = "0.0.0"
 dependencies = [
+ "actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-web 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1023,9 +1025,9 @@ dependencies = [
  "habitat_builder_db 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_net 0.0.0",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -40,6 +40,14 @@ host = "{{member.sys.ip}}"
 port = {{member.cfg.port}}
 {{~/each}}
 
+[jobsrv]
+{{~#eachAlive bind.jobsrv.members as |member|}}
+{{~#if @first}}
+host = "{{member.sys.ip}}"
+port = {{member.cfg.rpc_port}}
+{{~/if}}
+{{~/eachAlive}}
+
 [datastore]
 {{toToml cfg.datastore}}
 {{~#eachAlive bind.datastore.members as |member|}}

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -17,4 +17,7 @@ pkg_binds=(
   [memcached]="port"
   [datastore]="port"
 )
+pkg_binds_optional=(
+  [jobsrv]="rpc_port"
+)
 bin="bldr-api"

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -66,6 +66,7 @@ pub struct Config {
     pub ui: UiCfg,
     pub upstream: UpstreamCfg,
     pub memcache: MemcacheCfg,
+    pub jobsrv: JobsrvCfg,
     pub datastore: DataStoreCfg,
 }
 
@@ -82,6 +83,7 @@ impl Default for Config {
             ui: UiCfg::default(),
             upstream: UpstreamCfg::default(),
             memcache: MemcacheCfg::default(),
+            jobsrv: JobsrvCfg::default(),
             datastore: DataStoreCfg::default(),
         }
     }
@@ -279,6 +281,28 @@ impl fmt::Display for MemcacheCfgHosts {
     }
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct JobsrvCfg {
+    pub host: String,
+    pub port: u16,
+}
+
+impl Default for JobsrvCfg {
+    fn default() -> Self {
+        JobsrvCfg {
+            host: String::from("localhost"),
+            port: 5580,
+        }
+    }
+}
+
+impl fmt::Display for JobsrvCfg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "http://{}:{}", self.host, self.port)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -330,6 +354,10 @@ mod tests {
         [github]
         api_url = "https://api.github.com"
 
+        [jobsrv]
+        host = "1.2.3.4"
+        port = 1234
+
         [datastore]
         host = "1.1.1.1"
         port = 9000
@@ -369,6 +397,8 @@ mod tests {
             &format!("{}", config.memcache.hosts[0]),
             "memcache://192.168.0.1:12345"
         );
+
+        assert_eq!(&format!("{}", config.jobsrv), "http://1.2.3.4:1234");
 
         assert_eq!(config.upstream.endpoint, String::from("http://example.com"));
         assert_eq!(

--- a/components/builder-api/src/server/error.rs
+++ b/components/builder-api/src/server/error.rs
@@ -195,10 +195,18 @@ impl Into<HttpResponse> for Error {
             Error::OAuth(_) => HttpResponse::new(StatusCode::UNAUTHORIZED),
             Error::ParseIntError(_) => HttpResponse::new(StatusCode::BAD_REQUEST),
             Error::Protocol(_) => HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR),
+            Error::BuilderCore(ref e) => HttpResponse::new(bldr_core_err_to_http(e)),
 
             // Default
             _ => HttpResponse::new(StatusCode::UNPROCESSABLE_ENTITY),
         }
+    }
+}
+
+fn bldr_core_err_to_http(err: &bldr_core::Error) -> StatusCode {
+    match err {
+        bldr_core::error::Error::RpcError(code, _) => StatusCode::from_u16(*code).unwrap(),
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }
 

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -34,6 +34,7 @@ use actix_web::middleware::Logger;
 use actix_web::server::{self, KeepAlive};
 use actix_web::{App, HttpRequest, HttpResponse, Result};
 
+use bldr_core::rpc::RpcClient;
 use github_api_client::GitHubClient;
 use hab_net::socket;
 
@@ -75,6 +76,7 @@ pub struct AppState {
     config: Config,
     packages: S3Handler,
     github: GitHubClient,
+    jobsrv: RpcClient,
     oauth: OAuth2Client,
     segment: SegmentClient,
     upstream: UpstreamClient,
@@ -88,6 +90,7 @@ impl AppState {
             config: config.clone(),
             packages: S3Handler::new(config.s3.clone()),
             github: GitHubClient::new(config.github.clone()),
+            jobsrv: RpcClient::new(&format!("{}", config.jobsrv)),
             oauth: OAuth2Client::new(config.oauth.clone()),
             segment: SegmentClient::new(config.segment.clone()),
             upstream: UpstreamClient::default(),

--- a/components/builder-core/src/lib.rs
+++ b/components/builder-core/src/lib.rs
@@ -54,6 +54,7 @@ pub mod logger;
 pub mod metrics;
 pub mod package_graph;
 pub mod rdeps;
+pub mod rpc;
 pub mod target_graph;
 
 pub use error::Error;

--- a/components/builder-core/src/rpc.rs
+++ b/components/builder-core/src/rpc.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Read;
+
+use reqwest::header::{qitem, Accept, ContentType, Headers};
+use reqwest::mime;
+use reqwest::{Client, StatusCode};
+
+use protobuf;
+use serde_json;
+
+use error::{Error, Result};
+
+// RPC message, transport as JSON over HTTP
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct RpcMessage {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub body: Vec<u8>,
+}
+
+impl RpcMessage {
+    pub fn new(id: String, body: Vec<u8>) -> Self {
+        RpcMessage { id: id, body: body }
+    }
+
+    pub fn make<T>(msg: &T) -> Result<RpcMessage>
+    where
+        T: protobuf::Message,
+    {
+        let id = msg.descriptor().name().to_owned();
+        let body = msg.write_to_bytes().map_err(Error::Protobuf)?;
+
+        Ok(RpcMessage::new(id, body))
+    }
+
+    pub fn parse<T>(&self) -> Result<T>
+    where
+        T: protobuf::Message,
+    {
+        protobuf::parse_from_bytes::<T>(&self.body).map_err(Error::Protobuf)
+    }
+}
+
+// RPC client
+pub struct RpcClient {
+    cli: Client,
+    endpoint: String,
+}
+
+impl RpcClient {
+    pub fn new(url: &str) -> Self {
+        debug!("Creating RPC client, url = {}", url);
+
+        let mut headers = Headers::new();
+        headers.set(Accept(vec![qitem(mime::APPLICATION_JSON)]));
+        headers.set(ContentType::json());
+
+        let mut cli = Client::builder();
+        cli.default_headers(headers);
+
+        RpcClient {
+            cli: cli.build().unwrap(),
+            endpoint: format!("{}/rpc", url),
+        }
+    }
+
+    pub fn rpc<R, T>(&self, req: &R) -> Result<T>
+    where
+        R: protobuf::Message,
+        T: protobuf::Message,
+    {
+        let id = req.descriptor().name().to_owned();
+        let body = req.write_to_bytes()?;
+        let msg = RpcMessage { id: id, body: body };
+        debug!("Sending RPC Message: {:?}", msg);
+
+        let json = serde_json::to_string(&msg)?;
+        let mut res = self.cli.post(&self.endpoint).body(json).send()?;
+        debug!("Got http response status: {}", res.status());
+
+        let mut s = String::new();
+        res.read_to_string(&mut s).map_err(Error::IO)?;
+        debug!("Got http response body: {}", s);
+
+        match res.status() {
+            StatusCode::Ok => {
+                let resp_json: RpcMessage = serde_json::from_str(&s)?;
+                debug!("Got JSON: {:?}", resp_json);
+
+                let resp_msg = protobuf::parse_from_bytes::<T>(&resp_json.body)?;
+                Ok(resp_msg)
+            }
+            status => Err(Error::ApiError(status, s)),
+        }
+    }
+}

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+actix = "*"
 builder_core = { path = "../builder-core" }
 clippy = {version = "*", optional = true}
 futures = "*"
@@ -21,9 +22,9 @@ env_logger = "*"
 habitat_net = { path = "../net" }
 habitat_builder_db = { path = "../builder-db" }
 habitat-builder-protocol = { path = "../builder-protocol" }
-lazy_static = "*"
 linked-hash-map = "*"
 log = "*"
+num_cpus = "*"
 protobuf = "*"
 postgres = { version = "*", features = ["with-chrono"] }
 chrono = { version = "*", features = ["serde"] }
@@ -36,6 +37,10 @@ time = "*"
 toml = { version = "*", default-features = false }
 diesel = "*"
 diesel_migrations = "*"
+
+[dependencies.actix-web]
+version = "*"
+default-features = false
 
 [dependencies.clap]
 version = "*"

--- a/components/builder-jobsrv/habitat/config/config.toml
+++ b/components/builder-jobsrv/habitat/config/config.toml
@@ -24,3 +24,6 @@ port = {{member.cfg.port}}
 [archive]
 local_dir = "{{pkg.svc_data_path}}"
 {{toToml cfg.archive}}
+
+[http]
+{{toToml cfg.http}}

--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -2,6 +2,10 @@ log_level = "info"
 log_path = "/tmp"
 job_timeout = 60
 
+[http]
+listen = "0.0.0.0"
+port   = 5580
+
 [net]
 worker_command_listen = "0.0.0.0"
 worker_command_port = 5566

--- a/components/builder-jobsrv/habitat/plan.sh
+++ b/components/builder-jobsrv/habitat/plan.sh
@@ -12,8 +12,9 @@ pkg_exports=(
   [worker_port]=net.worker_command_port
   [worker_heartbeat]=net.worker_heartbeat_port
   [log_port]=net.log_ingestion_port
+  [rpc_port]=http.port
 )
-pkg_exposes=(worker_port worker_heartbeat log_port)
+pkg_exposes=(worker_port worker_heartbeat log_port rpc_port)
 pkg_binds=(
   [router]="port"
   [datastore]="port"

--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -445,42 +445,6 @@ impl DataStore {
         Ok(package)
     }
 
-    pub fn get_job_graph_package_stats(
-        &self,
-        msg: &jobsrv::JobGraphPackageStatsGet,
-    ) -> Result<jobsrv::JobGraphPackageStats> {
-        let conn = self.pool.get()?;
-
-        let origin = msg.get_origin();
-        let rows = &conn
-            .query("SELECT * FROM count_origin_packages_v1($1)", &[&origin])
-            .map_err(Error::JobGraphPackageStats)?;
-        assert!(rows.len() == 1); // should never have more than one
-
-        let package_count: i64 = rows.get(0).get("count_origin_packages_v1");
-
-        let rows = &conn
-            .query("SELECT * FROM count_group_projects_v2($1)", &[&origin])
-            .map_err(Error::JobGraphPackageStats)?;
-        assert!(rows.len() == 1); // should never have more than one
-        let build_count: i64 = rows.get(0).get("count_group_projects_v2");
-
-        let rows = &conn
-            .query(
-                "SELECT * FROM count_unique_origin_packages_v1($1)",
-                &[&origin],
-            ).map_err(Error::JobGraphPackageStats)?;
-        assert!(rows.len() == 1); // should never have more than one
-        let up_count: i64 = rows.get(0).get("count_unique_origin_packages_v1");
-
-        let mut package_stats = jobsrv::JobGraphPackageStats::new();
-        package_stats.set_plans(package_count as u64);
-        package_stats.set_builds(build_count as u64);
-        package_stats.set_unique_packages(up_count as u64);
-
-        Ok(package_stats)
-    }
-
     pub fn is_job_group_active(&self, project_name: &str) -> Result<bool> {
         let conn = self.pool.get()?;
 

--- a/components/builder-jobsrv/src/lib.rs
+++ b/components/builder-jobsrv/src/lib.rs
@@ -15,6 +15,8 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
+extern crate actix;
+extern crate actix_web;
 extern crate builder_core as bldr_core;
 extern crate chrono;
 extern crate diesel;
@@ -27,11 +29,10 @@ extern crate habitat_builder_db as db;
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;
 extern crate habitat_net as hab_net;
-#[macro_use]
-extern crate lazy_static;
 extern crate linked_hash_map;
 #[macro_use]
 extern crate log;
+extern crate num_cpus;
 extern crate postgres;
 extern crate protobuf;
 extern crate r2d2;

--- a/components/builder-jobsrv/src/server/log_directory.rs
+++ b/components/builder-jobsrv/src/server/log_directory.rs
@@ -26,9 +26,9 @@ impl LogDirectory {
     /// Create a new `LogDirectory` wrapping `path`.
     pub fn new<T>(path: T) -> Self
     where
-        T: Into<PathBuf>,
+        T: AsRef<Path>,
     {
-        LogDirectory(path.into())
+        LogDirectory(path.as_ref().into())
     }
 
     /// Ensures that the specified log directory can be used.
@@ -40,15 +40,15 @@ impl LogDirectory {
     /// * Path is not writable
     pub fn validate<T>(path: T) -> Result<()>
     where
-        T: AsRef<Path> + Into<PathBuf>,
+        T: AsRef<Path>,
     {
         let meta =
             fs::metadata(&path).map_err(|e| Error::LogDirDoesNotExist(path.as_ref().into(), e))?;
         if !meta.is_dir() {
-            return Err(Error::LogDirIsNotDir(path.into()));
+            return Err(Error::LogDirIsNotDir(path.as_ref().into()));
         }
         if meta.permissions().readonly() {
-            return Err(Error::LogDirNotWritable(path.into()));
+            return Err(Error::LogDirNotWritable(path.as_ref().into()));
         }
         Ok(())
     }

--- a/components/builder-jobsrv/src/server/log_ingester.rs
+++ b/components/builder-jobsrv/src/server/log_ingester.rs
@@ -15,7 +15,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::str;
-use std::sync::{mpsc, Arc};
+use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 
 use hab_net::socket::DEFAULT_CONTEXT;
@@ -39,14 +39,14 @@ const LOG_COMPLETE: &'static str = "C";
 pub struct LogIngester {
     intake_sock: zmq::Socket,
     msg: zmq::Message,
-    log_dir: Arc<LogDirectory>,
+    log_dir: LogDirectory,
     log_ingestion_addr: String,
     data_store: DataStore,
     archiver: Box<LogArchiver>,
 }
 
 impl LogIngester {
-    pub fn new(config: &Config, log_dir: Arc<LogDirectory>, data_store: DataStore) -> Result<Self> {
+    pub fn new(config: &Config, log_dir: LogDirectory, data_store: DataStore) -> Result<Self> {
         let intake_sock = (**DEFAULT_CONTEXT).as_mut().socket(zmq::ROUTER)?;
         intake_sock.set_router_mandatory(true)?;
         Ok(LogIngester {
@@ -61,7 +61,7 @@ impl LogIngester {
 
     pub fn start(
         cfg: &Config,
-        log_dir: Arc<LogDirectory>,
+        log_dir: LogDirectory,
         data_store: DataStore,
     ) -> Result<JoinHandle<()>> {
         let mut ingester = Self::new(cfg, log_dir, data_store)?;

--- a/components/builder-jobsrv/src/server/route_broker.rs
+++ b/components/builder-jobsrv/src/server/route_broker.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use hab_net::app::config::RouterAddr;
+use hab_net::conn::{ConnErr, RouteClient, RECV_TIMEOUT_MS, SEND_TIMEOUT_MS};
+use hab_net::socket::{ToAddrString, DEFAULT_CONTEXT};
+use zmq;
+
+/// A messaging RouteBroker for proxying messages from clients to one or more `RouteSrv` and vice
+/// versa.
+pub struct RouteBroker {
+    client_sock: zmq::Socket,
+    router_sock: zmq::Socket,
+}
+
+impl RouteBroker {
+    // RouteBroker IPC listening address for the application's RouteBroker's queue.
+    const IPC_ADDR: &'static str = "inproc://jobsrv.broker";
+
+    /// Helper function for creating a new `RouteClient`.
+    ///
+    /// # Errors
+    ///
+    /// * Could not connect to `RouteBroker`
+    /// * Could not create socket
+    ///
+    /// # Panics
+    ///
+    /// * Could not read `zmq::Context` due to deadlock or poisoning
+    pub fn connect() -> Result<RouteClient, ConnErr> {
+        let conn = RouteClient::new()?;
+        conn.connect(Self::IPC_ADDR)?;
+        Ok(conn)
+    }
+
+    pub fn start(net_ident: String, routers: &[RouterAddr]) -> Result<(), ConnErr> {
+        let mut broker = Self::new(net_ident)?;
+        broker.run(routers)
+    }
+
+    /// Create a new `RouteBroker`
+    ///
+    /// # Errors
+    ///
+    /// * A socket cannot be created within the given `zmq::Context`
+    /// * A socket cannot be configured
+    ///
+    /// # Panics
+    ///
+    /// * Could not read `zmq::Context` due to deadlock or poisoning
+    fn new(net_ident: String) -> Result<Self, ConnErr> {
+        let client_sock = (**DEFAULT_CONTEXT).as_mut().socket(zmq::ROUTER)?;
+        let router_sock = (**DEFAULT_CONTEXT).as_mut().socket(zmq::DEALER)?;
+        router_sock.set_identity(net_ident.as_bytes())?;
+        router_sock.set_rcvtimeo(RECV_TIMEOUT_MS)?;
+        router_sock.set_sndtimeo(SEND_TIMEOUT_MS)?;
+        router_sock.set_immediate(true)?;
+        Ok(RouteBroker {
+            client_sock: client_sock,
+            router_sock: router_sock,
+        })
+    }
+
+    pub fn run(&mut self, routers: &[RouterAddr]) -> Result<(), ConnErr> {
+        self.client_sock.bind(Self::IPC_ADDR)?;
+        for addr in routers {
+            self.router_sock.connect(&addr.to_addr_string())?;
+        }
+        zmq::proxy(&mut self.client_sock, &mut self.router_sock).map_err(ConnErr::Socket)
+    }
+}

--- a/components/builder-protocol/protocols/jobsrv.proto
+++ b/components/builder-protocol/protocols/jobsrv.proto
@@ -221,13 +221,3 @@ message JobGraphPackageReverseDependencies {
   optional string name = 2;
   repeated string rdeps = 3;
 }
-
-message JobGraphPackageStatsGet {
-  optional string origin = 1;
-}
-
-message JobGraphPackageStats {
-  optional uint64 plans = 1;
-  optional uint64 builds = 2;
-  optional uint64 unique_packages = 3;
-}

--- a/components/builder-protocol/src/jobsrv.rs
+++ b/components/builder-protocol/src/jobsrv.rs
@@ -386,14 +386,6 @@ impl Routable for JobGroupOriginGet {
     }
 }
 
-impl Routable for JobGraphPackageStatsGet {
-    type H = String;
-
-    fn route_key(&self) -> Option<Self::H> {
-        Some(self.get_origin().to_string())
-    }
-}
-
 impl Routable for JobGraphPackageCreate {
     type H = String;
     fn route_key(&self) -> Option<Self::H> {
@@ -542,19 +534,6 @@ impl Serialize for JobGraphPackageReverseDependencies {
         strukt.serialize_field("origin", &self.get_origin())?;
         strukt.serialize_field("name", &self.get_name())?;
         strukt.serialize_field("rdeps", &self.get_rdeps())?;
-        strukt.end()
-    }
-}
-
-impl Serialize for JobGraphPackageStats {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut strukt = serializer.serialize_struct("job_graph_package_stats", 2)?;
-        strukt.serialize_field("plans", &self.get_plans())?;
-        strukt.serialize_field("builds", &self.get_builds())?;
-        strukt.serialize_field("unique_packages", &self.get_unique_packages())?;
         strukt.end()
     }
 }

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -77,7 +77,7 @@ EOT
 
 mkdir -p /hab/svc/builder-jobsrv
 cat <<EOT > /hab/svc/builder-jobsrv/user.toml
-log_level = "info"
+log_level = "debug,tokio_core=error,tokio_reactor=error,zmq=error"
 
 [datastore]
 password = "$PGPASSWORD"

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -95,7 +95,7 @@ resource "aws_instance" "api" {
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
       "sudo hab svc load habitat/builder-memcached --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
-      "sudo hab svc load habitat/builder-api --group ${var.env} --bind memcached:builder-memcached.${var.env} --bind datastore:builder-datastore.${var.env} --bind router:builder-router.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load habitat/builder-api --group ${var.env} --bind memcached:builder-memcached.${var.env} --bind datastore:builder-datastore.${var.env} --bind router:builder-router.${var.env} --bind jobsrv:builder-jobsrv.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
       "sudo hab svc load habitat/builder-api-proxy --group ${var.env} --bind http:builder-api.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
       "sudo hab svc load core/sumologic --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]


### PR DESCRIPTION
This change adds a new HTTP transport for protobuf RPC. The new RPC infrastructure is now leveraged by the job server and builder-api for all JobSrv Protocol RPC. This eliminates the need to route the jobsrv protocol through the router.  Note that originsrv is still using the ZMQ based RPC, so it will still use the router for now.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-212205207](https://user-images.githubusercontent.com/13542112/46883124-d3e5a100-ce05-11e8-85fb-26deb5bcb519.gif)
