### PR TITLE
Memcache related bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "openssl 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_s3 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -39,6 +39,7 @@ serde_json = "*"
 sha2 = "*"
 toml = { version = "*", default-features = false }
 futures = "0.1"
+rand = "*"
 r2d2 = "*"
 regex = "*"
 rusoto_core = "0.32.0"

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -42,6 +42,7 @@ extern crate log;
 extern crate oauth_client;
 extern crate openssl;
 extern crate protobuf;
+extern crate rand;
 extern crate segment_api_client;
 extern crate serde;
 #[macro_use]

--- a/components/builder-api/src/server/services/memcache.rs
+++ b/components/builder-api/src/server/services/memcache.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::SystemTime;
-
 use config::MemcacheCfg;
 use hab_core::package::PackageIdent;
 use memcache;
 use protobuf;
 use protobuf::Message;
 use protocol::originsrv::Session;
+use rand::{self, Rng};
 use sha2::{Digest, Sha512};
 use time::PreciseTime;
 
@@ -220,13 +219,11 @@ impl MemcacheClient {
     }
 
     fn reset_namespace(&mut self, namespace_key: &str) -> String {
-        let epoch = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        self.cli.set(namespace_key, epoch, self.ttl * 60).unwrap();
-        self.cli.flush().unwrap();
-        format!("{}", epoch)
+        let mut rng = rand::thread_rng();
+        let val: u64 = rng.gen();
+        trace!("Reset namespace {} to {}", namespace_key, val);
+        self.cli.set(namespace_key, val, self.ttl * 60).unwrap();
+        format!("{}", val)
     }
 
     // These are to make the compiler happy


### PR DESCRIPTION
A trio of memcache related bug fixes : 1) we now use a random 64-bit number instead of epoch time seconds as a namespace key 2) no longer incorrectly flush memcache on namespace reset 3) fix json deserialization for package fetch

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-92173484](https://user-images.githubusercontent.com/13542112/48649928-1e2fe400-e9a9-11e8-94b8-b9a55acd0e70.gif)
