### PR TITLE
Better proxy support for builder-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,6 +723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_proxy"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,11 +1772,13 @@ name = "oauth-client"
 version = "0.0.0"
 dependencies = [
  "builder_core 0.0.0",
+ "env_proxy 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2396,11 +2407,13 @@ name = "segment-api-client"
 version = "0.0.0"
 dependencies = [
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_proxy 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3429,6 +3442,7 @@ dependencies = [
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum encoding_rs 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)" = "065f4d0c826fdaef059ac45487169d918558e3cf86c9d89f6e81cf52369126e5"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+"checksum env_proxy 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ecdcbf2ed7aac24349695d199db8100141a99be29d6d4e44d6e774c03ad8dbad"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faa976b4fd2e4c2b2f3f486874b19e61944d3de3de8b61c9fcf835d583871bcc"

--- a/components/oauth-client/Cargo.toml
+++ b/components/oauth-client/Cargo.toml
@@ -11,6 +11,8 @@ reqwest = "0.8.1"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"
+env_proxy = "*"
+url = "*"
 
 # For metrics library
 [dependencies.builder_core]

--- a/components/oauth-client/src/lib.rs
+++ b/components/oauth-client/src/lib.rs
@@ -19,7 +19,9 @@ extern crate reqwest;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate env_proxy;
 extern crate serde_json;
+extern crate url;
 
 pub mod a2;
 pub mod active_directory;

--- a/components/segment-api-client/Cargo.toml
+++ b/components/segment-api-client/Cargo.toml
@@ -6,11 +6,13 @@ workspace = "../../"
 
 [dependencies]
 base64 = "*"
+env_proxy = "*"
 reqwest = "0.8.1"
 log = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"
+url = "*"
 
 [[bin]]
 name = "segment-client"

--- a/components/segment-api-client/src/lib.rs
+++ b/components/segment-api-client/src/lib.rs
@@ -21,6 +21,8 @@ extern crate serde;
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
+extern crate env_proxy;
+extern crate url;
 
 pub mod client;
 pub mod config;


### PR DESCRIPTION
This PR improves http/https proxy support in builder.  It uses the env_proxy crate to determine the proxy settings, which takes no_proxy into account. The use case is primarily for on-prem builder.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-9234196](https://user-images.githubusercontent.com/13542112/48155113-1cff0880-e27f-11e8-8a42-0f926d088de0.gif)
