### PR TITLE
Add AWS security group for jobsrv RPC port

### DIFF
--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -123,6 +123,16 @@ resource "aws_security_group" "jobsrv" {
     ]
   }
 
+  ingress {
+    from_port = 5580
+    to_port   = 5580
+    protocol  = "tcp"
+
+    security_groups = [
+      "${aws_security_group.gateway.id}",
+    ]
+  }
+
   tags {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"


### PR DESCRIPTION
Small tweak to add the jobsrv RPC port ingress to the jobsrv security group.

Signed-off-by: Salim Alam <salam@chef.io>