### PR TITLE
Migrate platform helper to direct DB

### DIFF
--- a/components/builder-api/src/server/helpers.rs
+++ b/components/builder-api/src/server/helpers.rs
@@ -28,7 +28,6 @@ use protocol::originsrv::*;
 use db::models::channel::PackageChannelTrigger as PCT;
 use db::models::package::PackageVisibility;
 use server::authorize::authorize_session;
-use server::framework::middleware::route_message;
 
 use server::AppState;
 
@@ -161,32 +160,6 @@ pub fn visibility_for_optional_session_model(
     }
 
     v
-}
-
-// Get platforms for a package
-pub fn platforms_for_package_ident(
-    req: &HttpRequest<AppState>,
-    package: &OriginPackageIdent,
-) -> Option<Vec<String>> {
-    let opt_session_id = match authorize_session(req, None) {
-        Ok(id) => Some(id),
-        Err(_) => None,
-    };
-
-    let mut opplr = OriginPackagePlatformListRequest::new();
-    opplr.set_ident(package.clone());
-    opplr.set_visibilities(visibility_for_optional_session(
-        req,
-        opt_session_id,
-        package.get_origin(),
-    ));
-
-    match route_message::<OriginPackagePlatformListRequest, OriginPackagePlatformListResponse>(
-        req, &opplr,
-    ) {
-        Ok(p) => Some(p.get_platforms().to_vec()),
-        Err(_) => None,
-    }
 }
 
 pub fn all_visibilities() -> Vec<OriginPackageVisibility> {

--- a/components/builder-api/src/server/resources/jobs.rs
+++ b/components/builder-api/src/server/resources/jobs.rs
@@ -38,6 +38,7 @@ use server::framework::headers;
 use server::framework::middleware::route_message;
 use server::helpers::{self, Target};
 use server::resources::channels::channels_for_package_ident;
+use server::resources::pkgs::platforms_for_package_ident;
 use server::AppState;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -409,7 +410,7 @@ fn do_get_job(req: &HttpRequest<AppState>, job_id: u64) -> Result<String> {
 
             if job.get_package_ident().fully_qualified() {
                 let channels = channels_for_package_ident(req, job.get_package_ident())?;
-                let platforms = helpers::platforms_for_package_ident(req, job.get_package_ident());
+                let platforms = platforms_for_package_ident(req, job.get_package_ident())?;
                 let mut job_json = serde_json::to_value(job).unwrap();
 
                 if channels.is_some() {

--- a/components/builder-api/src/server/resources/projects.rs
+++ b/components/builder-api/src/server/resources/projects.rs
@@ -37,6 +37,7 @@ use server::framework::headers;
 use server::framework::middleware::route_message;
 use server::helpers::{self, Pagination};
 use server::resources::channels::channels_for_package_ident;
+use server::resources::pkgs::platforms_for_package_ident;
 use server::AppState;
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -445,7 +446,10 @@ fn get_jobs((pagination, req): (Query<Pagination>, HttpRequest<AppState>)) -> Ht
                                 Err(_) => None,
                             };
                         let platforms =
-                            helpers::platforms_for_package_ident(&req, &job.get_package_ident());
+                            match platforms_for_package_ident(&req, &job.get_package_ident()) {
+                                Ok(platforms) => platforms,
+                                Err(_) => None,
+                            };
                         let mut job_json = serde_json::to_value(job).unwrap();
 
                         if channels.is_some() {


### PR DESCRIPTION
The last migration.  With this change, all tests pass without originsrv and router running.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-62159871](https://user-images.githubusercontent.com/13542112/47886189-e6943a00-ddf5-11e8-8c5b-b43fa4475566.gif)
