### PR TITLE
Allow setting of datastore superuser password via config

### DIFF
--- a/components/builder-datastore/default.toml
+++ b/components/builder-datastore/default.toml
@@ -214,3 +214,5 @@ restart_after_crash = "on"
 
 [init]
 encoding = "UTF8"
+# If this isn't set, the package will create a random password at startup
+superuser_password = ""

--- a/components/builder-datastore/hooks/init
+++ b/components/builder-datastore/hooks/init
@@ -14,7 +14,11 @@ touch $RANDFILE
 
 if [ ! -f "{{pkg.svc_data_path}}/PG_VERSION" ]; then
   echo " Database does not exist, creating with 'initdb'"
-  openssl rand -base64 32 > {{pkg.svc_config_path}}/pwfile
+  if [ -z "{{cfg.init.superuser_password}}" ]; then
+    openssl rand -base64 32 > {{pkg.svc_config_path}}/pwfile
+  else
+    echo "{{cfg.init.superuser_password}}" > {{pkg.svc_config_path}}/pwfile
+  fi
   initdb -U hab \
          -E {{cfg.init.encoding}} \
          -D {{pkg.svc_data_path}} \


### PR DESCRIPTION
In a container based deployment scenario you need to set the password
externally so you can pass it to all containers that need it. This
enables that while maintaining the existing behaviour as the default.

Signed-off-by: James Casey <james@chef.io>