### PR TITLE
Redo search from the ground up using full text search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel_full_text_search"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "diesel_migrations"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +930,7 @@ dependencies = [
  "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_full_text_search 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -965,6 +974,7 @@ dependencies = [
  "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_full_text_search 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-builder-protocol 0.0.0",
@@ -3340,6 +3350,7 @@ dependencies = [
 "checksum diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "164080ac16a4d1d80a50f0a623e4ddef41cb2779eee85bcc76907d340dfc98cc"
 "checksum diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adbaf5e1344edeedc4d1cead2dc3ce6fc4115bb26b3704c533b92717940f2fb5"
 "checksum diesel_derives 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03bcaf77491f53e400d5ee3bdd57142ea4e1c47fe9217b3361ff9a76ca0e3d37"
+"checksum diesel_full_text_search 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad3168d9d2008c58b8c9fabb79ddc38d1f9d511fa15e0dcbd6b987912b05783"
 "checksum diesel_migrations 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b42c35d1ce9e8d57a3e7001b4127f2bc1b073a89708bb7019f5be27c991c28"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -21,6 +21,7 @@ constant_time_eq = "*"
 chrono = { version = "*", features = ["serde"] }
 diesel = { version = "*", features = ["postgres", "chrono", "serde_json", "r2d2"] }
 diesel-derive-enum = { version = "*", features = ["postgres"] }
+diesel_full_text_search = "*"
 env_logger = "*"
 features = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -25,6 +25,7 @@ extern crate bytes;
 extern crate chrono;
 extern crate constant_time_eq;
 extern crate diesel;
+extern crate diesel_full_text_search;
 #[macro_use]
 extern crate features;
 extern crate github_api_client;

--- a/components/builder-db/Cargo.toml
+++ b/components/builder-db/Cargo.toml
@@ -11,6 +11,7 @@ habitat-builder-protocol = { path = "../builder-protocol" }
 log = "*"
 diesel = { version = "*", features = ["postgres", "chrono", "serde_json", "r2d2"] }
 diesel-derive-enum = { version = "*", features = ["postgres"] }
+diesel_full_text_search = "*"
 r2d2 = "*"
 time = "*"
 rand = "*"

--- a/components/builder-db/src/lib.rs
+++ b/components/builder-db/src/lib.rs
@@ -19,6 +19,7 @@
 extern crate diesel;
 #[macro_use]
 extern crate diesel_derive_enum;
+extern crate diesel_full_text_search;
 extern crate fallible_iterator;
 extern crate fnv;
 extern crate habitat_builder_protocol as protocol;

--- a/components/builder-db/src/schema/package.rs
+++ b/components/builder-db/src/schema/package.rs
@@ -1,6 +1,7 @@
 table! {
     use models::package::PackageVisibilityMapping;
     use diesel::sql_types::{Array, BigInt, Integer, Text, Nullable, Timestamptz};
+    use diesel_full_text_search::TsVector;
     origin_packages {
         id -> BigInt,
         origin_id -> BigInt,
@@ -18,6 +19,7 @@ table! {
         visibility -> PackageVisibilityMapping,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
+        ident_vector -> TsVector,
     }
 }
 

--- a/components/builder-originsrv/src/migrations/2018-11-01-111111_full_text_search/up.sql
+++ b/components/builder-originsrv/src/migrations/2018-11-01-111111_full_text_search/up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE origin_packages ADD COLUMN ident_vector TSVECTOR;
+
+UPDATE origin_packages SET ident_vector = to_tsvector(array_to_string(ident_array[1:2], ' '));
+
+CREATE OR REPLACE FUNCTION update_origin_package_vector_index() RETURNS trigger AS $$
+    DECLARE iws TEXT;
+    BEGIN
+        NEW.ident_vector := to_tsvector(array_to_string(NEW.ident_array[1:2], ' '));
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER origin_packages_vector BEFORE INSERT ON origin_packages FOR EACH ROW EXECUTE PROCEDURE update_origin_package_vector_index();

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -139,9 +139,9 @@ describe('Working with packages', function () {
         .expect(200)
         .end(function (err, res) {
           expect(res.body.range_start).to.equal(0);
-          expect(res.body.range_end).to.equal(5);
-          expect(res.body.total_count).to.equal(6);
-          expect(res.body.data.length).to.equal(6);
+          expect(res.body.range_end).to.equal(3);
+          expect(res.body.total_count).to.equal(4);
+          expect(res.body.data.length).to.equal(4);
           expect(res.body.data[0].origin).to.equal('neurosis');
           expect(res.body.data[0].name).to.equal('testapp');
           expect(res.body.data[0].version).to.equal('0.1.3');
@@ -154,10 +154,28 @@ describe('Working with packages', function () {
           expect(res.body.data[2].name).to.equal('testapp');
           expect(res.body.data[2].version).to.equal('0.1.4');
           expect(res.body.data[2].release).to.equal(release3);
-          expect(res.body.data[5].origin).to.equal('xmen');
-          expect(res.body.data[5].name).to.equal('testapp');
-          expect(res.body.data[5].version).to.equal('0.1.4');
-          expect(res.body.data[5].release).to.equal(release4);
+          expect(res.body.data[3].origin).to.equal('xmen');
+          expect(res.body.data[3].name).to.equal('testapp');
+          expect(res.body.data[3].version).to.equal('0.1.4');
+          expect(res.body.data[3].release).to.equal(release4);
+          done(err);
+        });
+    });
+
+    it('allows me to search for distinct packages', function (done) {
+      request.get('/depot/pkgs/search/testapp?distinct=true')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.range_start).to.equal(0);
+          expect(res.body.range_end).to.equal(1);
+          expect(res.body.total_count).to.equal(2);
+          expect(res.body.data.length).to.equal(2);
+          expect(res.body.data[0].origin).to.equal('neurosis');
+          expect(res.body.data[0].name).to.equal('testapp');
+          expect(res.body.data[1].origin).to.equal('xmen');
+          expect(res.body.data[1].name).to.equal('testapp');
           done(err);
         });
     });


### PR DESCRIPTION
Move search into a direct db diesel query. Unfortuantely there are some trait bound
issues that prevents us from merging search and search_distinct into the same function.

Ignore the duplication and you'll be just fineeee.

![](https://media.giphy.com/media/26n6WywJyh39n1pBu/200w_d.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>