### PR TITLE
More conversions to direct DB

### DIFF
--- a/components/builder-db/src/models/integration.rs
+++ b/components/builder-db/src/models/integration.rs
@@ -20,32 +20,17 @@ pub struct OriginIntegration {
     pub updated_at: Option<NaiveDateTime>,
 }
 
-pub struct CreateIntegration {
-    pub origin: String,
-    pub integration: String,
-    pub name: String,
-    pub body: String,
-}
-
-pub struct GetIntegration {
-    pub origin: String,
-    pub integration: String,
-    pub name: String,
-}
-
-pub struct DeleteIntegration {
-    pub origin: String,
-    pub integration: String,
-    pub name: String,
-}
-
-pub struct ListIntegrations {
-    pub origin: String,
-    pub integration: String,
+#[derive(Insertable)]
+#[table_name = "origin_integrations"]
+pub struct NewOriginIntegration<'a> {
+    pub origin: &'a str,
+    pub integration: &'a str,
+    pub name: &'a str,
+    pub body: &'a str,
 }
 
 impl OriginIntegration {
-    pub fn create(req: CreateIntegration, conn: &PgConnection) -> QueryResult<usize> {
+    pub fn create(req: &NewOriginIntegration, conn: &PgConnection) -> QueryResult<usize> {
         diesel::sql_query("select * from upsert_origin_integration_v1($1, $2, $3, $4)")
             .bind::<Text, _>(req.origin)
             .bind::<Text, _>(req.integration)
@@ -54,34 +39,45 @@ impl OriginIntegration {
             .execute(conn)
     }
 
-    pub fn get(req: GetIntegration, conn: &PgConnection) -> QueryResult<OriginIntegration> {
+    pub fn get(
+        origin: &str,
+        integration: &str,
+        name: &str,
+        conn: &PgConnection,
+    ) -> QueryResult<OriginIntegration> {
         diesel::sql_query("select * from get_origin_integration_v1($1, $2, $3)")
-            .bind::<Text, _>(req.origin)
-            .bind::<Text, _>(req.integration)
-            .bind::<Text, _>(req.name)
+            .bind::<Text, _>(origin)
+            .bind::<Text, _>(integration)
+            .bind::<Text, _>(name)
             .get_result(conn)
     }
 
-    pub fn delete(req: DeleteIntegration, conn: &PgConnection) -> QueryResult<usize> {
+    pub fn delete(
+        origin: &str,
+        integration: &str,
+        name: &str,
+        conn: &PgConnection,
+    ) -> QueryResult<usize> {
         diesel::sql_query("select * from delete_origin_integration_v1($1, $2, $3)")
-            .bind::<Text, _>(req.origin)
-            .bind::<Text, _>(req.integration)
-            .bind::<Text, _>(req.name)
+            .bind::<Text, _>(origin)
+            .bind::<Text, _>(integration)
+            .bind::<Text, _>(name)
             .execute(conn)
     }
 
     pub fn list_for_origin_integration(
-        req: ListIntegrations,
+        origin: &str,
+        integration: &str,
         conn: &PgConnection,
     ) -> QueryResult<Vec<OriginIntegration>> {
         diesel::sql_query("select * from get_origin_integrations_v1($1, $2)")
-            .bind::<Text, _>(req.origin)
-            .bind::<Text, _>(req.integration)
+            .bind::<Text, _>(origin)
+            .bind::<Text, _>(integration)
             .get_results(conn)
     }
 
     pub fn list_for_origin(
-        origin: String,
+        origin: &str,
         conn: &PgConnection,
     ) -> QueryResult<Vec<OriginIntegration>> {
         diesel::sql_query("select * from get_origin_integrations_for_origin_v1($1)")

--- a/components/builder-db/src/models/keys.rs
+++ b/components/builder-db/src/models/keys.rs
@@ -1,0 +1,132 @@
+use super::db_id_format;
+use chrono::NaiveDateTime;
+use diesel;
+use diesel::pg::PgConnection;
+use diesel::result::QueryResult;
+use diesel::sql_types::{BigInt, Binary, Text};
+use diesel::RunQueryDsl;
+use schema::key::*;
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName)]
+#[table_name = "origin_public_encryption_keys"]
+pub struct PublicEncryptionKey {
+    #[serde(with = "db_id_format")]
+    pub id: i64,
+    #[serde(with = "db_id_format")]
+    pub origin_id: i64,
+    #[serde(with = "db_id_format")]
+    pub owner_id: i64,
+    pub name: String,
+    pub revision: String,
+    pub full_name: String,
+    pub body: Vec<u8>,
+    pub created_at: Option<NaiveDateTime>,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName)]
+#[table_name = "origin_private_encryption_keys"]
+pub struct PrivateEncryptionKey {
+    #[serde(with = "db_id_format")]
+    pub id: i64,
+    #[serde(with = "db_id_format")]
+    pub origin_id: i64,
+    #[serde(with = "db_id_format")]
+    pub owner_id: i64,
+    pub name: String,
+    pub revision: String,
+    pub full_name: String,
+    pub body: Vec<u8>,
+    pub created_at: Option<NaiveDateTime>,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+#[derive(Insertable)]
+#[table_name = "origin_public_encryption_keys"]
+pub struct NewPublicEncryptionKey<'a> {
+    pub owner_id: i64,
+    pub origin_id: i64,
+    pub name: &'a str,
+    pub revision: &'a str,
+    pub body: &'a [u8],
+}
+
+#[derive(Insertable)]
+#[table_name = "origin_private_encryption_keys"]
+pub struct NewPrivateEncryptionKey<'a> {
+    pub owner_id: i64,
+    pub origin_id: i64,
+    pub name: &'a str,
+    pub revision: &'a str,
+    pub body: &'a [u8],
+}
+
+impl PublicEncryptionKey {
+    pub fn get(
+        origin: &str,
+        revision: &str,
+        conn: &PgConnection,
+    ) -> QueryResult<PublicEncryptionKey> {
+        diesel::sql_query("select * from get_origin_public_encryption_key_v1($1, $2)")
+            .bind::<Text, _>(origin)
+            .bind::<Text, _>(revision)
+            .get_result(conn)
+    }
+
+    pub fn create(
+        req: &NewPublicEncryptionKey,
+        conn: &PgConnection,
+    ) -> QueryResult<PublicEncryptionKey> {
+        let full_name = format!("{}-{}", req.name, req.revision);
+        diesel::sql_query(
+            "select * from insert_origin_public_encryption_key_v1($1, $2, $3, $4, $5, $6)",
+        ).bind::<BigInt, _>(req.origin_id)
+        .bind::<BigInt, _>(req.owner_id)
+        .bind::<Text, _>(req.name)
+        .bind::<Text, _>(req.revision)
+        .bind::<Text, _>(full_name)
+        .bind::<Binary, _>(req.body)
+        .get_result(conn)
+    }
+
+    pub fn latest(origin: &str, conn: &PgConnection) -> QueryResult<PublicEncryptionKey> {
+        diesel::sql_query("select * from get_origin_public_encryption_key_latest_v1($1)")
+            .bind::<Text, _>(origin)
+            .get_result(conn)
+    }
+
+    pub fn list(origin: &str, conn: &PgConnection) -> QueryResult<Vec<PublicEncryptionKey>> {
+        diesel::sql_query("select * from get_origin_public_encryption_keys_for_origin_v1($1)")
+            .bind::<Text, _>(origin)
+            .get_results(conn)
+    }
+}
+
+impl PrivateEncryptionKey {
+    pub fn get(origin: &str, conn: &PgConnection) -> QueryResult<PrivateEncryptionKey> {
+        diesel::sql_query("select * from get_origin_private_encryption_key_v1($1)")
+            .bind::<Text, _>(origin)
+            .get_result(conn)
+    }
+
+    pub fn create(
+        req: &NewPrivateEncryptionKey,
+        conn: &PgConnection,
+    ) -> QueryResult<PrivateEncryptionKey> {
+        let full_name = format!("{}-{}", req.name, req.revision);
+        diesel::sql_query(
+            "select * from insert_origin_private_encryption_key_v1($1, $2, $3, $4, $5, $6)",
+        ).bind::<BigInt, _>(req.origin_id)
+        .bind::<BigInt, _>(req.owner_id)
+        .bind::<Text, _>(req.name)
+        .bind::<Text, _>(req.revision)
+        .bind::<Text, _>(full_name)
+        .bind::<Binary, _>(req.body)
+        .get_result(conn)
+    }
+}
+
+/*
+
+
+*/

--- a/components/builder-db/src/models/keys.rs
+++ b/components/builder-db/src/models/keys.rs
@@ -9,7 +9,7 @@ use schema::key::*;
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
 #[table_name = "origin_public_encryption_keys"]
-pub struct PublicEncryptionKey {
+pub struct OriginPublicEncryptionKey {
     #[serde(with = "db_id_format")]
     pub id: i64,
     #[serde(with = "db_id_format")]
@@ -26,7 +26,7 @@ pub struct PublicEncryptionKey {
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
 #[table_name = "origin_private_encryption_keys"]
-pub struct PrivateEncryptionKey {
+pub struct OriginPrivateEncryptionKey {
     #[serde(with = "db_id_format")]
     pub id: i64,
     #[serde(with = "db_id_format")]
@@ -43,7 +43,7 @@ pub struct PrivateEncryptionKey {
 
 #[derive(Insertable)]
 #[table_name = "origin_public_encryption_keys"]
-pub struct NewPublicEncryptionKey<'a> {
+pub struct NewOriginPublicEncryptionKey<'a> {
     pub owner_id: i64,
     pub origin_id: i64,
     pub name: &'a str,
@@ -53,7 +53,7 @@ pub struct NewPublicEncryptionKey<'a> {
 
 #[derive(Insertable)]
 #[table_name = "origin_private_encryption_keys"]
-pub struct NewPrivateEncryptionKey<'a> {
+pub struct NewOriginPrivateEncryptionKey<'a> {
     pub owner_id: i64,
     pub origin_id: i64,
     pub name: &'a str,
@@ -61,12 +61,12 @@ pub struct NewPrivateEncryptionKey<'a> {
     pub body: &'a [u8],
 }
 
-impl PublicEncryptionKey {
+impl OriginPublicEncryptionKey {
     pub fn get(
         origin: &str,
         revision: &str,
         conn: &PgConnection,
-    ) -> QueryResult<PublicEncryptionKey> {
+    ) -> QueryResult<OriginPublicEncryptionKey> {
         diesel::sql_query("select * from get_origin_public_encryption_key_v1($1, $2)")
             .bind::<Text, _>(origin)
             .bind::<Text, _>(revision)
@@ -74,9 +74,9 @@ impl PublicEncryptionKey {
     }
 
     pub fn create(
-        req: &NewPublicEncryptionKey,
+        req: &NewOriginPublicEncryptionKey,
         conn: &PgConnection,
-    ) -> QueryResult<PublicEncryptionKey> {
+    ) -> QueryResult<OriginPublicEncryptionKey> {
         let full_name = format!("{}-{}", req.name, req.revision);
         diesel::sql_query(
             "select * from insert_origin_public_encryption_key_v1($1, $2, $3, $4, $5, $6)",
@@ -89,30 +89,30 @@ impl PublicEncryptionKey {
         .get_result(conn)
     }
 
-    pub fn latest(origin: &str, conn: &PgConnection) -> QueryResult<PublicEncryptionKey> {
+    pub fn latest(origin: &str, conn: &PgConnection) -> QueryResult<OriginPublicEncryptionKey> {
         diesel::sql_query("select * from get_origin_public_encryption_key_latest_v1($1)")
             .bind::<Text, _>(origin)
             .get_result(conn)
     }
 
-    pub fn list(origin: &str, conn: &PgConnection) -> QueryResult<Vec<PublicEncryptionKey>> {
+    pub fn list(origin: &str, conn: &PgConnection) -> QueryResult<Vec<OriginPublicEncryptionKey>> {
         diesel::sql_query("select * from get_origin_public_encryption_keys_for_origin_v1($1)")
             .bind::<Text, _>(origin)
             .get_results(conn)
     }
 }
 
-impl PrivateEncryptionKey {
-    pub fn get(origin: &str, conn: &PgConnection) -> QueryResult<PrivateEncryptionKey> {
+impl OriginPrivateEncryptionKey {
+    pub fn get(origin: &str, conn: &PgConnection) -> QueryResult<OriginPrivateEncryptionKey> {
         diesel::sql_query("select * from get_origin_private_encryption_key_v1($1)")
             .bind::<Text, _>(origin)
             .get_result(conn)
     }
 
     pub fn create(
-        req: &NewPrivateEncryptionKey,
+        req: &NewOriginPrivateEncryptionKey,
         conn: &PgConnection,
-    ) -> QueryResult<PrivateEncryptionKey> {
+    ) -> QueryResult<OriginPrivateEncryptionKey> {
         let full_name = format!("{}-{}", req.name, req.revision);
         diesel::sql_query(
             "select * from insert_origin_private_encryption_key_v1($1, $2, $3, $4, $5, $6)",

--- a/components/builder-db/src/models/keys.rs
+++ b/components/builder-db/src/models/keys.rs
@@ -125,8 +125,3 @@ impl PrivateEncryptionKey {
         .get_result(conn)
     }
 }
-
-/*
-
-
-*/

--- a/components/builder-db/src/models/mod.rs
+++ b/components/builder-db/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod account;
 pub mod channel;
 pub mod integration;
 pub mod invitations;
+pub mod keys;
 pub mod origin;
 pub mod package;
 pub mod project_integration;

--- a/components/builder-db/src/models/mod.rs
+++ b/components/builder-db/src/models/mod.rs
@@ -11,6 +11,7 @@ pub mod origin;
 pub mod package;
 pub mod project_integration;
 pub mod projects;
+pub mod secrets;
 
 mod db_id_format {
     use serde::{self, Deserialize, Deserializer, Serializer};

--- a/components/builder-db/src/models/origin.rs
+++ b/components/builder-db/src/models/origin.rs
@@ -62,15 +62,11 @@ pub struct UpdateOrigin {
     pub default_package_visibility: PackageVisibility,
 }
 
-pub struct GetOrigin {
-    pub name: String,
-}
-
 impl Origin {
-    pub fn get(orig: GetOrigin, conn: &PgConnection) -> QueryResult<OriginWithSecretKey> {
+    pub fn get(origin: &str, conn: &PgConnection) -> QueryResult<OriginWithSecretKey> {
         diesel::sql_query(
             "select * from origins_with_secret_key_full_name_v2 where name = $1 limit 1",
-        ).bind::<Text, _>(orig.name)
+        ).bind::<Text, _>(origin)
         .get_result(conn)
     }
 

--- a/components/builder-db/src/models/secrets.rs
+++ b/components/builder-db/src/models/secrets.rs
@@ -1,0 +1,59 @@
+use super::db_id_format;
+use chrono::NaiveDateTime;
+use diesel;
+use diesel::pg::PgConnection;
+use diesel::result::QueryResult;
+use diesel::sql_types::{BigInt, Text};
+use diesel::RunQueryDsl;
+use schema::secrets::*;
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName)]
+#[table_name = "origin_secrets"]
+pub struct OriginSecret {
+    #[serde(with = "db_id_format")]
+    pub id: i64,
+    #[serde(with = "db_id_format")]
+    pub origin_id: i64,
+    #[serde(with = "db_id_format")]
+    pub owner_id: i64,
+    pub name: String,
+    pub value: String,
+    pub created_at: Option<NaiveDateTime>,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+impl OriginSecret {
+    pub fn create(
+        origin_id: i64,
+        name: &str,
+        value: &str,
+        conn: &PgConnection,
+    ) -> QueryResult<usize> {
+        // TODO FIX: We're missing setting the account id here
+        diesel::sql_query("select * from insert_origin_secret_v1($1, $2, $3)")
+            .bind::<BigInt, _>(origin_id)
+            .bind::<Text, _>(name)
+            .bind::<Text, _>(value)
+            .execute(conn)
+    }
+
+    pub fn get(origin_id: i64, name: &str, conn: &PgConnection) -> QueryResult<OriginSecret> {
+        diesel::sql_query("select * from get_origin_secret_v1($1, $2)")
+            .bind::<BigInt, _>(origin_id)
+            .bind::<Text, _>(name)
+            .get_result(conn)
+    }
+
+    pub fn delete(origin_id: i64, name: &str, conn: &PgConnection) -> QueryResult<usize> {
+        diesel::sql_query("select * from delete_origin_secret_v1($1, $2)")
+            .bind::<BigInt, _>(origin_id)
+            .bind::<Text, _>(name)
+            .execute(conn)
+    }
+
+    pub fn list(origin_id: i64, conn: &PgConnection) -> QueryResult<Vec<OriginSecret>> {
+        diesel::sql_query("select * from get_origin_secrets_for_origin_v1($1)")
+            .bind::<BigInt, _>(origin_id)
+            .get_results(conn)
+    }
+}

--- a/components/builder-db/src/schema/key.rs
+++ b/components/builder-db/src/schema/key.rs
@@ -1,54 +1,54 @@
 table! {
-    origin_public_keys {
+    origin_public_keys(id) {
         id -> BigInt,
         origin_id -> BigInt,
         owner_id -> BigInt,
         name -> Text,
         revision -> Text,
         full_name -> Text,
-        body -> Vec<u8>,
+        body -> Binary,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
     }
 }
 
 table! {
-    origin_secret_keys {
+    origin_secret_keys(id) {
         id -> BigInt,
         origin_id -> BigInt,
         owner_id -> BigInt,
         name -> Text,
         revision -> Text,
         full_name -> Text,
-        body -> Vec<u8>,
+        body -> Binary,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
     }
 }
 
 table! {
-    origin_public_encryption_keys {
+    origin_public_encryption_keys(id) {
         id -> BigInt,
         origin_id -> BigInt,
         owner_id -> BigInt,
         name -> Text,
         revision -> Text,
         full_name -> Text,
-        body -> Vec<u8>,
+        body -> Binary,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
     }
 }
 
 table! {
-    origin_private_encryption_keys {
+    origin_private_encryption_keys(id) {
         id -> BigInt,
         origin_id -> BigInt,
         owner_id -> BigInt,
         name -> Text,
         revision -> Text,
         full_name -> Text,
-        body -> Vec<u8>,
+        body -> Binary,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
     }

--- a/components/builder-db/src/schema/mod.rs
+++ b/components/builder-db/src/schema/mod.rs
@@ -13,3 +13,4 @@ pub mod origin;
 pub mod package;
 pub mod project;
 pub mod project_integration;
+pub mod secrets;

--- a/components/builder-db/src/schema/secrets.rs
+++ b/components/builder-db/src/schema/secrets.rs
@@ -1,0 +1,11 @@
+table! {
+    origin_secrets (id) {
+        id -> BigInt,
+        origin_id -> BigInt,
+        owner_id -> BigInt,
+        name -> Text,
+        value -> Text,
+        created_at -> Nullable<Timestamptz>,
+        updated_at -> Nullable<Timestamptz>,
+    }
+}

--- a/test/builder-api/src/keys.js
+++ b/test/builder-api/src/keys.js
@@ -140,6 +140,37 @@ describe('Keys API', function () {
     });
   });
 
+  describe('Downloading encryption keys', function () {
+    it('requires authentication', function (done) {
+      request.get('/depot/origins/neurosis/encryption_key')
+        .expect(401)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('requires membership in the origin', function (done) {
+      request.get('/depot/origins/neurosis/encryption_key')
+        .set('Authorization', global.mystiqueBearer)
+        .expect(403)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('can download the latest encryption public key', function (done) {
+      request.get('/depot/origins/neurosis/encryption_key')
+        .set('Authorization', global.boboBearer)
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.text).to.not.be.empty;
+          done(err);
+        });
+    });
+  });
+
   describe('Generating keys', function () {
     it('requires authentication', function (done) {
       request.post('/depot/origins/neurosis/keys')


### PR DESCRIPTION
This PR converts origin encryption keys and origin secrets to direct DB, and also does some cleanup on the models.

![tenor-61847183](https://user-images.githubusercontent.com/13542112/47626306-9fe9cb80-dae7-11e8-8474-e0a14928b6b9.gif)
