### PR TITLE
Don't unwrap memcache calls

### DIFF
--- a/components/builder-api/src/server/services/memcache.rs
+++ b/components/builder-api/src/server/services/memcache.rs
@@ -170,11 +170,23 @@ impl MemcacheClient {
 
     // These are to make the compiler happy
     fn get_bytes(&mut self, key: &str) -> Option<Vec<u8>> {
-        self.cli.get(key).unwrap()
+        match self.cli.get(key) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                warn!("Error getting key {}: {:?}", key, e);
+                None
+            }
+        }
     }
 
     fn get_string(&mut self, key: &str) -> Option<String> {
-        self.cli.get(key).unwrap()
+        match self.cli.get(key) {
+            Ok(string) => string,
+            Err(e) => {
+                warn!("Error getting key {}: {:?}", key, e);
+                None
+            }
+        }
     }
 }
 


### PR DESCRIPTION
We were seeing cases where the keys were too long on get requests.
This removes the unwraps that were causing a panic and replaces them with
a warn.

![](https://media.giphy.com/media/3owypf6HrM3J7UTvAA/giphy-downsized.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>