### PR TITLE
Terraform - add memcache stats to datadog

### DIFF
--- a/terraform/files/mcache.yaml
+++ b/terraform/files/mcache.yaml
@@ -1,0 +1,14 @@
+init_config:
+
+instances:
+  - url: localhost  # url used to connect to the memcached instance
+  #   socket: /socket/path # if url missing; 'dd-agent' user must have read/write permission
+  #   port: 11211 # If this line is not present, port will default to 11211
+  #   username: my_username
+  #   password: my_password
+  #   tags:
+  #     - optional_tag
+
+  #   options:
+  #     items: false  # set to true if you wish to collect items memcached stats.
+  #     slabs: false  # set to true if you wish to collect slabs memcached stats.

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -56,6 +56,11 @@ resource "aws_instance" "api" {
   }
 
   provisioner "file" {
+    source = "${path.module}/files/mcache.yaml"
+    destination = "/tmp/mcache.yaml"
+  }
+
+  provisioner "file" {
     source = "${path.module}/files/nginx.logrotate"
     destination = "/tmp/nginx.logrotate"
   }
@@ -63,6 +68,7 @@ resource "aws_instance" "api" {
   provisioner "remote-exec" {
     inline = [
       "sudo cp /tmp/nginx.yaml /etc/dd-agent/conf.d/nginx.yaml",
+      "sudo cp /tmp/mcache.yaml /etc/dd-agent/conf.d/mcache.yaml",
       "sudo cp /tmp/nginx.logrotate /etc/logrotate.d/nginx",
       "sudo /etc/init.d/datadog-agent start"
     ]


### PR DESCRIPTION
Updates the Terraform scripts to add sending of memcache stats from the api node to Datadog.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-154106785](https://user-images.githubusercontent.com/13542112/47958812-aae1a780-df90-11e8-98fc-8e04539cd00e.gif)
