### PR TITLE
Add memcache timing metric, etc

### DIFF
--- a/components/builder-api/src/server/services/metrics.rs
+++ b/components/builder-api/src/server/services/metrics.rs
@@ -49,3 +49,17 @@ impl metrics::Metric for Counter {
         }
     }
 }
+
+pub enum Histogram {
+    MemcacheCallTime,
+}
+
+impl metrics::HistogramMetric for Histogram {}
+
+impl metrics::Metric for Histogram {
+    fn id(&self) -> Cow<'static, str> {
+        match *self {
+            Histogram::MemcacheCallTime => "memcache.call-time".into(),
+        }
+    }
+}


### PR DESCRIPTION
Adds trace and metrics for memcache get calls. Also disables Nagle's algorithm in the memcache client which results in a significant perf gain (client calls go from around 47ms to ~0ms).

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-223798994](https://user-images.githubusercontent.com/13542112/47958572-d82b5700-df8a-11e8-9c6b-f955c8465dd9.gif)
