### PR TITLE
Jobs schema migration start

### DIFF
--- a/components/builder-db/src/models/jobs.rs
+++ b/components/builder-db/src/models/jobs.rs
@@ -1,0 +1,135 @@
+use super::db_id_format;
+use chrono::prelude::*;
+use diesel::pg::PgConnection;
+use diesel::result::QueryResult;
+use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use protobuf::ProtobufEnum;
+
+use protocol::jobsrv;
+use protocol::net;
+use protocol::originsrv;
+
+use schema::jobs::jobs;
+
+use bldr_core::metrics::CounterMetric;
+use metrics::Counter;
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
+#[table_name = "jobs"]
+pub struct Job {
+    #[serde(with = "db_id_format")]
+    pub id: i64,
+    #[serde(with = "db_id_format")]
+    pub owner_id: i64,
+    pub job_state: String,
+    #[serde(with = "db_id_format")]
+    pub project_id: i64,
+    pub project_name: String,
+    #[serde(with = "db_id_format")]
+    pub project_owner_id: i64,
+    pub project_plan_path: String,
+    pub vcs: String,
+    pub vcs_arguments: Vec<String>,
+    pub net_error_code: i32,
+    pub net_error_msg: Option<String>,
+    pub scheduler_sync: bool,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub build_started_at: Option<DateTime<Utc>>,
+    pub build_finished_at: Option<DateTime<Utc>>,
+    pub package_ident: Option<String>,
+    pub archived: bool,
+    pub channel: Option<String>,
+    pub sync_count: i32,
+    pub worker: Option<String>,
+}
+
+impl Job {
+    pub fn get(id: i64, conn: &PgConnection) -> QueryResult<Job> {
+        Counter::DBCall.increment();
+        jobs::table.filter(jobs::id.eq(id)).get_result(conn)
+    }
+}
+
+impl Into<jobsrv::Job> for Job {
+    fn into(self) -> jobsrv::Job {
+        let mut job = jobsrv::Job::new();
+        job.set_id(self.id as u64);
+        job.set_owner_id(self.owner_id as u64);
+
+        let job_state: jobsrv::JobState = self.job_state.parse().unwrap();
+        job.set_state(job_state);
+
+        job.set_created_at(self.created_at.unwrap().to_rfc3339());
+
+        // Note: these may be null (e.g., a job is scheduled, but hasn't
+        // started; a job has started and is currently running)
+        if let Some(start) = self.build_started_at {
+            job.set_build_started_at(start.to_rfc3339());
+        }
+        if let Some(stop) = self.build_finished_at {
+            job.set_build_finished_at(stop.to_rfc3339());
+        }
+
+        // package_ident will only be present if the build succeeded
+        if let Some(ident_str) = self.package_ident {
+            let ident: originsrv::OriginPackageIdent = ident_str.parse().unwrap();
+            job.set_package_ident(ident);
+        }
+
+        let mut project = originsrv::OriginProject::new();
+        project.set_id(self.project_id as u64);
+
+        // only 'project_name' exists in the jobs table, but it's just
+        // "origin/name", so we can set those fields in the Project
+        // struct.
+        //
+        // 'package_ident' may be null, though, so we shouldn't use it to
+        // get the origin and name.
+        let name = self.project_name.clone();
+        let name_for_split = self.project_name.clone();
+        let name_split: Vec<&str> = name_for_split.split("/").collect();
+        project.set_origin_name(name_split[0].to_string());
+        project.set_package_name(name_split[1].to_string());
+        project.set_name(name);
+
+        project.set_owner_id(self.project_owner_id as u64);
+        project.set_plan_path(self.project_plan_path.clone());
+
+        match self.vcs.as_ref() {
+            "git" => {
+                let mut vcsa: Vec<String> = self.vcs_arguments;
+                project.set_vcs_type(String::from("git"));
+                project.set_vcs_data(vcsa.remove(0));
+                if vcsa.len() > 0 {
+                    let install_id = vcsa.remove(0);
+                    project.set_vcs_installation_id(install_id.parse::<u32>().unwrap());
+                }
+            }
+            e => error!("Unknown VCS, {}", e),
+        }
+        job.set_project(project);
+
+        if let Some(err_msg) = self.net_error_msg {
+            let mut err = net::NetError::new();
+
+            if let Some(net_err_code) = net::ErrCode::from_i32(self.net_error_code) {
+                err.set_code(net_err_code);
+                err.set_msg(err_msg);
+                job.set_error(err);
+            }
+        }
+
+        job.set_is_archived(self.archived);
+
+        if let Some(channel) = self.channel {
+            job.set_channel(channel);
+        };
+
+        if let Some(worker) = self.worker {
+            job.set_worker(worker);
+        };
+
+        job
+    }
+}

