### PR TITLE
Update packages view to only show distinct rows

### DIFF
--- a/components/builder-db/src/migrations/2018-11-15-202231_update_packages_list/up.sql
+++ b/components/builder-db/src/migrations/2018-11-15-202231_update_packages_list/up.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE VIEW packages_with_channel_platform AS
+    SELECT DISTINCT
+        op.id,
+        op.owner_id,
+        op.name,
+        op.ident,
+        op.ident_array,
+        op.checksum,
+        op.manifest,
+        op.config,
+        op.target,
+        op.deps,
+        op.tdeps,
+        op.exposes,
+        op.visibility,
+        op.created_at,
+        op.updated_at,
+        op.origin,
+        array_agg(oc.name) OVER w AS channels,
+        array_agg(op.target) OVER w AS platforms
+    FROM origin_packages op
+    INNER JOIN origin_channel_packages AS ocp ON op.id = ocp.package_id
+    INNER JOIN origin_channels AS oc ON oc.id = ocp.channel_id
+    WINDOW w AS (PARTITION BY op.ident);

--- a/test/builder-api/src/channels.js
+++ b/test/builder-api/src/channels.js
@@ -151,6 +151,31 @@ describe('Channels API', function () {
         });
     });
 
+    it('returns all packages with the specified name and version', function (done) {
+      request.get('/depot/pkgs/neurosis/testapp/0.1.3')
+        .set('Authorization', global.boboBearer)
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.range_start).to.equal(0);
+          expect(res.body.range_end).to.equal(1);
+          expect(res.body.total_count).to.equal(2);
+          expect(res.body.data.length).to.equal(2);
+          expect(res.body.data[0].origin).to.equal('neurosis');
+          expect(res.body.data[0].name).to.equal('testapp');
+          expect(res.body.data[0].version).to.equal('0.1.3');
+          expect(res.body.data[0].release).to.equal('20171206004121');
+          expect(res.body.data[1].platforms[0]).to.equal('x86_64-linux');
+          expect(res.body.data[1].origin).to.equal('neurosis');
+          expect(res.body.data[1].name).to.equal('testapp');
+          expect(res.body.data[1].version).to.equal('0.1.3');
+          expect(res.body.data[1].release).to.equal('20171205003213');
+          expect(res.body.data[1].platforms[0]).to.equal('x86_64-linux');
+          done(err);
+        });
+    });
+
     it('returns the package with the given name, version and release in a channel', function (done) {
       request.get('/depot/channels/neurosis/foo/pkgs/testapp/0.1.3/20171205003213')
         .type('application/json')


### PR DESCRIPTION
This fixes an issue where we are showing multiple versions of the same package in the UI. The root cause is duplicate rows in the packages view, which is resolved by updating the view defn.  A new test is added to catch this scenario in the future.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-244413307](https://user-images.githubusercontent.com/13542112/48579785-4ef11a00-e8d2-11e8-995f-487298c3b167.gif)

