### PR TITLE
Windows builder-worker enablement

### DIFF
--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -1,7 +1,7 @@
 auto_publish = {{cfg.auto_publish}}
-data_path = "{{pkg.svc_data_path}}"
-key_dir = "{{pkg.svc_files_path}}"
-log_path = "{{pkg.svc_path}}/logs"
+data_path = '{{pkg.svc_data_path}}'
+key_dir = '{{pkg.svc_files_path}}'
+log_path = '{{pkg.svc_path}}/logs'
 bldr_channel = "{{cfg.bldr_channel}}"
 features_enabled = "{{cfg.features_enabled}}"
 {{~#eachAlive bind.depot.members as |member|}}
@@ -18,7 +18,7 @@ network_gateway = "{{cfg.network_gateway}}"
 {{~/if}}
 
 [github]
-app_private_key = "{{pkg.svc_files_path}}/builder-github-app.pem"
+app_private_key = '{{pkg.svc_files_path}}/builder-github-app.pem'
 {{toToml cfg.github}}
 
 {{~#eachAlive bind.jobsrv.members as |member|}}

--- a/components/builder-worker/habitat/default.toml
+++ b/components/builder-worker/habitat/default.toml
@@ -3,7 +3,7 @@ auto_publish = true
 bldr_channel = "unstable"
 bldr_url = "https://bldr.habitat.sh"
 features_enabled = ""
-airlock_enabled = true
+airlock_enabled = false
 recreate_ns_dir = false
 
 [github]

--- a/components/builder-worker/habitat/hooks/run.ps1
+++ b/components/builder-worker/habitat/hooks/run.ps1
@@ -1,0 +1,14 @@
+$env:HOME = "{{pkg.svc_data_path}}"
+$env:RUST_LOG = "{{cfg.log_level}}"
+$env:RUST_BACKTRACE = 1
+
+# Wait for pem file before starting the service
+while (!(Test-Path -Path "{{pkg.svc_files_path}}/builder-github-app.pem")) {
+    Write-Host "Waiting for builder-github-app.pem"
+    Start-Sleep -Seconds 30
+}
+
+Write-Host "Starting builder-worker, parent process environment:"
+gci env:
+
+bldr-worker start -c "{{pkg.svc_config_path}}/config.toml"

--- a/components/builder-worker/habitat/plan.ps1
+++ b/components/builder-worker/habitat/plan.ps1
@@ -1,0 +1,94 @@
+$pkg_name = "builder-worker"
+$pkg_origin = "habitat"
+$pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license = @("Apache-2.0")
+$pkg_deps = @(
+    "core/openssl",
+    "core/zeromq",
+    "core/zlib",
+    "core/libarchive",
+    "core/libsodium",
+    "core/hab-studio",
+    "core/hab-pkg-export-docker",
+    "core/docker"
+)
+$pkg_bin_dirs = @("bin")
+$pkg_build_deps = @(
+    "core/visual-cpp-build-tools-2015",
+    "core/protobuf",
+    "core/rust",
+    "core/cacerts",
+    "core/git"
+)
+$pkg_binds = @{
+    jobsrv = "worker_port worker_heartbeat log_port"
+    depot  = "url"
+}
+$bin = "bldr-worker"
+
+function pkg_version {
+    # TED: After migrating the builder repo we needed to add to
+    # the rev-count to keep version sorting working
+    5000 + (git rev-list master --count)
+}
+
+function Invoke-Before {
+    Invoke-DefaultBefore
+    Set-PkgVersion
+}
+
+function Invoke-Prepare {
+    if ($env:HAB_CARGO_TARGET_DIR) {
+        $env:CARGO_TARGET_DIR = "$env:HAB_CARGO_TARGET_DIR"
+    }
+    else {
+        $env:CARGO_TARGET_DIR = "$env:HAB_CACHE_SRC_PATH/$pkg_dirname"
+    }
+
+    $env:SSL_CERT_FILE = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
+    $env:LIB += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
+    $env:INCLUDE += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+    $env:SODIUM_LIB_DIR = "$(Get-HabPackagePath "libsodium")/lib"
+    $env:LIBARCHIVE_INCLUDE_DIR = "$(Get-HabPackagePath "libarchive")/include"
+    $env:LIBARCHIVE_LIB_DIR = "$(Get-HabPackagePath "libarchive")/lib"
+    $env:OPENSSL_LIBS = 'ssleay32:libeay32'
+    $env:OPENSSL_LIB_DIR = "$(Get-HabPackagePath "openssl")/lib"
+    $env:OPENSSL_INCLUDE_DIR = "$(Get-HabPackagePath "openssl")/include"
+    $env:LIBZMQ_PREFIX = "$(Get-HabPackagePath "zeromq")"
+
+    # Used by the `build.rs` program to set the version of the binaries
+    $env:PLAN_VERSION = "$pkg_version/$pkg_release"
+    Write-BuildLine "Setting env:PLAN_VERSION=$env:PLAN_VERSION"
+
+    # Used to set the active package target for the binaries at build time
+    $env:PLAN_PACKAGE_TARGET = "$pkg_target"
+    Write-BuildLine "Setting env:PLAN_PACKAGE_TARGET=$env:PLAN_PACKAGE_TARGET"
+}
+
+function Invoke-BuildConfig {
+    Invoke-DefaultBuildConfig
+    Write-BuildLine "Copying run.ps1 to run"
+    Copy-Item "$PLAN_CONTEXT/hooks/run.ps1" "$pkg_prefix/hooks/run"
+}
+
+function Invoke-Build {
+    Push-Location "$PLAN_CONTEXT"
+    try {
+        cargo build --release --verbose
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Cargo build failed!"
+        }
+    }
+    finally { Pop-Location }
+}
+
+function Invoke-Install {
+    Write-BuildLine "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    Copy-Item "$env:CARGO_TARGET_DIR/release/bldr-worker.exe" "$pkg_prefix/bin/bldr-worker.exe"
+    Copy-Item "$(Get-HabPackagePath "openssl")/bin/*.dll" "$pkg_prefix/bin"
+    Copy-Item "$(Get-HabPackagePath "zlib")/bin/*.dll" "$pkg_prefix/bin"
+    Copy-Item "$(Get-HabPackagePath "libarchive")/bin/*.dll" "$pkg_prefix/bin"
+    Copy-Item "$(Get-HabPackagePath "libsodium")/bin/*.dll" "$pkg_prefix/bin"
+    Copy-Item "$(Get-HabPackagePath "zeromq")/bin/*.dll" "$pkg_prefix/bin"
+    Copy-Item "$(Get-HabPackagePath "visual-cpp-build-tools-2015")/Program Files/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.CRT/*.dll" "$pkg_prefix/bin"
+}

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -83,7 +83,7 @@ impl Default for Config {
             jobsrv: vec![JobSrvAddr::default()],
             features_enabled: "".to_string(),
             github: GitHubCfg::default(),
-            airlock_enabled: true,
+            airlock_enabled: false,
             recreate_ns_dir: false,
             network_interface: None,
             network_gateway: None,
@@ -126,6 +126,7 @@ mod tests {
         log_path = "/path/to/logs"
         key_dir = "/path/to/key"
         features_enabled = "FOO,BAR"
+        airlock_enabled = true
         recreate_ns_dir = true
         network_interface = "eth1"
         network_gateway = "192.168.10.1"

--- a/components/builder-worker/src/runner/util.rs
+++ b/components/builder-worker/src/runner/util.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(not(windows))]
 use std::path::Path;
+#[cfg(not(windows))]
 use std::process::Command;
 
 use serde_json::{self, Value as JsonValue};
@@ -24,6 +26,7 @@ use crate::runner::workspace::Workspace;
 // TODO fn: The horror... well, it's not that bad. There isn't a quick win for recursive chown'ing
 // a path, so we'll use the `chown` binary as provided by busybox and guarenteed by the Supervisor.
 // I'm wincing here right now, honest.
+#[cfg(not(windows))]
 pub fn chown_recursive<P: AsRef<Path>>(path: P, uid: u32, gid: u32) -> Result<()> {
     let mut cmd = Command::new("chown");
     cmd.arg("-R"); // Recursively apply ownership


### PR DESCRIPTION
This change adds a Windows plan, run hook, and updates the runner and associated infrastructure to enable a Windows version of the builder-worker package that can generate builds end-to-end.

This is a first step - the Windows studio currently only runs locally and does not support Airlock. Subsequent changes will enable further isolation. Airlock configuration is also now disabled by default.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-259918205](https://user-images.githubusercontent.com/13542112/51569547-7f64af80-1e51-11e9-9493-90929d98416e.gif)
