### PR TITLE
Make builder-minio clustered

### DIFF
--- a/components/builder-minio/README.md
+++ b/components/builder-minio/README.md
@@ -1,0 +1,13 @@
+# Overview
+
+This plans implements `builder-minio` - **AWS S3** compatible storage for the **Habitat Builder**.
+
+# Configuration
+
+All important configuration is described in the `habitat/default.toml` file and it is good practice.
+
+# Versioning
+
+Each commit produces increment version number which is good approach for the *Continues Integration*.
+
+

--- a/components/builder-minio/docker-compose.yml
+++ b/components/builder-minio/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  srv1:
+    &server-configuration
+    image: habitat/builder-minio:latest
+    command: --peer srv1
+    environment:
+      HAB_BUILDER_MINIO: |
+        standalone = false
+        members = [
+          "http://srv1/hab/svc/builder-minio/data",
+          "http://srv2/hab/svc/builder-minio/data",
+          "http://srv3/hab/svc/builder-minio/data",
+          "http://srv4/hab/svc/builder-minio/data",
+        ]
+    ports:
+      - "9000"
+  srv2:
+    *server-configuration
+  srv3:
+    *server-configuration
+  srv4:
+    *server-configuration

--- a/components/builder-minio/habitat/config/hook-helper.sh
+++ b/components/builder-minio/habitat/config/hook-helper.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# This helper optimizes minio hooks by:
+# * extracting toml variables to bash
+# * creating helper methods
+# * keeping secrets out: https://github.com/habitat-sh/habitat/issues/6076
+#
+# Expected be sourced by all hooks at very early stage
+
+standalone="{{ cfg.standalone }}"
+expected="{{ cfg.expected }}"
+use_ssl="{{ cfg.use_ssl }}"
+ssl_cert_pw="{{ cfg.ssl_cert_pw }}"
+
+# This hook is used for caching last known good configuration
+run_good_hook="{{pkg.svc_static_path}}/run-good"
+
+# This meta hook is used for restart detection
+meta_restart_hook="{{pkg.svc_config_path}}/restart-hook.txt"
+
+# For aws cli
+export AWS_ACCESS_KEY_ID="{{cfg.key_id}}"
+export AWS_SECRET_ACCESS_KEY="{{cfg.secret_key}}"
+
+# For minio server
+export MINIO_ACCESS_KEY="{{cfg.key_id}}"
+export MINIO_SECRET_KEY="{{cfg.secret_key}}"
+
+if [ -n "$ssl_cert_pw" ]; then
+    export MINIO_CERT_PASSWD="$ssl_cert_pw"
+fi
+
+# Generate Expected Members
+# {{#eachAlive svc.members as |member|}}
+svc_members="$svc_members http://{{member.sys.hostname}}{{../pkg.svc_data_path}}"
+# {{/eachAlive}}
+svc_count=$(echo "$svc_members" | wc -w)
+
+# Generate Explicit Members
+# {{#each cfg.members as |member|}}
+explicit_members="$explicit_members {{member}}"
+# {{/each}}
+explicit_count=$(echo "$explicit_members" | wc -w)
+
+# Helper methods
+
+# Can't calculate PID on the early stage, so defer it by method
+minio_pid() {
+    cat "{{pkg.svc_pid_file}}"
+}
+
+# Copy certificates from ring
+copy_certs() {
+    cert_dir="{{pkg.svc_config_path}}/certs"
+    priv_key="{{pkg.svc_files_path}}/private.key"
+    pub_key="{{pkg.svc_files_path}}/public.crt"
+
+    mkdir -p $cert_dir
+
+    cp $priv_key $cert_dir
+    cp $pub_key $cert_dir
+}
+
+# TODO: Remove or refactor this method
+# when fixed https://github.com/habitat-sh/habitat/issues/2364
+# Wait a little so minio can initialize
+minio_splay_delay() {
+    if [ "$standalone" == "true" ]; then
+        # In standalone mode more likely it starts quickly
+        sleep 1
+    else
+        sleep $((RANDOM % 5 + 5))
+    fi
+}
+
+create_bucket() {
+    if [ "$use_ssl" == "true" ]; then
+        aws_s3="aws --endpoint-url https://localhost:9000 --no-verify-ssl s3api"
+    else
+        aws_s3="aws --endpoint-url http://localhost:9000 s3api"
+    fi
+
+    if $aws_s3 list-buckets | grep "{{cfg.bucket_name}}" > /dev/null; then
+        echo "Minio bucket is up to date."
+    else
+        echo "Creating minio bucket {{cfg.bucket_name}}."
+        $aws_s3 create-bucket --bucket "{{cfg.bucket_name}}"
+    fi
+}
+
+# If something in restart-hook.txt will change then reload hook will restart service
+checksum_restart_hook() {
+    sha256sum $meta_restart_hook > $meta_restart_hook.sha256
+}
+
+check_restart_hook() {
+    sha256sum -c $meta_restart_hook.sha256 --status 2> /dev/null
+}

