### PR TITLE
Use the IP address of API service, not my sys.ip in backend block

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -86,9 +86,13 @@ http {
                    '"$http_referer" "$http_user_agent" - $http_x_forwarded_for';
 
   upstream backend {
+    {{~#if cfg.load_balanced}}
     {{~#each bind.http.members as |member|}}
     server {{member.sys.ip}}:{{member.cfg.port}};
     {{~/each}}
+    {{~else}}
+    server {{sys.ip}}:{{bind.http.first.cfg.port}};
+    {{~/if}}
     keepalive {{cfg.http.keepalive_connections}};
   }
 

--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -86,7 +86,9 @@ http {
                    '"$http_referer" "$http_user_agent" - $http_x_forwarded_for';
 
   upstream backend {
-    server {{sys.ip}}:{{bind.http.first.cfg.port}};
+    {{~#each bind.http.members as |member|}}
+    server {{member.sys.ip}}:{{member.cfg.port}};
+    {{~/each}}
     keepalive {{cfg.http.keepalive_connections}};
   }
 

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -13,6 +13,11 @@ status_url                = "https://status.habitat.sh/"
 tutorials_url             = "https://www.habitat.sh/learn"
 use_gravatar              = true
 www_url                   = "https://www.habitat.sh"
+# How we connect to the proxied backend API service.
+#   When true, connect to all backend API services via their IPs provided
+#   via the bind
+#   By default (load_balanced=false) we connect to a single backend on the same `sys.ip` as this service
+load_balanced             = false
 
 [analytics]
 company_id                = ""


### PR DESCRIPTION
This allows the builder api and api-proxy services to be different hosts (or containers/pods)

Signed-off-by: James Casey <james@chef.io>