### PR TITLE
Increase open file limit for builder-api

### DIFF
--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -66,6 +66,13 @@ resource "aws_security_group" "gateway" {
     ]
   }
 
+  ingress {
+    from_port = 11211
+    to_port   = 11211
+    protocol  = "tcp"
+    self      = true
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/templates/hab-sup.service
+++ b/terraform/templates/hab-sup.service
@@ -7,6 +7,7 @@ Environment=HAB_STATS_ADDR=localhost:8125
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem"
 ExecStart=/bin/hab run ${flags}
 KillMode=process
+LimitNOFILE=65535
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This update increases the open file limit settings in order to allow builder-api to run at higher handler counts without running into the "too many open files" error.  Also adds a security group to allow memcache instances to communicate.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-44824159](https://user-images.githubusercontent.com/13542112/49042596-77540080-f17d-11e8-9eed-0de809a0d64b.gif)