--- a/components/builder-db/src/models/mod.rs
+++ b/components/builder-db/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod account;
 pub mod channel;
 pub mod integration;
 pub mod invitations;
+pub mod jobs;
 pub mod keys;
 pub mod origin;
 pub mod package;

--- a/components/builder-db/src/schema/jobs.rs
+++ b/components/builder-db/src/schema/jobs.rs
@@ -1,0 +1,66 @@
+table! {
+    use diesel::sql_types::{Bool, Array, Integer, BigInt, Text, Nullable, Timestamptz};
+
+    jobs (id) {
+        id -> BigInt,
+        owner_id -> BigInt,
+        job_state -> Text,
+        project_id -> BigInt,
+        project_name -> Text,
+        project_owner_id -> BigInt,
+        project_plan_path -> Text,
+        vcs -> Text,
+        vcs_arguments-> Array<Text>,
+        net_error_code -> Integer,
+        net_error_msg -> Nullable<Text>,
+        scheduler_sync -> Bool,
+        created_at -> Nullable<Timestamptz>,
+        updated_at -> Nullable<Timestamptz>,
+        build_started_at -> Nullable<Timestamptz>,
+        build_finished_at -> Nullable<Timestamptz>,
+        package_ident -> Nullable<Text>,
+        archived -> Bool,
+        channel -> Nullable<Text>,
+        sync_count -> Integer,
+        worker -> Nullable<Text>,
+    }
+}
+
+table! {
+    use diesel::sql_types::{BigInt, Text, Nullable, Timestamptz};
+
+    groups (id) {
+        id -> BigInt,
+        group_state -> Text,
+        project_name -> Text,
+        created_at -> Nullable<Timestamptz>,
+        updated_at -> Nullable<Timestamptz>,
+    }
+}
+
+table! {
+    use diesel::sql_types::{BigInt, Text, Nullable, Timestamptz};
+
+    group_projects (id) {
+        id -> BigInt,
+        owner_id -> BigInt,
+        project_name -> Text,
+        project_ident -> Text,
+        project_state -> Text,
+        job_id -> BigInt,
+        created_at -> Nullable<Timestamptz>,
+        updated_at -> Nullable<Timestamptz>,
+    }
+}
+
+table! {
+    use diesel::sql_types::{BigInt, Bool, Text, Nullable, Timestamptz};
+
+    busy_workers(ident, job_id) {
+        ident -> Text,
+        job_id -> BigInt,
+        quarantined -> Bool,
+        created_at -> Nullable<Timestamptz>,
+        updated_at -> Nullable<Timestamptz>,
+    }
+}

