### PR TITLE
Testing Travis CI runs when new PR is created

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# Test Travis CI build is triggered by PR
 branches:
   only:
     - master


### PR DESCRIPTION
Just a test of Travis/GitHub integration since it's not working on the `habitat` repo for https://github.com/habitat-sh/habitat/pull/6041 or https://github.com/habitat-sh/habitat/pull/6042.