### PR TITLE
Fix handling of RPC errors

### DIFF
--- a/components/builder-core/src/rpc.rs
+++ b/components/builder-core/src/rpc.rs
@@ -104,7 +104,7 @@ impl RpcClient {
                 let resp_msg = protobuf::parse_from_bytes::<T>(&resp_json.body)?;
                 Ok(resp_msg)
             }
-            status => Err(Error::ApiError(status, s)),
+            status => Err(Error::RpcError(status.as_u16(), s)),
         }
     }
 }

--- a/test/builder-api/src/jobs.js
+++ b/test/builder-api/src/jobs.js
@@ -211,6 +211,18 @@ describe('Jobs API', function () {
         });
     });
 
+    it('returns a NotFound for a non-existent job id', function (done) {
+      request.get(`/jobs/123456`)
+        .type('application/json')
+        .accept('application/json')
+        .set('Authorization', global.boboBearer)
+        .expect(404)
+        .end(function (err, res) {
+          expect(res.body).to.be.empty;
+          done(err);
+        });
+    });
+
     it('succeeds', function (done) {
       request.get(`/jobs/${global.neurosisTestappJob.id}`)
         .type('application/json')
@@ -306,6 +318,17 @@ describe('Jobs API', function () {
           .expect(400)
           .end(function (err, res) {
             expect(res.text).to.be.empty;
+            done(err);
+          });
+      });
+
+      it('returns a NotFound for a non-existent job log', function (done) {
+        request.get(`/jobs/123456/log`)
+          .accept('application/json')
+          .set('Authorization', global.boboBearer)
+          .expect(404)
+          .end(function (err, res) {
+            expect(res.body).to.be.empty;
             done(err);
           });
       });


### PR DESCRIPTION
Small fix to correctly pass back RPC errors to the caller - this fixes some minor issues where we were not returning error codes correctly (eg, returning error 500 instead of 404 on job logs, etc).  Also adds a couple of tests to catch those scenarios.
 
Signed-off-by: Salim Alam <salam@chef.io>

![tenor-14598103](https://user-images.githubusercontent.com/13542112/48517837-72f22400-e81c-11e8-8371-d67ed4707a47.gif)