--- a/components/builder-minio/habitat/config/restart-hook.txt
+++ b/components/builder-minio/habitat/config/restart-hook.txt
@@ -1,0 +1,8 @@
+This meta file is used to track config changes.
+If something in this file will change then reload hook will restart service.
+We will use sha256sum for that
+=====================================================================
+{{ cfg.key_id}}
+{{ cfg.secret_key }}
+{{ cfg.use_ssl }}
+{{ cfg.ssl_cert_pw }}

--- a/components/builder-minio/habitat/default.toml
+++ b/components/builder-minio/habitat/default.toml
@@ -1,5 +1,51 @@
+# Minio must be started with static number of server/disk by design
+# so there are 3 possible ways to run minio
+
+# --= Standalone mode =--
+#
+# Best for local experiments
+standalone = true
+
+# --= Automatic cluster =--
+#
+# Best for temporary installation, integration test,
+# and when you sure hostname or ipaddress will not change.
+#
+# Just set ~expected~ number of nodes and habitat will do the rest
+# Note: If cluster view changes:
+# * Habitat will validate new view and use if valid
+# * Otherwise, habitat will use last known good configuration
+# Options is ignored when ~standalone~
+# Ignored when ~members~ is defined
+# Ignored when ~standalone~
+# Must be >= 2
+expected = 2
+
+# --= Explicit Cluster =--
+#
+# Recommended for production environments: explicitly set cluster members.
+# From minio server documentation:
+# DIR points to a directory on a filesystem. When you want to combine
+#   multiple drives into a single large system, pass one directory per
+#   filesystem separated by space. You may also use a '...' convention
+#   to abbreviate the directory arguments. Remote directories in a
+#   distributed setup are encoded as HTTP(s) URIs.
+#
+# ~members~ is a ~Array~ of DIRs
+# Ignored when standalone
+members = []
+
+# Admin Account
 key_id = "depot"
 secret_key = "password"
+
+# Enable SSL in your Minio
+# This expects certificates files loaded via ~hab file upload~ or
+# in $pkg_svc_config_path/certs: ~private.key~ and ~public.crt~
 use_ssl = false
+
+# Password for certificate
 ssl_cert_pw = ""
+
+# Default bucket name to create
 bucket_name = "habitat-builder-artifact-store.default"

--- a/components/builder-minio/habitat/hooks/post-run
+++ b/components/builder-minio/habitat/hooks/post-run
@@ -1,19 +1,15 @@
-#!/bin/sh
+#!/bin/bash
+# shellcheck disable=2154
 
 exec 2>&1
 
-export AWS_ACCESS_KEY_ID="{{cfg.key_id}}"
-export AWS_SECRET_ACCESS_KEY="{{cfg.secret_key}}"
+source "{{ pkg.svc_config_path }}/hook-helper.sh"
 
