### PR TITLE
Convert origin projects to direct DB calls

### DIFF
--- a/components/builder-api/src/server/error.rs
+++ b/components/builder-api/src/server/error.rs
@@ -176,6 +176,7 @@ impl ResponseError for Error {
             Error::OAuth(_) => HttpResponse::new(StatusCode::UNAUTHORIZED),
             Error::ParseIntError(_) => HttpResponse::new(StatusCode::BAD_REQUEST),
             Error::Protocol(_) => HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR),
+            Error::DieselError(ref e) => HttpResponse::new(diesel_err_to_http(&e)),
 
             // Default
             _ => HttpResponse::new(StatusCode::UNPROCESSABLE_ENTITY),
@@ -196,10 +197,18 @@ impl Into<HttpResponse> for Error {
             Error::ParseIntError(_) => HttpResponse::new(StatusCode::BAD_REQUEST),
             Error::Protocol(_) => HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR),
             Error::BuilderCore(ref e) => HttpResponse::new(bldr_core_err_to_http(e)),
+            Error::DieselError(ref e) => HttpResponse::new(diesel_err_to_http(e)),
 
             // Default
             _ => HttpResponse::new(StatusCode::UNPROCESSABLE_ENTITY),
         }
+    }
+}
+
+fn diesel_err_to_http(err: &diesel::result::Error) -> StatusCode {
+    match err {
+        diesel::result::Error::NotFound => StatusCode::NOT_FOUND,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }
 

--- a/components/builder-db/Cargo.toml
+++ b/components/builder-db/Cargo.toml
@@ -15,7 +15,7 @@ r2d2 = "*"
 time = "*"
 rand = "*"
 serde = "*"
-chrono = "*"
+chrono = { version = "*", features = ["serde"] }
 serde_derive = "*"
 num_cpus = "*"
 protobuf = "*"

--- a/components/builder-db/src/models/mod.rs
+++ b/components/builder-db/src/models/mod.rs
@@ -7,6 +7,8 @@ pub mod channel;
 pub mod invitations;
 pub mod origins;
 pub mod package;
+pub mod project_integration;
+pub mod projects;
 
 mod db_id_format {
     use serde::{self, Deserialize, Deserializer, Serializer};

--- a/components/builder-db/src/models/project_integration.rs
+++ b/components/builder-db/src/models/project_integration.rs
@@ -1,0 +1,71 @@
+use super::db_id_format;
+use chrono::NaiveDateTime;
+use diesel;
+use diesel::pg::PgConnection;
+use diesel::result::QueryResult;
+use diesel::sql_types::Text;
+use diesel::RunQueryDsl;
+use schema::project_integration::*;
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName)]
+#[table_name = "origin_project_integrations"]
+pub struct ProjectIntegration {
+    #[serde(with = "db_id_format")]
+    pub id: i64,
+    #[serde(with = "db_id_format")]
+    pub project_id: i64,
+    #[serde(with = "db_id_format")]
+    pub integration_id: i64,
+    pub body: String,
+    pub created_at: Option<NaiveDateTime>,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NewProjectIntegration {
+    pub origin: String,
+    pub name: String,
+    pub integration: String,
+    pub body: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GetProjectIntegration {
+    pub origin: String,
+    pub name: String,
+    pub integration: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DeleteProjectIntegration {
+    pub origin: String,
+    pub name: String,
+    pub integration: String,
+}
+
+impl ProjectIntegration {
+    pub fn get(req: GetProjectIntegration, conn: &PgConnection) -> QueryResult<ProjectIntegration> {
+        diesel::sql_query("select * from get_origin_project_integrations_v2($1, $2, $3)")
+            .bind::<Text, _>(req.origin)
+            .bind::<Text, _>(req.name)
+            .bind::<Text, _>(req.integration)
+            .get_result(conn)
+    }
+
+    pub fn delete(req: DeleteProjectIntegration, conn: &PgConnection) -> QueryResult<usize> {
+        diesel::sql_query("select * from delete_origin_project_integration_v1($1, $2, $3)")
+            .bind::<Text, _>(req.origin)
+            .bind::<Text, _>(req.name)
+            .bind::<Text, _>(req.integration)
+            .execute(conn)
+    }
+
+    pub fn create(req: NewProjectIntegration, conn: &PgConnection) -> QueryResult<usize> {
+        diesel::sql_query("SELECT * FROM upsert_origin_project_integration_v3($1, $2, $3, $4)")
+            .bind::<Text, _>(req.origin)
+            .bind::<Text, _>(req.name)
+            .bind::<Text, _>(req.integration)
+            .bind::<Text, _>(req.body)
+            .execute(conn)
+    }
+}

--- a/components/builder-db/src/models/projects.rs
+++ b/components/builder-db/src/models/projects.rs
@@ -1,0 +1,109 @@
+use super::db_id_format;
+use chrono::NaiveDateTime;
+use diesel;
+use diesel::pg::PgConnection;
+use diesel::result::QueryResult;
+use diesel::sql_types::{BigInt, Bool, Text};
+use diesel::RunQueryDsl;
+use schema::project::*;
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName)]
+#[table_name = "origin_projects"]
+pub struct Project {
+    #[serde(with = "db_id_format")]
+    pub id: i64,
+    #[serde(with = "db_id_format")]
+    pub origin_id: i64,
+    #[serde(with = "db_id_format")]
+    pub owner_id: i64,
+    pub origin_name: String,
+    pub package_name: String,
+    pub name: String,
+    pub plan_path: String,
+    pub visibility: String,
+    pub vcs_type: String,
+    pub vcs_data: String,
+    #[serde(with = "db_id_format")]
+    pub vcs_installation_id: i64,
+    pub auto_build: bool,
+    pub created_at: Option<NaiveDateTime>,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NewProject {
+    pub owner_id: i64,
+    pub origin_name: String,
+    pub package_name: String,
+    pub plan_path: String,
+    pub vcs_type: String,
+    pub vcs_data: String,
+    pub install_id: i64,
+    pub visibility: String,
+    pub auto_build: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateProject {
+    pub id: i64,
+    pub owner_id: i64,
+    pub origin_id: i64,
+    pub package_name: String,
+    pub plan_path: String,
+    pub vcs_type: String,
+    pub vcs_data: String,
+    pub install_id: i64,
+    pub visibility: String,
+    pub auto_build: bool,
+}
+
+impl Project {
+    pub fn get(name: String, conn: &PgConnection) -> QueryResult<Project> {
+        diesel::sql_query("select * from get_origin_project_v1($1)")
+            .bind::<Text, _>(name)
+            .get_result(conn)
+    }
+
+    pub fn delete(name: String, conn: &PgConnection) -> QueryResult<usize> {
+        diesel::sql_query("select * from delete_origin_project_v1($1)")
+            .bind::<Text, _>(name)
+            .execute(conn)
+    }
+
+    pub fn create(project: NewProject, conn: &PgConnection) -> QueryResult<Project> {
+        diesel::sql_query(
+            "SELECT * FROM insert_origin_project_v5($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        ).bind::<Text, _>(project.origin_name)
+        .bind::<Text, _>(project.package_name)
+        .bind::<Text, _>(project.plan_path)
+        .bind::<Text, _>(project.vcs_type)
+        .bind::<Text, _>(project.vcs_data)
+        .bind::<BigInt, _>(project.owner_id)
+        .bind::<BigInt, _>(project.install_id)
+        .bind::<Text, _>(project.visibility)
+        .bind::<Bool, _>(project.auto_build)
+        .get_result(conn)
+    }
+
+    pub fn update(project: UpdateProject, conn: &PgConnection) -> QueryResult<usize> {
+        diesel::sql_query(
+            "SELECT * FROM update_origin_project_v4($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+        ).bind::<BigInt, _>(project.id)
+        .bind::<BigInt, _>(project.origin_id)
+        .bind::<Text, _>(project.package_name)
+        .bind::<Text, _>(project.plan_path)
+        .bind::<Text, _>(project.vcs_type)
+        .bind::<Text, _>(project.vcs_data)
+        .bind::<BigInt, _>(project.owner_id)
+        .bind::<BigInt, _>(project.install_id)
+        .bind::<Text, _>(project.visibility)
+        .bind::<Bool, _>(project.auto_build)
+        .execute(conn)
+    }
+
+    pub fn list(origin: String, conn: &PgConnection) -> QueryResult<Vec<Project>> {
+        diesel::sql_query("select * from get_origin_project_list_v2($1)")
+            .bind::<Text, _>(origin)
+            .get_results(conn)
+    }
+}

--- a/components/builder-db/src/schema/project.rs
+++ b/components/builder-db/src/schema/project.rs
@@ -1,14 +1,18 @@
 table! {
     origin_projects (id) {
         id -> BigInt,
-        origin_id -> Nullable<BigInt>,
-        origin_name -> Nullable<Text>,
-        package_name -> Nullable<Text>,
-        name -> Nullable<Text>,
-        plan_path -> Nullable<Text>,
-        owner_id -> Nullable<BigInt>,
+        origin_id -> BigInt,
+        origin_name -> Text,
+        package_name -> Text,
+        name -> Text,
+        plan_path -> Text,
+        owner_id -> BigInt,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
         visibility -> Text,
+        vcs_type -> Text,
+        vcs_data -> Text,
+        vcs_installation_id -> BigInt,
+        auto_build -> Bool,
     }
 }

--- a/components/builder-db/src/schema/project_integration.rs
+++ b/components/builder-db/src/schema/project_integration.rs
@@ -2,9 +2,6 @@ table! {
     origin_project_integrations (id) {
         id -> BigInt,
         origin -> Text,
-        name -> Text,
-        integration -> Text,
-        integration_name -> Text,
         body -> Text,
         project_id -> BigInt,
         integration_id -> BigInt,

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -54,6 +54,7 @@ mkdir -p /hab/svc/builder-api-proxy
 cat <<EOT > /hab/svc/builder-api-proxy/user.toml
 log_level = "info"
 enable_builder = true
+enable_publisher_docker = true
 
 app_url = "http://${APP_HOSTNAME}"
 


### PR DESCRIPTION
This change migrates the project-related APIs over to direct DB calls.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-102190634](https://user-images.githubusercontent.com/13542112/47397072-5f9edd80-d6e2-11e8-8fb3-9159c7cee98d.gif)
