### PR TITLE
Perf and monitoring improvements to builder-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
 name = "habitat_builder_db"
 version = "0.0.0"
 dependencies = [
+ "builder_core 0.0.0",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-api/src/server/authorize.rs
+++ b/components/builder-api/src/server/authorize.rs
@@ -45,13 +45,22 @@ pub fn authorize_session(
 
         match memcache.get_origin_member(origin, session.get_id()) {
             Some(val) => {
+                trace!(
+                    "Origin membership {} {} Cache Hit!",
+                    origin,
+                    session.get_id()
+                );
                 if val {
                     return Ok(session);
                 } else {
                     return Err(Error::Authorization);
                 }
             }
-            None => (),
+            None => trace!(
+                "Origin membership {} {} Cache Miss!",
+                origin,
+                session.get_id()
+            ),
         }
 
         match check_origin_member(req, origin, session.get_id()) {

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -509,11 +509,11 @@ fn do_get_channel_package(
         let mut memcache = req.state().memcache.borrow_mut();
         match memcache.get_package(req_ident.clone().into(), &channel, &target) {
             Some(pkg_json) => {
-                trace!("Cache Hit!");
+                trace!("Channel package {} {} Cache Hit!", channel, ident);
                 return Ok(pkg_json);
             }
             None => {
-                trace!("Cache Miss!");
+                trace!("Channel package {} {} Cache Miss!", channel, ident);
             }
         };
     }

--- a/components/builder-api/src/server/resources/profile.rs
+++ b/components/builder-api/src/server/resources/profile.rs
@@ -69,7 +69,7 @@ pub fn do_get_access_tokens(
 //
 fn get_account(req: HttpRequest<AppState>) -> HttpResponse {
     let account_id = match authorize_session(&req, None) {
-        Ok(id) => id,
+        Ok(session) => session.get_id(),
         Err(_err) => return HttpResponse::new(StatusCode::UNAUTHORIZED),
     };
 
@@ -86,7 +86,7 @@ fn get_account(req: HttpRequest<AppState>) -> HttpResponse {
 
 fn get_access_tokens(req: HttpRequest<AppState>) -> HttpResponse {
     let account_id = match authorize_session(&req, None) {
-        Ok(id) => id,
+        Ok(session) => session.get_id(),
         Err(err) => return err.into(),
     };
 
@@ -106,7 +106,7 @@ fn get_access_tokens(req: HttpRequest<AppState>) -> HttpResponse {
 
 fn generate_access_token(req: HttpRequest<AppState>) -> HttpResponse {
     let account_id = match authorize_session(&req, None) {
-        Ok(id) => id,
+        Ok(session) => session.get_id(),
         Err(err) => return err.into(),
     };
 
@@ -160,7 +160,7 @@ fn revoke_access_token(req: HttpRequest<AppState>) -> HttpResponse {
     };
 
     let account_id = match authorize_session(&req, None) {
-        Ok(id) => id,
+        Ok(session) => session.get_id(),
         Err(err) => return err.into(),
     };
 
@@ -188,7 +188,7 @@ fn revoke_access_token(req: HttpRequest<AppState>) -> HttpResponse {
 
 fn update_account((req, body): (HttpRequest<AppState>, Json<UserUpdateReq>)) -> HttpResponse {
     let account_id = match authorize_session(&req, None) {
-        Ok(id) => id,
+        Ok(session) => session.get_id(),
         Err(_err) => return HttpResponse::new(StatusCode::UNAUTHORIZED),
     };
 

--- a/components/builder-api/src/server/resources/projects.rs
+++ b/components/builder-api/src/server/resources/projects.rs
@@ -109,7 +109,7 @@ fn create_project((req, body): (HttpRequest<AppState>, Json<ProjectCreateReq>)) 
     }
 
     let account_id = match authorize_session(&req, Some(&body.origin)) {
-        Ok(id) => id,
+        Ok(session) => session.get_id(),
         Err(err) => return err.into(),
     };
 
@@ -265,7 +265,7 @@ fn update_project((req, body): (HttpRequest<AppState>, Json<ProjectUpdateReq>)) 
         .into_inner(); // Unwrap Ok
 
     let account_id = match authorize_session(&req, Some(&origin)) {
-        Ok(id) => id,
+        Ok(session) => session.get_id(),
         Err(err) => return err.into(),
     };
 

--- a/components/builder-api/src/server/resources/user.rs
+++ b/components/builder-api/src/server/resources/user.rs
@@ -37,7 +37,7 @@ impl User {
 //
 fn get_invitations(req: HttpRequest<AppState>) -> HttpResponse {
     let account_id = match authorize_session(&req, None) {
-        Ok(id) => id,
+        Ok(session) => session.get_id(),
         Err(err) => return err.into(),
     };
 
@@ -54,7 +54,7 @@ fn get_invitations(req: HttpRequest<AppState>) -> HttpResponse {
 
 fn get_origins(req: HttpRequest<AppState>) -> HttpResponse {
     let account_id = match authorize_session(&req, None) {
-        Ok(id) => id as i64,
+        Ok(session) => session.get_id() as i64,
         Err(err) => return err.into(),
     };
 

--- a/components/builder-api/src/server/services/memcache.rs
+++ b/components/builder-api/src/server/services/memcache.rs
@@ -159,6 +159,12 @@ impl MemcacheClient {
     }
 
     pub fn get_origin_member(&mut self, origin: &str, account_id: u64) -> Option<bool> {
+        trace!(
+            "Getting origin membership for {} {} from memcached",
+            origin,
+            account_id
+        );
+
         let key = format!("member:{}/{}", origin, account_id);
 
         self.get_bool(&key)

--- a/components/builder-db/Cargo.toml
+++ b/components/builder-db/Cargo.toml
@@ -35,3 +35,6 @@ git = "https://github.com/habitat-sh/core.git"
 
 [dependencies.habitat_net]
 path = "../net"
+
+[dependencies.builder_core]
+path = "../builder-core"

--- a/components/builder-db/src/lib.rs
+++ b/components/builder-db/src/lib.rs
@@ -22,6 +22,7 @@ extern crate diesel_derive_enum;
 extern crate diesel_full_text_search;
 #[macro_use]
 extern crate diesel_migrations;
+extern crate builder_core as bldr_core;
 extern crate fallible_iterator;
 extern crate fnv;
 extern crate habitat_builder_protocol as protocol;
@@ -50,6 +51,7 @@ extern crate url;
 pub mod config;
 pub mod diesel_pool;
 pub mod error;
+pub mod metrics;
 pub mod migration;
 pub mod models;
 pub mod pool;

--- a/components/builder-db/src/models/integration.rs
+++ b/components/builder-db/src/models/integration.rs
@@ -7,6 +7,9 @@ use diesel::sql_types::Text;
 use diesel::RunQueryDsl;
 use schema::integration::*;
 
+use bldr_core::metrics::CounterMetric;
+use metrics::Counter;
+
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
 #[table_name = "origin_integrations"]
 pub struct OriginIntegration {
@@ -31,6 +34,7 @@ pub struct NewOriginIntegration<'a> {
 
 impl OriginIntegration {
     pub fn create(req: &NewOriginIntegration, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from upsert_origin_integration_v1($1, $2, $3, $4)")
             .bind::<Text, _>(req.origin)
             .bind::<Text, _>(req.integration)
@@ -45,6 +49,7 @@ impl OriginIntegration {
         name: &str,
         conn: &PgConnection,
     ) -> QueryResult<OriginIntegration> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_integration_v1($1, $2, $3)")
             .bind::<Text, _>(origin)
             .bind::<Text, _>(integration)
@@ -58,6 +63,7 @@ impl OriginIntegration {
         name: &str,
         conn: &PgConnection,
     ) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from delete_origin_integration_v1($1, $2, $3)")
             .bind::<Text, _>(origin)
             .bind::<Text, _>(integration)
@@ -70,6 +76,7 @@ impl OriginIntegration {
         integration: &str,
         conn: &PgConnection,
     ) -> QueryResult<Vec<OriginIntegration>> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_integrations_v1($1, $2)")
             .bind::<Text, _>(origin)
             .bind::<Text, _>(integration)
@@ -80,6 +87,7 @@ impl OriginIntegration {
         origin: &str,
         conn: &PgConnection,
     ) -> QueryResult<Vec<OriginIntegration>> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_integrations_for_origin_v1($1)")
             .bind::<Text, _>(origin)
             .get_results(conn)

--- a/components/builder-db/src/models/invitations.rs
+++ b/components/builder-db/src/models/invitations.rs
@@ -7,6 +7,9 @@ use diesel::sql_types::{BigInt, Bool, Text};
 use diesel::RunQueryDsl;
 use schema::invitation::*;
 
+use bldr_core::metrics::CounterMetric;
+use metrics::Counter;
+
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
 #[table_name = "origin_invitations"]
 pub struct OriginInvitation {
@@ -37,6 +40,7 @@ pub struct NewOriginInvitation<'a> {
 
 impl OriginInvitation {
     pub fn create(req: &NewOriginInvitation, conn: &PgConnection) -> QueryResult<OriginInvitation> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from insert_origin_invitation_v1($1, $2, $3, $4, $5)")
             .bind::<BigInt, _>(req.origin_id)
             .bind::<Text, _>(req.origin_name)
@@ -50,6 +54,7 @@ impl OriginInvitation {
         origin_id: u64,
         conn: &PgConnection,
     ) -> QueryResult<Vec<OriginInvitation>> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_invitations_for_origin_v1($1)")
             .bind::<BigInt, _>(origin_id as i64)
             .get_results(conn)
@@ -59,12 +64,14 @@ impl OriginInvitation {
         owner_id: u64,
         conn: &PgConnection,
     ) -> QueryResult<Vec<OriginInvitation>> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_invitations_for_account_v1($1)")
             .bind::<BigInt, _>(owner_id as i64)
             .get_results(conn)
     }
 
     pub fn accept(invite_id: u64, ignore: bool, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from accept_origin_invitation_v1($1, $2)")
             .bind::<BigInt, _>(invite_id as i64)
             .bind::<Bool, _>(ignore)
@@ -72,6 +79,7 @@ impl OriginInvitation {
     }
 
     pub fn ignore(invite_id: u64, account_id: u64, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from ignore_origin_invitation_v1($1, $2)")
             .bind::<BigInt, _>(invite_id as i64)
             .bind::<BigInt, _>(account_id as i64)
@@ -79,6 +87,7 @@ impl OriginInvitation {
     }
 
     pub fn rescind(invite_id: u64, account_id: u64, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from rescind_origin_invitation_v1($1, $2)")
             .bind::<BigInt, _>(invite_id as i64)
             .bind::<BigInt, _>(account_id as i64)

--- a/components/builder-db/src/models/keys.rs
+++ b/components/builder-db/src/models/keys.rs
@@ -7,6 +7,9 @@ use diesel::sql_types::{BigInt, Binary, Text};
 use diesel::RunQueryDsl;
 use schema::key::*;
 
+use bldr_core::metrics::CounterMetric;
+use metrics::Counter;
+
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
 #[table_name = "origin_public_encryption_keys"]
 pub struct OriginPublicEncryptionKey {
@@ -121,6 +124,7 @@ impl OriginPublicEncryptionKey {
         revision: &str,
         conn: &PgConnection,
     ) -> QueryResult<OriginPublicEncryptionKey> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_public_encryption_key_v1($1, $2)")
             .bind::<Text, _>(origin)
             .bind::<Text, _>(revision)
@@ -131,6 +135,7 @@ impl OriginPublicEncryptionKey {
         req: &NewOriginPublicEncryptionKey,
         conn: &PgConnection,
     ) -> QueryResult<OriginPublicEncryptionKey> {
+        Counter::DBCall.increment();
         let full_name = format!("{}-{}", req.name, req.revision);
         diesel::sql_query(
             "select * from insert_origin_public_encryption_key_v1($1, $2, $3, $4, $5, $6)",
@@ -144,12 +149,14 @@ impl OriginPublicEncryptionKey {
     }
 
     pub fn latest(origin: &str, conn: &PgConnection) -> QueryResult<OriginPublicEncryptionKey> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_public_encryption_key_latest_v1($1)")
             .bind::<Text, _>(origin)
             .get_result(conn)
     }
 
     pub fn list(origin: &str, conn: &PgConnection) -> QueryResult<Vec<OriginPublicEncryptionKey>> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_public_encryption_keys_for_origin_v1($1)")
             .bind::<Text, _>(origin)
             .get_results(conn)
@@ -158,6 +165,7 @@ impl OriginPublicEncryptionKey {
 
 impl OriginPrivateEncryptionKey {
     pub fn get(origin: &str, conn: &PgConnection) -> QueryResult<OriginPrivateEncryptionKey> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_private_encryption_key_v1($1)")
             .bind::<Text, _>(origin)
             .get_result(conn)
@@ -167,6 +175,7 @@ impl OriginPrivateEncryptionKey {
         req: &NewOriginPrivateEncryptionKey,
         conn: &PgConnection,
     ) -> QueryResult<OriginPrivateEncryptionKey> {
+        Counter::DBCall.increment();
         let full_name = format!("{}-{}", req.name, req.revision);
         diesel::sql_query(
             "select * from insert_origin_private_encryption_key_v1($1, $2, $3, $4, $5, $6)",
@@ -186,6 +195,7 @@ impl OriginPublicSigningKey {
         revision: &str,
         conn: &PgConnection,
     ) -> QueryResult<OriginPublicSigningKey> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_public_key_v1($1, $2)")
             .bind::<Text, _>(origin)
             .bind::<Text, _>(revision)
@@ -196,6 +206,7 @@ impl OriginPublicSigningKey {
         req: &NewOriginPublicSigningKey,
         conn: &PgConnection,
     ) -> QueryResult<OriginPublicSigningKey> {
+        Counter::DBCall.increment();
         let full_name = format!("{}-{}", req.name, req.revision);
         diesel::sql_query("select * from insert_origin_public_key_v1($1, $2, $3, $4, $5, $6)")
             .bind::<BigInt, _>(req.origin_id)
@@ -208,12 +219,14 @@ impl OriginPublicSigningKey {
     }
 
     pub fn latest(origin: &str, conn: &PgConnection) -> QueryResult<OriginPublicSigningKey> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_public_key_latest_v1($1)")
             .bind::<Text, _>(origin)
             .get_result(conn)
     }
 
     pub fn list(origin_id: u64, conn: &PgConnection) -> QueryResult<Vec<OriginPublicSigningKey>> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_public_keys_for_origin_v1($1)")
             .bind::<BigInt, _>(origin_id as i64)
             .get_results(conn)
@@ -222,6 +235,7 @@ impl OriginPublicSigningKey {
 
 impl OriginPrivateSigningKey {
     pub fn get(origin: &str, conn: &PgConnection) -> QueryResult<OriginPrivateSigningKey> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_secret_key_v1($1)")
             .bind::<Text, _>(origin)
             .get_result(conn)
@@ -231,6 +245,7 @@ impl OriginPrivateSigningKey {
         req: &NewOriginPrivateSigningKey,
         conn: &PgConnection,
     ) -> QueryResult<OriginPrivateSigningKey> {
+        Counter::DBCall.increment();
         let full_name = format!("{}-{}", req.name, req.revision);
         diesel::sql_query("select * from insert_origin_secret_key_v1($1, $2, $3, $4, $5, $6)")
             .bind::<BigInt, _>(req.origin_id)

--- a/components/builder-db/src/models/project_integration.rs
+++ b/components/builder-db/src/models/project_integration.rs
@@ -8,6 +8,9 @@ use diesel::RunQueryDsl;
 use protocol::originsrv;
 use schema::project_integration::*;
 
+use bldr_core::metrics::CounterMetric;
+use metrics::Counter;
+
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
 #[table_name = "origin_project_integrations"]
 pub struct ProjectIntegration {
@@ -40,6 +43,7 @@ impl ProjectIntegration {
         integration: &str,
         conn: &PgConnection,
     ) -> QueryResult<ProjectIntegration> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_project_integrations_v2($1, $2, $3)")
             .bind::<Text, _>(origin)
             .bind::<Text, _>(name)
@@ -52,6 +56,7 @@ impl ProjectIntegration {
         name: &str,
         conn: &PgConnection,
     ) -> QueryResult<Vec<ProjectIntegration>> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_project_integrations_for_project_v2($1, $2)")
             .bind::<Text, _>(origin)
             .bind::<Text, _>(name)
@@ -64,6 +69,7 @@ impl ProjectIntegration {
         integration: &str,
         conn: &PgConnection,
     ) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from delete_origin_project_integration_v1($1, $2, $3)")
             .bind::<Text, _>(origin)
             .bind::<Text, _>(name)
@@ -72,6 +78,7 @@ impl ProjectIntegration {
     }
 
     pub fn create(req: NewProjectIntegration, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query("SELECT * FROM upsert_origin_project_integration_v3($1, $2, $3, $4)")
             .bind::<Text, _>(req.origin)
             .bind::<Text, _>(req.name)

--- a/components/builder-db/src/models/projects.rs
+++ b/components/builder-db/src/models/projects.rs
@@ -9,6 +9,9 @@ use models::package::{PackageVisibility, PackageVisibilityMapping};
 use protocol::originsrv;
 use schema::project::*;
 
+use bldr_core::metrics::CounterMetric;
+use metrics::Counter;
+
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
 #[table_name = "origin_projects"]
 pub struct Project {
@@ -59,18 +62,21 @@ pub struct UpdateProject<'a> {
 
 impl Project {
     pub fn get(name: &str, conn: &PgConnection) -> QueryResult<Project> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_project_v1($1)")
             .bind::<Text, _>(name)
             .get_result(conn)
     }
 
     pub fn delete(name: &str, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from delete_origin_project_v1($1)")
             .bind::<Text, _>(name)
             .execute(conn)
     }
 
     pub fn create(project: &NewProject, conn: &PgConnection) -> QueryResult<Project> {
+        Counter::DBCall.increment();
         diesel::sql_query(
             "SELECT * FROM insert_origin_project_v6($1, $2, $3, $4, $5, $6, $7, $8, $9)",
         ).bind::<Text, _>(project.origin_name)
@@ -86,6 +92,7 @@ impl Project {
     }
 
     pub fn update(project: &UpdateProject, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query(
             "SELECT * FROM update_origin_project_v5($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
         ).bind::<BigInt, _>(project.id)
@@ -102,6 +109,7 @@ impl Project {
     }
 
     pub fn list(origin: &str, conn: &PgConnection) -> QueryResult<Vec<Project>> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_project_list_v2($1)")
             .bind::<Text, _>(origin)
             .get_results(conn)

--- a/components/builder-db/src/models/secrets.rs
+++ b/components/builder-db/src/models/secrets.rs
@@ -7,6 +7,9 @@ use diesel::sql_types::{BigInt, Text};
 use diesel::RunQueryDsl;
 use schema::secrets::*;
 
+use bldr_core::metrics::CounterMetric;
+use metrics::Counter;
+
 #[derive(Debug, Serialize, Deserialize, QueryableByName)]
 #[table_name = "origin_secrets"]
 pub struct OriginSecret {
@@ -29,6 +32,7 @@ impl OriginSecret {
         value: &str,
         conn: &PgConnection,
     ) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         // TODO FIX: We're missing setting the account id here
         diesel::sql_query("select * from insert_origin_secret_v1($1, $2, $3)")
             .bind::<BigInt, _>(origin_id)
@@ -38,6 +42,7 @@ impl OriginSecret {
     }
 
     pub fn get(origin_id: i64, name: &str, conn: &PgConnection) -> QueryResult<OriginSecret> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_secret_v1($1, $2)")
             .bind::<BigInt, _>(origin_id)
             .bind::<Text, _>(name)
@@ -45,6 +50,7 @@ impl OriginSecret {
     }
 
     pub fn delete(origin_id: i64, name: &str, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from delete_origin_secret_v1($1, $2)")
             .bind::<BigInt, _>(origin_id)
             .bind::<Text, _>(name)
@@ -52,6 +58,7 @@ impl OriginSecret {
     }
 
     pub fn list(origin_id: i64, conn: &PgConnection) -> QueryResult<Vec<OriginSecret>> {
+        Counter::DBCall.increment();
         diesel::sql_query("select * from get_origin_secrets_for_origin_v1($1)")
             .bind::<BigInt, _>(origin_id)
             .get_results(conn)


### PR DESCRIPTION
This PR makes a few key improvements to open up perf for the direct DB builder API.  Since getting a DB connection/making a DB call are blocking operations, we need to ensure we avoid those in the high volume paths. With the changes here, we are able to serve all high volume calls (including authentication/authorization via personal access tokens) without hitting the DB.  Leveraging memcache for origin membership also allows us to make some other key simplifications. Finally, counter metrics are added for every DB API in the builder-db models.

![tenor-268071921](https://user-images.githubusercontent.com/13542112/47949066-1593d400-defa-11e8-9956-2181fa2c7720.gif)
