### PR TITLE
Display visibility settings more prominently in general

### DIFF
--- a/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.html
@@ -53,17 +53,15 @@
           </div>
         </div>
         <div class="jobgroup-overview-item">
-          <ng-container *ngIf="true">
-            <h4 class="jobgroup-overview-item-title">&nbsp;</h4>
-            <div class="jobgroup-overview-item-value">
-              <span class="jobgroup-actions">
-                <a *ngIf="pendingCount > 0" class="cancel" (click)="cancel(id)">
-                  <hab-icon symbol="no"></hab-icon>
-                  Cancel remaining jobs
-                </a>
-              </span>
-            </div>
-          </ng-container>
+          <h4 class="jobgroup-overview-item-title">&nbsp;</h4>
+          <div class="jobgroup-overview-item-value">
+            <span class="jobgroup-actions">
+              <a *ngIf="pendingCount > 0" class="cancel" (click)="cancel(id)">
+                <hab-icon symbol="no"></hab-icon>
+                Cancel remaining jobs
+              </a>
+            </span>
+          </div>
         </div>
       </section>
     </section>

--- a/components/builder-web/app/origin/origin-page/origin-page.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-page.component.html
@@ -1,6 +1,9 @@
 <div class="origin-page-component">
   <header>
-    <h1>{{ origin.name }}</h1>
+    <h1>
+      {{ origin.name }}
+      <hab-visibility-icon [visibility]="origin.default_package_visibility" *ngIf="memberOfOrigin" prefix="Default Package Visibility:"></hab-visibility-icon>
+    </h1>
     <h2>origin</h2>
   </header>
   <nav class="tabs" mat-tab-nav-bar>

