### PR TITLE
More perf tuning

### DIFF
--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -546,6 +546,9 @@ fn do_get_channel_package(
     };
 
     let mut pkg_json = serde_json::to_value(pkg.clone()).unwrap();
+    let channels = channels_for_package_ident(req, &pkg.ident.clone())?;
+
+    pkg_json["channels"] = json!(channels);
     pkg_json["is_a_service"] = json!(pkg.is_a_service());
 
     let json_body = serde_json::to_string(&pkg_json).unwrap();

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -53,6 +53,7 @@ use server::feat;
 use server::framework::headers;
 use server::framework::middleware::route_message;
 use server::helpers::{self, Pagination, Target};
+use server::resources::channels::channels_for_package_ident;
 use server::services::metrics::Counter;
 use server::AppState;
 
@@ -1093,6 +1094,9 @@ fn do_get_package(
     };
 
     let mut pkg_json = serde_json::to_value(pkg.clone()).unwrap();
+    let channels = channels_for_package_ident(req, &pkg.ident.clone())?;
+
+    pkg_json["channels"] = json!(channels);
     pkg_json["is_a_service"] = json!(pkg.is_a_service());
 
     let json_body = serde_json::to_string(&pkg_json).unwrap();

--- a/components/builder-db/src/metrics.rs
+++ b/components/builder-db/src/metrics.rs
@@ -31,3 +31,17 @@ impl metrics::Metric for Counter {
         }
     }
 }
+
+pub enum Histogram {
+    DbCallTime,
+}
+
+impl metrics::HistogramMetric for Histogram {}
+
+impl metrics::Metric for Histogram {
+    fn id(&self) -> Cow<'static, str> {
+        match *self {
+            Histogram::DbCallTime => "db-call.call-time".into(),
+        }
+    }
+}

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -258,11 +258,11 @@ impl Package {
         ident: BuilderPackageIdent,
         visibility: Vec<PackageVisibility>,
         conn: &PgConnection,
-    ) -> QueryResult<PackageWithChannelPlatform> {
+    ) -> QueryResult<Package> {
         Counter::DBCall.increment();
-        packages_with_channel_platform::table
-            .filter(packages_with_channel_platform::ident.eq(ident))
-            .filter(packages_with_channel_platform::visibility.eq(any(visibility)))
+        Self::all()
+            .filter(origin_packages::ident.eq(ident))
+            .filter(origin_packages::visibility.eq(any(visibility)))
             .get_result(conn)
     }
 
@@ -285,16 +285,13 @@ impl Package {
             .get_results(conn)
     }
 
-    pub fn get_latest(
-        req: GetLatestPackage,
-        conn: &PgConnection,
-    ) -> QueryResult<PackageWithChannelPlatform> {
+    pub fn get_latest(req: GetLatestPackage, conn: &PgConnection) -> QueryResult<Package> {
         Counter::DBCall.increment();
-        packages_with_channel_platform::table
-            .filter(packages_with_channel_platform::ident_array.contains(req.ident.parts()))
-            .filter(packages_with_channel_platform::target.eq(req.target))
-            .filter(packages_with_channel_platform::visibility.eq(any(req.visibility)))
-            .order(sql::<PackageWithChannelPlatform>(
+        Self::all()
+            .filter(origin_packages::ident_array.contains(req.ident.parts()))
+            .filter(origin_packages::target.eq(req.target))
+            .filter(origin_packages::visibility.eq(any(req.visibility)))
+            .order(sql::<Package>(
                 "to_semver(ident_array[3]) desc, ident_array[4] desc",
             )).limit(1)
             .get_result(conn)

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -7,6 +7,8 @@ use protobuf;
 use protocol::originsrv::{OriginPackage, OriginPackageIdent, OriginPackageVisibility};
 
 use chrono::NaiveDateTime;
+use time::PreciseTime;
+
 use diesel;
 use diesel::deserialize::{self, FromSql};
 use diesel::dsl::sql;
@@ -30,8 +32,8 @@ use schema::channel::{origin_channel_packages, origin_channels};
 use schema::origin::origins;
 use schema::package::{origin_package_versions, origin_packages, packages_with_channel_platform};
 
-use bldr_core::metrics::CounterMetric;
-use metrics::Counter;
+use bldr_core::metrics::{CounterMetric, HistogramMetric};
+use metrics::{Counter, Histogram};
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable, Clone, Identifiable)]
 #[table_name = "origin_packages"]
@@ -287,14 +289,25 @@ impl Package {
 
     pub fn get_latest(req: GetLatestPackage, conn: &PgConnection) -> QueryResult<Package> {
         Counter::DBCall.increment();
-        Self::all()
+        let start_time = PreciseTime::now();
+
+        let result = Self::all()
             .filter(origin_packages::ident_array.contains(req.ident.parts()))
             .filter(origin_packages::target.eq(req.target))
             .filter(origin_packages::visibility.eq(any(req.visibility)))
             .order(sql::<Package>(
                 "to_semver(ident_array[3]) desc, ident_array[4] desc",
             )).limit(1)
-            .get_result(conn)
+            .get_result(conn);
+
+        let end_time = PreciseTime::now();
+        trace!(
+            "DBCall package::get_latest time: {} ms",
+            start_time.to(end_time).num_milliseconds()
+        );
+        Histogram::DbCallTime.set(start_time.to(end_time).num_milliseconds() as f64);
+
+        result
     }
 
     pub fn create(package: NewPackage, conn: &PgConnection) -> QueryResult<Package> {


### PR DESCRIPTION
With this PR we go back to using the regular package table instead of the combined package-channels-platform view for the latest package calls due to the perf penalty on the view.  This change also adds a new metric to start tracking DB call times.

![tenor-56030929](https://user-images.githubusercontent.com/13542112/48637804-9edbe980-e983-11e8-9ef4-96dd29b906aa.gif)