--- a/components/builder-db/src/schema/jobs.rs
+++ b/components/builder-db/src/schema/jobs.rs
@@ -11,7 +11,7 @@ table! {
         project_plan_path -> Text,
         vcs -> Text,
         vcs_arguments-> Array<Text>,
-        net_error_code -> Integer,
+        net_error_code -> Nullable<Integer>,
         net_error_msg -> Nullable<Text>,
         scheduler_sync -> Bool,
         created_at -> Nullable<Timestamptz>,

--- a/components/builder-db/src/schema/mod.rs
+++ b/components/builder-db/src/schema/mod.rs
@@ -7,6 +7,7 @@ pub mod audit;
 pub mod channel;
 pub mod integration;
 pub mod invitation;
+pub mod jobs;
 pub mod key;
 pub mod member;
 pub mod origin;

--- a/components/builder-jobsrv/src/error.rs
+++ b/components/builder-jobsrv/src/error.rs
@@ -77,7 +77,6 @@ pub enum Error {
     LogDirNotWritable(PathBuf),
     NotFound,
     ParseVCSInstallationId(num::ParseIntError),
-    ProjectJobsGet(postgres::error::Error),
     Protobuf(protobuf::ProtobufError),
     Protocol(protocol::ProtocolError),
     System,
@@ -176,9 +175,6 @@ impl fmt::Display for Error {
             }
             Error::Protobuf(ref e) => format!("{}", e),
             Error::Protocol(ref e) => format!("{}", e),
-            Error::ProjectJobsGet(ref e) => {
-                format!("Database error getting jobs for project, {}", e)
-            }
             Error::System => "Internal error".to_string(),
             Error::UnknownJobGroup => format!("Unknown Group"),
             Error::UnknownJobGroupState => format!("Unknown Group State"),
@@ -236,7 +232,6 @@ impl error::Error for Error {
             Error::LogDirNotWritable(_) => "Build log directory is not writable",
             Error::NotFound => "Entity not found",
             Error::ParseVCSInstallationId(_) => "VCS installation id could not be parsed as u64",
-            Error::ProjectJobsGet(ref err) => err.description(),
             Error::Protobuf(ref err) => err.description(),
             Error::Protocol(ref err) => err.description(),
             Error::System => "Internal error",

--- a/components/builder-jobsrv/src/server/handlers.rs
+++ b/components/builder-jobsrv/src/server/handlers.rs
@@ -50,21 +50,6 @@ pub fn job_get(req: &RpcMessage, state: &AppState) -> Result<RpcMessage> {
     }
 }
 
-pub fn project_jobs_get(req: &RpcMessage, state: &AppState) -> Result<RpcMessage> {
-    let msg = req.parse::<jobsrv::ProjectJobsGet>()?;
-    match state.datastore.get_jobs_for_project(&msg) {
-        Ok(ref jobs) => {
-            // NOTE: Currently no difference between "project has no jobs" and "no
-            // such project"
-            RpcMessage::make(jobs).map_err(Error::BuilderCore)
-        }
-        Err(e) => {
-            warn!("project_jobs_get error: {:?}", e);
-            Err(Error::System)
-        }
-    }
-}
-
 pub fn job_log_get(req: &RpcMessage, state: &AppState) -> Result<RpcMessage> {
     let msg = req.parse::<jobsrv::JobLogGet>()?;
     let mut get = jobsrv::JobGet::new();

--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -81,7 +81,6 @@ fn handle_rpc((req, msg): (HttpRequest<AppState>, Json<RpcMessage>)) -> HttpResp
 
     let result = match msg.id.as_str() {
         "JobGet" => handlers::job_get(&msg, req.state()),
-        "ProjectJobsGet" => handlers::project_jobs_get(&msg, req.state()),
         "JobLogGet" => handlers::job_log_get(&msg, req.state()),
         "JobGroupSpec" => handlers::job_group_create(&msg, req.state()),
         "JobGroupCancel" => handlers::job_group_cancel(&msg, req.state()),

--- a/components/builder-protocol/protocols/jobsrv.proto
+++ b/components/builder-protocol/protocols/jobsrv.proto
@@ -77,19 +77,6 @@ message JobSpec {
   optional string channel = 3;
 }
 
-message ProjectJobsGet {
-  optional string name = 1;
-  optional uint64 start = 2;
-  optional uint64 stop = 3;
-}
-
-message ProjectJobsGetResponse {
-  repeated Job jobs = 1;
-  optional uint64 start = 2;
-  optional uint64 stop = 3;
-  optional uint64 count = 4;
-}
-
 message JobLogChunk {
   optional uint64 job_id = 1;
   optional uint64 seq = 2; // Chunk ordering (line number)

--- a/components/builder-protocol/src/jobsrv.rs
+++ b/components/builder-protocol/src/jobsrv.rs
@@ -18,7 +18,6 @@ use std::str::FromStr;
 
 use message::originsrv::OriginPackage;
 use message::{Persistable, Routable};
-use originsrv::Pageable;
 use protobuf::RepeatedField;
 use regex::Regex;
 use serde::ser::SerializeStruct;
@@ -72,25 +71,6 @@ impl Routable for Job {
 
     fn route_key(&self) -> Option<Self::H> {
         Some(InstaId(self.get_id()))
-    }
-}
-
-// Note: Given that we only run a single JobServer, the specific
-// routing key for this message isn't really important (everything is
-// going to route to the same, single place anyway). If we ever do run
-// multiple JobServers, though, this may need to be revisited (as will
-// other corners of the code).
-impl Routable for ProjectJobsGet {
-    type H = String;
-
-    fn route_key(&self) -> Option<Self::H> {
-        Some(self.get_name().to_string())
-    }
-}
-
-impl Pageable for ProjectJobsGet {
-    fn get_range(&self) -> [u64; 2] {
-        [self.get_start(), self.get_stop()]
     }
 }
 
@@ -152,17 +132,6 @@ impl Serialize for Job {
             strukt.serialize_field("channel", self.get_channel())?;
         }
 
-        strukt.end()
-    }
-}
-
-impl Serialize for ProjectJobsGetResponse {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut strukt = serializer.serialize_struct("project_jobs_get_response", 1)?;
-        strukt.serialize_field("jobs", self.get_jobs())?;
         strukt.end()
     }
 }


### PR DESCRIPTION
Initial job schema migration - this PR creates the jobs schema, and migrates a couple of calls over to use direct to DB instead of RPC calls.

![tenor-227495175](https://user-images.githubusercontent.com/13542112/49554265-4af06080-f8b0-11e8-9f54-00826dcbea63.gif)
