### PR TITLE
Flag to disable/enable ipv6 binding

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -93,7 +93,9 @@ http {
   {{~#if cfg.server.listen_tls}}
   server {
     listen       *:{{cfg.server.listen_port}};
+    {{~#if cfg.nginx.enable_ipv6}}
     listen       [::]:{{cfg.server.listen_port}};
+    {{~/if}}
     server_name  {{sys.hostname}};
     return       308 https://$host$request_uri;
   }
@@ -112,7 +114,9 @@ http {
 
     {{~#if cfg.server.listen_tls}}
     listen                    *:{{cfg.server.listen_tls_port}} ssl;
+    {{~#if cfg.nginx.enable_ipv6}}
     listen                    [::]:{{cfg.server.listen_tls_port}} ssl;
+    {{~/if}}
     ssl_certificate           {{pkg.svc_files_path}}/{{cfg.server.cert_file}};
     ssl_certificate_key       {{pkg.svc_files_path}}/{{cfg.server.cert_key_file}};
     ssl_protocols             {{cfg.server.ssl_protocols}};
@@ -122,7 +126,9 @@ http {
     ssl_session_timeout       {{cfg.server.ssl_session_timeout}};
     {{~else}}
     listen                    *:{{cfg.server.listen_port}};
+    {{~#if cfg.nginx.enable_ipv6}}
     listen                    [::]:{{cfg.server.listen_port}};
+    {{~/if}}
     {{~/if}}
 
     if ($http_x_forwarded_proto = "http") {

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -49,6 +49,7 @@ limit_ua_known            = "hab|builder|Chef|Mozilla|Github"
 limit_ua_unknown_target   = "$http_x_forwarded_for"
 enable_caching            = false
 enable_gzip               = false
+enable_ipv6               = true
 
 [http]
 keepalive_connections     = 16


### PR DESCRIPTION
This flag `enable_ipv6` allows service providers to provision bldr on
hosts that do not support ipv6.  By default, bldr will attempt to bind
to ipv6.

closes #875

Signed-off-by: Ben Dang <me@bdang.it>