### PR TITLE
Fix target handling for package upload

### DIFF
--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -484,10 +484,10 @@ fn do_get_channel_package(
     let req_ident = ident.clone();
 
     // TODO: Deprecate target from headers
-    let target = match qtarget.target.clone() {
-        Some(t) => {
+    let target = match qtarget.target {
+        Some(ref t) => {
             debug!("Query requested target = {}", t);
-            PackageTarget::from_str(&t)?
+            PackageTarget::from_str(t)?
         }
         None => helpers::target_from_headers(req),
     };

--- a/components/builder-api/src/server/resources/jobs.rs
+++ b/components/builder-api/src/server/resources/jobs.rs
@@ -92,10 +92,10 @@ fn get_rdeps((qtarget, req): (Query<Target>, HttpRequest<AppState>)) -> HttpResp
         .into_inner(); // Unwrap Ok
 
     // TODO: Deprecate target from headers
-    let target = match qtarget.target.clone() {
-        Some(t) => {
+    let target = match qtarget.target {
+        Some(ref t) => {
             debug!("Query requested target = {}", t);
-            match PackageTarget::from_str(&t) {
+            match PackageTarget::from_str(t) {
                 Ok(t) => t,
                 Err(err) => return Error::HabitatCore(err).into(),
             }

--- a/components/builder-core/src/rpc.rs
+++ b/components/builder-core/src/rpc.rs
@@ -86,20 +86,20 @@ impl RpcClient {
         let id = req.descriptor().name().to_owned();
         let body = req.write_to_bytes()?;
         let msg = RpcMessage { id: id, body: body };
-        debug!("Sending RPC Message: {:?}", msg);
+        debug!("Sending RPC Message: {}", msg.id);
 
         let json = serde_json::to_string(&msg)?;
         let mut res = self.cli.post(&self.endpoint).body(json).send()?;
-        debug!("Got http response status: {}", res.status());
+        debug!("Got RPC response status: {}", res.status());
 
         let mut s = String::new();
         res.read_to_string(&mut s).map_err(Error::IO)?;
-        debug!("Got http response body: {}", s);
+        trace!("Got http response body: {}", s);
 
         match res.status() {
             StatusCode::Ok => {
                 let resp_json: RpcMessage = serde_json::from_str(&s)?;
-                debug!("Got JSON: {:?}", resp_json);
+                trace!("Got RPC JSON: {:?}", resp_json);
 
                 let resp_msg = protobuf::parse_from_bytes::<T>(&resp_json.body)?;
                 Ok(resp_msg)


### PR DESCRIPTION
Bug fix and some minor cleanup to package upload target handling - previously we were falling back to a default Linux target if no target was specified by the client on upload - however that failed for Windows packages where the hab client is not explicitly specifying a target in the url.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-84017365](https://user-images.githubusercontent.com/13542112/48294922-72344900-e43c-11e8-8677-1b293ac59bab.gif)
