### PR TITLE
Allow log level for API to be configured

### DIFF
--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -1,3 +1,5 @@
+log_level = "{{cfg.log_level}}"
+
 [api]
 data_path = "{{pkg.svc_data_path}}"
 log_path = "{{pkg.svc_var_path}}"


### PR DESCRIPTION
While we allow for log_level in `default.toml` it wasn't wired through into the `config.conf` file

Signed-off-by: James Casey <james@chef.io>