### PR TITLE
Only route to single upstream

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -86,9 +86,7 @@ http {
                    '"$http_referer" "$http_user_agent" - $http_x_forwarded_for';
 
   upstream backend {
-    {{#each bind.http.members as |member| ~}}
-    server {{member.sys.ip}}:{{member.cfg.port}};
-    {{/each ~}}
+    server {{sys.ip}}:{{bind.http.first.cfg.port}};
     keepalive {{cfg.http.keepalive_connections}};
   }
 


### PR DESCRIPTION
We had inadvertently changed the nginx config to add all the builder-api nodes as upstream servers. That is not correct for our current topology which installs nginx on each api node. This change reverts us back to having a single upstream (with a small change to always use the system IP instead of the bind IP).

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-9463675](https://user-images.githubusercontent.com/13542112/49115716-6c1dd500-f250-11e8-8294-528d222278fa.gif)
