### PR TITLE
Present appropriate GitHub app messaging

### DIFF
--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -46,17 +46,16 @@
   </div>
   <div class="connecting" *ngIf="connecting">
     <form [formGroup]="form" #formValues="ngForm">
-      <div class="note">
+      <div class="note" *ngIf="!loadingInstallations">
         <div class="icon">
           <hab-icon symbol="github"></hab-icon>
         </div>
         <div class="info">
-          In order to connect a plan file in your repo, you must first install the Habitat Builder GitHub app and allow access to that
-          repository.
+          {{ gitHubAppNote }}
         </div>
         <div class="cta">
           <a href="{{ config['github_app_url'] }}" mat-raised-button color="accent" class="button" target="_blank">
-            Install GitHub App
+            {{ gitHubAppLabel }} GitHub App
           </a>
         </div>
       </div>

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -132,6 +132,35 @@ export class ProjectSettingsComponent implements OnChanges, AfterViewChecked {
     return this.store.getState().gitHub.files;
   }
 
+  get gitHubAppNote() {
+
+    let note = `In order to connect a plan file in your repo,
+      you must first install the Builder GitHub app
+      and allow access to that repository.`;
+
+    if (this.gitHubAppInstalled) {
+      note = `If you don't see one or more of your organizations
+        or repositories listed below, you may need to adjust the
+        settings of the Builder GitHub app.`;
+    }
+
+    return note;
+  }
+
+  get gitHubAppLabel() {
+    let label = 'Install';
+
+    if (this.gitHubAppInstalled) {
+      label = 'Open';
+    }
+
+    return label;
+  }
+
+  get gitHubAppInstalled() {
+    return !this.loadingInstallations && this.installations.size > 0;
+  }
+
   get hasPrivateKey() {
     const currentOrigin = this.store.getState().origins.current;
     return currentOrigin.name === this.origin && !!currentOrigin.private_key_name;


### PR DESCRIPTION
This minor change modifies the messaging displayed above the plan-connection view based on whether or not a GitHub app has been installed and configured.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/l0DEJvXHmIoM8702Y/200.webp)