### PR TITLE
Fix keys breakage

### DIFF
--- a/components/builder-api/src/server/error.rs
+++ b/components/builder-api/src/server/error.rs
@@ -208,6 +208,10 @@ impl Into<HttpResponse> for Error {
 fn diesel_err_to_http(err: &diesel::result::Error) -> StatusCode {
     match err {
         diesel::result::Error::NotFound => StatusCode::NOT_FOUND,
+        diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            _,
+        ) => StatusCode::CONFLICT,
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }

--- a/components/builder-api/src/server/resources/origins.rs
+++ b/components/builder-api/src/server/resources/origins.rs
@@ -18,7 +18,9 @@
 use std::collections::HashMap;
 use std::str::from_utf8;
 
-use actix_web::http::header::{ContentDisposition, DispositionParam, DispositionType};
+use actix_web::http::header::{
+    Charset, ContentDisposition, DispositionParam, DispositionType, ExtendedValue,
+};
 use actix_web::http::{self, Method, StatusCode};
 use actix_web::FromRequest;
 use actix_web::{App, HttpRequest, HttpResponse, Json, Path, Query};
@@ -1130,7 +1132,11 @@ fn download_content_as_file(content: &[u8], filename: String) -> HttpResponse {
             http::header::CONTENT_DISPOSITION,
             ContentDisposition {
                 disposition: DispositionType::Attachment,
-                parameters: vec![DispositionParam::Filename(filename.clone())],
+                parameters: vec![DispositionParam::FilenameExt(ExtendedValue {
+                    charset: Charset::Iso_8859_1, // The character set for the bytes of the filename
+                    language_tag: None, // The optional language tag (see `language-tag` crate)
+                    value: filename.as_bytes().to_vec(), // the actual bytes of the filename
+                })],
             },
         ).header(
             http::header::HeaderName::from_static(headers::XFILENAME),

--- a/test/builder-api/src/keys.js
+++ b/test/builder-api/src/keys.js
@@ -41,6 +41,17 @@ describe('Keys API', function () {
           done(err);
         });
     });
+
+    it('expects a Conflict result on second upload of same key', function (done) {
+      request.post(`/depot/origins/neurosis/keys/${revision}`)
+        .set('Authorization', global.boboBearer)
+        .send(pubFile)
+        .expect(409)
+        .end(function (err, res) {
+          expect(res.body).to.be.empty;
+          done(err);
+        });
+    });
   });
 
   describe('Downloading public keys', function () {
@@ -90,6 +101,17 @@ describe('Keys API', function () {
         .expect(201)
         .end(function (err, res) {
           expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('expects a Conflict result on second upload of same key', function (done) {
+      request.post(`/depot/origins/neurosis/secret_keys/${revision}`)
+        .set('Authorization', global.boboBearer)
+        .send(secretFile)
+        .expect(409)
+        .end(function (err, res) {
+          expect(res.body).to.be.empty;
           done(err);
         });
     });


### PR DESCRIPTION
Fix a couple of key related breakages - return expected status code for conflict, and do a better encoding for content disposition for key download.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-210407704](https://user-images.githubusercontent.com/13542112/47756037-c92c6800-dc5d-11e8-983e-37fab686f491.gif)