-{{ #if cfg.use_ssl }}
-MINIO_ENDPOINT="--endpoint-url https://localhost:9000 --no-verify-ssl"
-{{else ~}}
-MINIO_ENDPOINT="--endpoint-url http://localhost:9000"
-{{ /if }}
+minio_splay_delay
 
-if aws $MINIO_ENDPOINT s3api list-buckets | grep "{{cfg.bucket_name}}" > /dev/null; then
-  echo "Minio already configured"
-else
-  echo "Creating bucket in Minio"
-  aws  $MINIO_ENDPOINT s3api create-bucket --bucket "{{cfg.bucket_name}}"
+if [ "$standalone" != "true" ] && [ ! -f "$run_good_hook" ]; then
+    echo "Minio is not ready for bucket configuring. May be later"
+    exit 1
 fi
+
+create_bucket

--- a/components/builder-minio/habitat/hooks/reconfigure
+++ b/components/builder-minio/habitat/hooks/reconfigure
@@ -5,6 +5,10 @@ exec 2>&1
 
 source "{{ pkg.svc_config_path }}/hook-helper.sh"
 
+minio_splay_delay
+
 if [ "$use_ssl" == "true" ]; then
     copy_certs
 fi
+
+create_bucket

--- a/components/builder-minio/habitat/hooks/reload
+++ b/components/builder-minio/habitat/hooks/reload
@@ -1,0 +1,30 @@
+#!/bin/bash
+# shellcheck disable=2154
+
+exec 2>&1
+
+source "{{ pkg.svc_config_path }}/hook-helper.sh"
+
+minio_pid=$(minio_pid)
+
+if check_restart_hook; then
+    echo "Settings are up to date."
+else
+    echo "Restart is required."
+    kill "$minio_pid"
+    sleep 1
+    exit 0
+fi
+
+if [ "$standalone" == "true" ]; then
+    exit 0
+fi
+
+if [ ! -f "$run_good_hook" ]; then
+    echo "Cluster is not configured yet. Restart is required."
+    kill "$minio_pid"
+    sleep 1
+    exit 0
+fi
+
+

--- a/components/builder-minio/habitat/hooks/run
+++ b/components/builder-minio/habitat/hooks/run
@@ -1,15 +1,49 @@
-#!/bin/sh
+#!/bin/bash
+# shellcheck disable=2154
 
 exec 2>&1
 
-export MINIO_ACCESS_KEY="{{cfg.key_id}}"
-export MINIO_SECRET_KEY="{{cfg.secret_key}}"
+source "{{ pkg.svc_config_path }}/hook-helper.sh"
 
-{{#if cfg.ssl_cert_pw}}
-    export MINIO_CERT_PASSWD="{{cfg.ssl_cert_pw}}"
-{{/if ~}}
+# This is helps to restart service instead of reload
+checksum_restart_hook
 
-exec minio server \
---config-dir "{{pkg.svc_config_path}}" \
-"{{pkg.svc_data_path}}"
+if [ "$standalone" == "true" ]; then
+    echo "Starting in standalone mode ..."
+    exec minio server --config-dir "{{pkg.svc_config_path}}" "{{pkg.svc_data_path}}"
+    exit 0 # never get here and its ok
+fi
 
+echo "Entering clustered configuration ..."
+
+if [ "$explicit_count" -eq 0 ]; then
+    echo "Starting automatic cluster ..."
+    members="$svc_members"
+    count=$svc_count
+else
+    echo "Starting explicit cluster ..."
+    members="$explicit_members"
+    # Member can be http://1.2.3.{1...89}
+    # It is hard to calculate count and actually isn't required
+    count=$expected
+fi
+
+if [ "$count" -eq "$expected" ] && [ "$expected" -ge 2 ]; then
+    echo "Valid members count was found. Caching configuration ..."
+    cat <<-EOF > "$run_good_hook"
+      exec minio server --config-dir "{{pkg.svc_config_path}}" $members
+EOF
+fi
+
+if [ -f "$run_good_hook" ]; then
+    echo "Running latest known good configuration ..."
+    source "$run_good_hook"
+    exit 0 # expect exec in source so never get here
+fi
+
+echo "Nor valid members count nor cached configuration was found."
+echo "Members count must be == expected."
+echo "Count: $count. Expected: $expected. Members: $members"
+echo "During initial bootstrap this is ok."
+echo "Sleeping infinity. When full cluster will be ready service will been reloaded."
+sleep infinity

--- a/components/builder-minio/habitat/plan.sh
+++ b/components/builder-minio/habitat/plan.sh
@@ -2,7 +2,7 @@ pkg_name=builder-minio
 pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/minio core/cacerts core/openssl core/aws-cli)
+pkg_deps=(core/minio core/cacerts core/openssl core/aws-cli core/bash)
 pkg_build_deps=(core/git)
 
 pkg_version() {

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -24,9 +24,6 @@ find . -type f \
   -and \! -path "./test/builder-api/node_modules/*" \
   -and \! -path "./components/builder-api-proxy/habitat/hooks/health_check" \
   -and \! -path "./components/builder-api-proxy/habitat/hooks/init" \
-  -and \! -path "./components/builder-minio/habitat/hooks/init" \
-  -and \! -path "./components/builder-minio/habitat/hooks/run" \
-  -and \! -path "./components/builder-minio/habitat/hooks/post-run" \
   -print \
   | xargs shellcheck --external-sources --exclude=1090,1091,2148,2034
 


### PR DESCRIPTION
This change completely reworks minio:
* Fix ssl certs not always copied on change
* Fix ssl cert name private.crt -> public.crt
* Add standalone mode (defualt)
* Add automatic cluster mode (using habitat discovery)
* Add explicit cluster mode
* Smart reload/restart service on config changes

Added docker-compose.yml for test.

Signed-off-by: Yauhen Artsiukhou <jsirex@gmail.com>