### PR TITLE
Fix regression; return private key name with origin

### DIFF
--- a/components/builder-db/src/models/origin.rs
+++ b/components/builder-db/src/models/origin.rs
@@ -23,6 +23,18 @@ pub struct Origin {
 }
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
+#[table_name = "origins_with_secret_key"]
+pub struct OriginWithSecretKey {
+    #[serde(with = "db_id_format")]
+    pub id: i64,
+    #[serde(with = "db_id_format")]
+    pub owner_id: i64,
+    pub name: String,
+    pub private_key_name: Option<String>,
+    pub default_package_visibility: PackageVisibility,
+}
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName)]
 #[table_name = "origins_with_stats"]
 pub struct OriginWithStats {
     #[serde(with = "db_id_format")]
@@ -55,10 +67,11 @@ pub struct GetOrigin {
 }
 
 impl Origin {
-    pub fn get(orig: GetOrigin, conn: &PgConnection) -> QueryResult<Origin> {
-        diesel::sql_query("select * from get_origin_v1($1)")
-            .bind::<Text, _>(orig.name)
-            .get_result(conn)
+    pub fn get(orig: GetOrigin, conn: &PgConnection) -> QueryResult<OriginWithSecretKey> {
+        diesel::sql_query(
+            "select * from origins_with_secret_key_full_name_v2 where name = $1 limit 1",
+        ).bind::<Text, _>(orig.name)
+        .get_result(conn)
     }
 
     pub fn list(owner_id: i64, conn: &PgConnection) -> QueryResult<Vec<OriginWithStats>> {

--- a/components/builder-db/src/schema/origin.rs
+++ b/components/builder-db/src/schema/origin.rs
@@ -13,6 +13,18 @@ table! {
 
 table! {
     use models::package::PackageVisibilityMapping;
+    use diesel::sql_types::{BigInt, Text, Nullable};
+    origins_with_secret_key (id) {
+        id -> BigInt,
+        name -> Text,
+        owner_id -> BigInt,
+        private_key_name -> Nullable<Text>,
+        default_package_visibility -> PackageVisibilityMapping,
+    }
+}
+
+table! {
+    use models::package::PackageVisibilityMapping;
     use diesel::sql_types::{BigInt, Text, Nullable, Timestamptz};
     origins_with_stats (id) {
         id -> BigInt,

--- a/test/builder-api/src/keys.js
+++ b/test/builder-api/src/keys.js
@@ -93,6 +93,20 @@ describe('Keys API', function () {
           done(err);
         });
     });
+
+    it('retrieves the secret key with origin get request', function (done) {
+      request.get('/depot/origins/neurosis')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.name).to.equal(global.originNeurosis.name);
+          expect(res.body.id).to.equal(global.originNeurosis.id);
+          expect(res.body.owner_id).to.equal(global.originNeurosis.owner_id);
+          expect(res.body.default_package_visibility).to.equal(global.originNeurosis.default_package_visibility);
+          expect(res.body.private_key_name).to.equal(`neurosis-${revision}`);
+          done(err);
+        });
+    });
+
   });
 
   describe('Downloading secret keys', function () {


### PR DESCRIPTION
This fixes a regression where we were not returning the private key name with the origin request, thereby causing the UI to not account for keys properly.  Also adds an e2e test for this scenario.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-217203149](https://user-images.githubusercontent.com/13542112/47585932-9e67aa00-d913-11e8-9857-705578b0272a.gif)
