### PR TITLE
Sort version list using semver

### DIFF
--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -434,7 +434,7 @@ impl Package {
             .filter(origin_package_versions::origin.eq(ident.origin()))
             .filter(origin_package_versions::name.eq(ident.name()))
             .filter(origin_package_versions::visibility.eq(any(visibility)))
-            .order(origin_package_versions::version.desc())
+            .order(sql::<OriginPackageVersions>("to_semver(version) desc"))
             .get_results(conn)
     }
 


### PR DESCRIPTION
Version sorting is broken - we need to use semver instead of lexicographic sort.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-180266693](https://user-images.githubusercontent.com/13542112/48652867-9a7cf400-e9b6-11e8-8e8d-1cf7f150b25b.gif)
