### PR TITLE
Migrate job server to direct DB - initial infra and partial migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,6 +1022,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-db/src/models/projects.rs
+++ b/components/builder-db/src/models/projects.rs
@@ -5,6 +5,7 @@ use diesel::pg::PgConnection;
 use diesel::result::QueryResult;
 use diesel::sql_types::{BigInt, Bool, Text};
 use diesel::RunQueryDsl;
+use protocol::originsrv;
 use schema::project::*;
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
@@ -105,5 +106,23 @@ impl Project {
         diesel::sql_query("select * from get_origin_project_list_v2($1)")
             .bind::<Text, _>(origin)
             .get_results(conn)
+    }
+}
+
+impl Into<originsrv::OriginProject> for Project {
+    fn into(self) -> originsrv::OriginProject {
+        let mut proj = originsrv::OriginProject::new();
+        proj.set_id(self.id as u64);
+        proj.set_owner_id(self.owner_id as u64);
+        proj.set_origin_id(self.origin_id as u64);
+        proj.set_origin_name(self.origin_name);
+        proj.set_package_name(self.package_name);
+        proj.set_name(self.name);
+        proj.set_plan_path(self.plan_path);
+        proj.set_vcs_type(self.vcs_type);
+        proj.set_vcs_data(self.vcs_data);
+        proj.set_vcs_installation_id(self.vcs_installation_id as u32);
+        proj.set_auto_build(self.auto_build);
+        proj
     }
 }

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -15,6 +15,10 @@ doc = false
 actix = "*"
 builder_core = { path = "../builder-core" }
 clippy = {version = "*", optional = true}
+chrono = { version = "*", features = ["serde"] }
+diesel = { version = "*", features = ["postgres", "chrono", "serde_json", "r2d2"] }
+diesel-derive-enum = { version = "*", features = ["postgres"] }
+diesel_migrations = "*"
 futures = "*"
 rusoto_core = "0.32.0"
 rusoto_s3 = "0.32.0"
@@ -28,7 +32,6 @@ num_cpus = "*"
 protobuf = "*"
 postgres = { version = "*", features = ["with-chrono"] }
 postgres-derive = "*"
-chrono = { version = "*", features = ["serde"] }
 rand = "*"
 r2d2 = "*"
 serde = "*"
@@ -36,8 +39,6 @@ serde_derive = "*"
 sha2 = "*"
 time = "*"
 toml = { version = "*", default-features = false }
-diesel = "*"
-diesel_migrations = "*"
 
 [dependencies.actix-web]
 version = "*"


### PR DESCRIPTION
This is the first part of the migration of job server to db model usage. This PR adds the infra to hook into the db model to jobsrv, and migrates several of the router-based calls to direct DB.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-88373003](https://user-images.githubusercontent.com/13542112/47594608-024c9b80-d931-11e8-87c2-b03c6b85fdfa.gif)
