### PR TITLE
Fix channels list logic and PAT token generation

### DIFF
--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -40,7 +40,7 @@ use server::AppState;
 #[derive(Debug, Default, Clone, Deserialize)]
 struct SandboxBool {
     #[serde(default)]
-    is_set: bool,
+    sandbox: bool,
 }
 
 pub struct Channels;
@@ -106,7 +106,7 @@ fn get_channels((req, sandbox): (HttpRequest<AppState>, Query<SandboxBool>)) -> 
         Err(err) => return err.into(),
     };
 
-    match Channel::list(&origin, sandbox.is_set, &*conn).map_err(Error::DieselError) {
+    match Channel::list(&origin, sandbox.sandbox, &*conn).map_err(Error::DieselError) {
         Ok(list) => {
             // TED: This is to maintain backwards API compat while killing some proto definitions
             // currently the output looks like [{"name": "foo"}] when it probably should be ["foo"]

--- a/components/builder-db/src/migrations/2018-11-06-444444_unique_account_id/up.sql
+++ b/components/builder-db/src/migrations/2018-11-06-444444_unique_account_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account_tokens ADD UNIQUE(account_id);

--- a/components/builder-db/src/models/account.rs
+++ b/components/builder-db/src/models/account.rs
@@ -98,6 +98,9 @@ impl AccountToken {
         Counter::DBCall.increment();
         diesel::insert_into(account_tokens::table)
             .values(req)
+            .on_conflict(account_tokens::account_id)
+            .do_update()
+            .set(account_tokens::token.eq(req.token))
             .get_result(conn)
     }
 

--- a/components/builder-db/src/models/channel.rs
+++ b/components/builder-db/src/models/channel.rs
@@ -68,8 +68,8 @@ impl Channel {
             .select(origin_channels::table::all_columns())
             .filter(origin_channels::origin.eq(origin))
             .into_boxed();
-        if include_sandbox_channels {
-            query = query.filter(origin_channels::name.like("bldr-%"));
+        if !include_sandbox_channels {
+            query = query.filter(origin_channels::name.not_like("bldr-%"));
         }
         query.order(origin_channels::name.asc()).get_results(conn)
     }


### PR DESCRIPTION
Personal account tokens were able to be duplicated. This change adds a constraint to disallow account_ids with multiple tokens

Channels list now returns sandbox channels correctly

Signed-off-by: Elliott Davis <elliott@excellent.io>