### PR TITLE
Fix list secret regression

### DIFF
--- a/components/builder-db/src/models/secrets.rs
+++ b/components/builder-db/src/models/secrets.rs
@@ -17,8 +17,7 @@ pub struct OriginSecret {
     pub id: i64,
     #[serde(with = "db_id_format")]
     pub origin_id: i64,
-    #[serde(with = "db_id_format")]
-    pub owner_id: i64,
+    pub owner_id: Option<i64>, // can be null
     pub name: String,
     pub value: String,
     pub created_at: Option<NaiveDateTime>,

--- a/components/builder-db/src/schema/secrets.rs
+++ b/components/builder-db/src/schema/secrets.rs
@@ -2,7 +2,7 @@ table! {
     origin_secrets (id) {
         id -> BigInt,
         origin_id -> BigInt,
-        owner_id -> BigInt,
+        owner_id -> Nullable<BigInt>,
         name -> Text,
         value -> Text,
         created_at -> Nullable<Timestamptz>,


### PR DESCRIPTION
This fixes a regression where origin secrets list was failing, due to a Diesel trying to map a null owner_id. Currently we don't write out the owner id for secrets, so that column is unused.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-21168069](https://user-images.githubusercontent.com/13542112/48033593-c1167180-e110-11e8-81c6-9a5e82feb2bd.gif)
