### PR TITLE
Remove fanout for channel package call

### DIFF
--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -25,8 +25,6 @@ use hab_core::package::{PackageIdent, PackageTarget};
 use hab_net::{ErrCode, NetError};
 use serde_json;
 
-use super::pkgs::is_a_service;
-
 use db::models::channel::*;
 use db::models::package::{BuilderPackageIdent, Package};
 use server::authorize::authorize_session;
@@ -543,9 +541,7 @@ fn do_get_channel_package(
     };
 
     let mut pkg_json = serde_json::to_value(pkg.clone()).unwrap();
-    let channels = channels_for_package_ident(req, &pkg.ident.clone())?;
-    pkg_json["channels"] = json!(channels);
-    pkg_json["is_a_service"] = json!(is_a_service(&pkg.into()));
+    pkg_json["is_a_service"] = json!(pkg.is_a_service());
 
     let json_body = serde_json::to_string(&pkg_json).unwrap();
 

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -1070,7 +1070,7 @@ pub fn postprocess_package_model(
         Err(_) => None,
     };
     pkg_json["channels"] = json!(channels);
-    pkg_json["is_a_service"] = json!(is_a_service(pkg));
+    pkg_json["is_a_service"] = json!(pkg.is_a_service());
 
     let body = serde_json::to_string(&pkg_json).unwrap();
 
@@ -1177,14 +1177,6 @@ fn check_circular_deps(
         }
         Err(err) => return Err(err),
     }
-}
-
-pub fn is_a_service(package: &Package) -> bool {
-    let m = package.manifest.clone();
-    // TODO: This is a temporary workaround until we plumb in a better solution for
-    // determining whether a package is a service from the DB instead of needing
-    // to crack the archive file to look for a SVC_USER file
-    m.contains("pkg_exposes") || m.contains("pkg_binds") || m.contains("pkg_exports")
 }
 
 pub fn platforms_for_package_ident(

--- a/components/builder-db/src/models/channel.rs
+++ b/components/builder-db/src/models/channel.rs
@@ -9,13 +9,13 @@ use diesel::{
     ExpressionMethods, NullableExpressionMethods, PgArrayExpressionMethods, QueryDsl, RunQueryDsl,
     Table, TextExpressionMethods,
 };
-use models::package::{BuilderPackageIdent, Package, PackageVisibility};
+use models::package::{BuilderPackageIdent, PackageVisibility, PackageWithChannelPlatform};
 use models::pagination::Paginate;
 use protocol::jobsrv::JobGroupTrigger;
 use schema::audit::{audit_package, audit_package_group};
 use schema::channel::{origin_channel_packages, origin_channels};
 use schema::origin::origins;
-use schema::package::origin_packages;
+use schema::package::{origin_packages, packages_with_channel_platform};
 
 use bldr_core::metrics::CounterMetric;
 use metrics::Counter;
@@ -98,18 +98,20 @@ impl Channel {
         ).execute(conn)
     }
 
-    pub fn get_latest_package(req: GetLatestPackage, conn: &PgConnection) -> QueryResult<Package> {
+    pub fn get_latest_package(
+        req: GetLatestPackage,
+        conn: &PgConnection,
+    ) -> QueryResult<PackageWithChannelPlatform> {
         Counter::DBCall.increment();
         let ident = req.ident;
 
-        Package::all()
-            .inner_join(origin_channel_packages::table.inner_join(origin_channels::table))
-            .filter(origin_packages::origin.eq(&ident.origin))
-            .filter(origin_channels::name.eq(req.channel))
-            .filter(origin_packages::target.eq(req.target))
-            .filter(origin_packages::visibility.eq(any(req.visibility)))
-            .filter(origin_packages::ident_array.contains(ident.clone().parts()))
-            .order(sql::<Package>(
+        packages_with_channel_platform::table
+            .filter(packages_with_channel_platform::origin.eq(&ident.origin))
+            .filter(packages_with_channel_platform::target.eq(req.target))
+            .filter(packages_with_channel_platform::visibility.eq(any(req.visibility)))
+            .filter(packages_with_channel_platform::ident_array.contains(ident.clone().parts()))
+            .filter(packages_with_channel_platform::channels.contains(vec![req.channel]))
+            .order(sql::<PackageWithChannelPlatform>(
                 "to_semver(ident_array[3]) desc, ident_array[4] desc",
             )).limit(1)
             .get_result(conn)

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -492,6 +492,26 @@ impl Package {
             .filter(origin_packages::visibility.eq(any(visibilities)))
             .get_results(conn)
     }
+
+    pub fn is_a_service(&self) -> bool {
+        // TODO: This is a temporary workaround until we plumb in a better solution for
+        // determining whether a package is a service from the DB instead of needing
+        // to crack the archive file to look for a SVC_USER file
+        self.manifest.contains("pkg_exposes")
+            || self.manifest.contains("pkg_binds")
+            || self.manifest.contains("pkg_exports")
+    }
+}
+
+impl PackageWithChannelPlatform {
+    pub fn is_a_service(&self) -> bool {
+        // TODO: This is a temporary workaround until we plumb in a better solution for
+        // determining whether a package is a service from the DB instead of needing
+        // to crack the archive file to look for a SVC_USER file
+        self.manifest.contains("pkg_exposes")
+            || self.manifest.contains("pkg_binds")
+            || self.manifest.contains("pkg_exports")
+    }
 }
 
 fn searchable_ident(ident: &BuilderPackageIdent) -> Vec<String> {


### PR DESCRIPTION
This change improves the perf on the channel package call by removing the internal fanout of calls that were being made to retrieve channels and platforms. Instead, it leverages the new packages_with_channel_platform view to perform the same operation.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-266416807](https://user-images.githubusercontent.com/13542112/48514880-36222f00-e814-11e8-8920-0134091ea17f.gif)