--- a/components/builder-web/app/origin/origins-page/_origins-page.component.scss
+++ b/components/builder-web/app/origin/origins-page/_origins-page.component.scss
@@ -2,6 +2,12 @@
 
   .nav-list {
     font-size: $base-font-size;
+
+    h4, .column {
+      &:not(:first-child) {
+        text-align: center;
+      }
+    }
   }
 
   .invitation {

--- a/components/builder-web/app/origin/origins-page/origins-page.component.html
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.html
@@ -29,12 +29,16 @@
             <li class="heading">
               <h4>Origin Name</h4>
               <h4>Packages</h4>
+              <h4>Default Visibility</h4>
               <h4></h4>
             </li>
             <li class="item" [class.invitation]="isInvitation(item)" *ngFor="let item of origins" (click)="navigateTo(item)">
               <a>
                 <span class="column name">{{ name(item) }}</span>
                 <span class="column package-count">{{ packageCount(item) }}</span>
+                <span class="column visibility">
+                  <hab-icon [symbol]="visibilityIcon(item)" [title]="visibilityLabel(item)"></hab-icon>
+                </span>
                 <span class="column actions">
                   <span *ngIf="isInvitation(item)">
                     <span class="action" (click)="accept(item)">

--- a/components/builder-web/app/origin/origins-page/origins-page.component.ts
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.ts
@@ -99,6 +99,14 @@ export class OriginsPageComponent implements OnInit {
     return count >= 0 ? count : '-';
   }
 
+  visibilityIcon(item) {
+    return item.default_package_visibility === 'public' ? 'public' : 'lock';
+  }
+
+  visibilityLabel(item) {
+    return item.default_package_visibility === 'public' ? 'Public' : 'Private';
+  }
+
   isInvitation(item) {
     return !!item.isInvite;
   }

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
@@ -5,6 +5,25 @@
       {{ buildButtonLabel }}
     </button>
   </section>
+  <section *ngIf="buildable">
+    <h3>Settings</h3>
+    <ul>
+      <li>
+        <hab-icon symbol="github"></hab-icon> {{ repoName }}
+        <a href="{{ repoUrl }}" target="_blank" title="View GitHub Repo">
+          <hab-icon symbol="open-in-new"></hab-icon>
+        </a>
+      </li>
+      <li>
+        <hab-icon symbol="loading"></hab-icon>
+        Auto-build {{ autoBuildSetting }}
+      </li>
+      <li>
+        <hab-visibility-icon [visibility]="project.visibility" prefix="Default Package Visibility:"></hab-visibility-icon>
+        {{ project.visibility | titlecase }} packages
+      </li>
+    </ul>
+  </section>
   <section class="platforms">
     <h3>Supported Platforms</h3>
     <p *ngIf="platforms.length === 0">

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.spec.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.spec.ts
@@ -48,7 +48,9 @@ describe('PackageSidebarComponent', () => {
       declarations: [
         PackageSidebarComponent,
         MockComponent({ selector: 'hab-copyable', inputs: ['style', 'text'] }),
-        MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] })
+        MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] }),
+        MockComponent({ selector: 'hab-icon', inputs: ['symbol'] }),
+        MockComponent({ selector: 'hab-visibility-icon', inputs: ['visibility', 'prefix'] })
       ],
       providers: [
         { provide: AppStore, useClass: MockAppStore }
@@ -72,6 +74,13 @@ describe('PackageSidebarComponent', () => {
               version: '1.11.10'
             }
           }
+        },
+      },
+      projects: {
+        current: {
+          visibility: 'private',
+          vcs_data: 'https://github.com/cnunciato/testapp.git',
+          auto_rebuild: false
         }
       },
       session: {

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
@@ -74,9 +74,24 @@ export class PackageSidebarComponent implements OnChanges {
     return this.store.getState().packages.ui.latestInChannel.stable.loading;
   }
 
+  get project() {
+    return this.store.getState().projects.current;
+  }
 
   get runCommand() {
     return `hab start ${this.origin}/${this.name}`;
+  }
+
+  get autoBuildSetting() {
+    return this.project.auto_build ? 'enabled' : 'disabled';
+  }
+
+  get repoName() {
+    return (this.project.vcs_data.match(/github.com\/(.+)\.git$/) || [''])[1] || '';
+  }
+
+  get repoUrl() {
+    return this.project.vcs_data.replace('.git', '');
   }
 
   get platforms() {

--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -1,6 +1,7 @@
 <header>
   <h1>
     <hab-package-breadcrumbs [ident]="ident"></hab-package-breadcrumbs>
+    <hab-visibility-icon [visibility]="visibility" *ngIf="isOriginMember" prefix="Default Package Visibility:"></hab-visibility-icon>
   </h1>
   <h2>package</h2>
 </header>

--- a/components/builder-web/app/package/package/package.component.spec.ts
+++ b/components/builder-web/app/package/package/package.component.spec.ts
@@ -64,6 +64,11 @@ describe('PackageComponent', () => {
           current: {
             exists: true
           }
+        },
+        current: {
+          visibility: 'private',
+          vcs_data: 'https://github.com/cnunciato/testapp.git',
+          auto_rebuild: false
         }
       },
       session: {
@@ -83,7 +88,8 @@ describe('PackageComponent', () => {
         PackageComponent,
         MockComponent({ selector: 'hab-package-breadcrumbs', inputs: ['ident'] }),
         MockComponent({ selector: 'hab-package-sidebar', inputs: ['origin', 'name', 'building', 'buildable'] }),
-        MockComponent({ selector: 'hab-job-notice', inputs: ['job'] })
+        MockComponent({ selector: 'hab-job-notice', inputs: ['job'] }),
+        MockComponent({ selector: 'hab-visibility-icon', inputs: ['visibility', 'prefix'] })
       ],
       providers: [
         { provide: ActivatedRoute, useClass: MockRoute },

--- a/components/builder-web/app/package/package/package.component.ts
+++ b/components/builder-web/app/package/package/package.component.ts
@@ -112,6 +112,10 @@ export class PackageComponent implements OnInit, OnDestroy {
     return this.store.getState().session.token;
   }
 
+  get visibility() {
+    return this.store.getState().projects.current.visibility;
+  }
+
   onRouteActivate(routedComponent) {
     this.showSidebar = false;
     this.showActiveJob = false;

--- a/components/builder-web/app/reducers/origins.ts
+++ b/components/builder-web/app/reducers/origins.ts
@@ -43,9 +43,14 @@ export default function origins(state = initialState['origins'], action) {
           setIn(['ui', 'mine', 'loading'], false);
       } else {
         return state.setIn(['mine'], List(action.payload.map(origin =>
-          Origin({ name: origin.name, package_count: origin.package_count })
-        ))).setIn(['ui', 'mine', 'errorMessage'], undefined).
-          setIn(['ui', 'mine', 'loading'], false);
+          Origin({
+            name: origin.name,
+            package_count: origin.package_count,
+            default_package_visibility: origin.default_package_visibility
+          })
+        )))
+        .setIn(['ui', 'mine', 'errorMessage'], undefined)
+        .setIn(['ui', 'mine', 'loading'], false);
       }
 
     case actionTypes.POPULATE_MY_ORIGIN_INVITATIONS:

--- a/components/builder-web/app/shared/shared.module.ts
+++ b/components/builder-web/app/shared/shared.module.ts
@@ -39,6 +39,7 @@ import { JobStatusLabelComponent } from './job-status-label/job-status-label.com
 import { PackageListComponent } from './package-list/package-list.component';
 import { ProjectSettingsComponent } from './project-settings/project-settings.component';
 import { PlatformIconComponent } from './platform-icon/platform-icon.component';
+import { VisibilityIconComponent } from './visibility-icon/visibility-icon.component';
 import { VisibilitySelectorComponent } from './visibility-selector/visibility-selector.component';
 import { KeysPipe } from './pipes/keys.pipe';
 import { SimpleConfirmDialog } from './dialog/simple-confirm/simple-confirm.dialog';
@@ -79,6 +80,7 @@ import { JobNoticeComponent } from './job-notice/job-notice.component';
     PackageListComponent,
     ProjectSettingsComponent,
     PlatformIconComponent,
+    VisibilityIconComponent,
     VisibilitySelectorComponent,
     SimpleConfirmDialog,
     JobNoticeComponent,
@@ -106,6 +108,7 @@ import { JobNoticeComponent } from './job-notice/job-notice.component';
     MatRadioButton,
     MatSlideToggle,
     PackageListComponent,
+    VisibilityIconComponent,
     VisibilitySelectorComponent,
     ProjectSettingsComponent,
     PlatformIconComponent,

--- a/components/builder-web/app/shared/visibility-icon/visibility-icon.component.ts
+++ b/components/builder-web/app/shared/visibility-icon/visibility-icon.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'hab-visibility-icon',
+  template: `<hab-icon [symbol]="symbol" class="icon-visibility" [title]="title"></hab-icon>`
+})
+export class VisibilityIconComponent {
+
+  @Input() visibility: string;
+  @Input() prefix: string;
+
+  get symbol() {
+    return this.visibility === 'public' ? 'public' : 'lock';
+  }
+
+  get title() {
+    const t = this.visibility === 'public' ? 'Public' : 'Private';
+    return this.prefix ? `${this.prefix} ${t}` : t;
+  }
+}

--- a/components/builder-web/app/shared/visibility-selector/visibility-selector.component.html
+++ b/components/builder-web/app/shared/visibility-selector/visibility-selector.component.html
@@ -6,7 +6,7 @@
         <hab-icon symbol="public"></hab-icon>
       </h5>
       <span>
-        Package build will appear in public search results and can be utilized by any user.
+        Package builds will appear in public search results and can be utilized by any user.
       </span>
     </mat-radio-button>
     <mat-radio-button class="selector" [class.active]="setting === 'private'" value="private">


### PR DESCRIPTION
This change adds package-visibility icons on the origin and package views to indicate more clearly whether a package is (or would be) public or private. It also adds a couple of bits of information to the package sidebar to reflect the connected GitHub repository and whether automatic rebuilds are enabled.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes #480 

![](https://i.giphy.com/media/17lmGSt5tqRVqWMj8K/giphy.webp)
