### PR TITLE
Update Builder services for Windows build target

### DIFF
--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -3,6 +3,7 @@ log_level = "info"
 [api]
 features_enabled = "jobsrv"
 targets = ["x86_64-linux", "x86_64-linux-kernel2", "x86_64-windows"]
+build_targets = ["x86_64-linux", "x86_64-windows"]
 
 [http]
 listen = "0.0.0.0"

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -143,6 +143,7 @@ pub struct ApiCfg {
     pub log_path: PathBuf,
     pub key_path: PathBuf,
     pub targets: Vec<PackageTarget>,
+    pub build_targets: Vec<PackageTarget>,
     pub features_enabled: String,
 }
 
@@ -157,6 +158,7 @@ impl Default for ApiCfg {
                 target::X86_64_LINUX_KERNEL2,
                 target::X86_64_WINDOWS,
             ],
+            build_targets: vec![target::X86_64_LINUX, target::X86_64_WINDOWS],
             features_enabled: String::from("jobsrv"),
         }
     }
@@ -287,6 +289,7 @@ mod tests {
         log_path = "/hab/svc/hab-depot/var/log"
         key_path = "/hab/svc/hab-depot/files"
         targets = ["x86_64-linux", "x86_64-linux-kernel2", "x86_64-windows"]
+        build_targets = ["x86_64-linux"]
         features_enabled = "foo, bar"
 
         [http]
@@ -351,6 +354,9 @@ mod tests {
         assert_eq!(config.api.targets[0], target::X86_64_LINUX);
         assert_eq!(config.api.targets[1], target::X86_64_LINUX_KERNEL2);
         assert_eq!(config.api.targets[2], target::X86_64_WINDOWS);
+
+        assert_eq!(config.api.build_targets.len(), 1);
+        assert_eq!(config.api.build_targets[0], target::X86_64_LINUX);
 
         assert_eq!(&config.api.features_enabled, "foo, bar");
 

--- a/components/builder-db/src/models/jobs.rs
+++ b/components/builder-db/src/models/jobs.rs
@@ -10,7 +10,7 @@ use crate::protocol::net;
 use crate::protocol::originsrv;
 
 use crate::models::pagination::Paginate;
-use crate::schema::jobs::jobs;
+use crate::schema::jobs::{busy_workers, groups, jobs};
 
 use crate::bldr_core::metrics::CounterMetric;
 use crate::metrics::Counter;
@@ -43,6 +43,21 @@ pub struct Job {
     pub channel: Option<String>,
     pub sync_count: i32,
     pub worker: Option<String>,
+    pub target: String,
+}
+
+#[derive(Insertable)]
+#[table_name = "jobs"]
+pub struct NewJob<'a> {
+    pub owner_id: i64,
+    pub project_id: i64,
+    pub project_name: &'a str,
+    pub project_owner_id: i64,
+    pub project_plan_path: &'a str,
+    pub vcs: &'a str,
+    pub vcs_arguments: Vec<&'a str>,
+    pub channel: &'a str,
+    pub target: &'a str,
 }
 
 pub struct ListProjectJobs {
@@ -64,6 +79,13 @@ impl Job {
             .paginate(lpj.page)
             .per_page(lpj.limit)
             .load_and_count_records(conn)
+    }
+
+    pub fn create(job: &NewJob, conn: &PgConnection) -> QueryResult<Job> {
+        Counter::DBCall.increment();
+        diesel::insert_into(jobs::table)
+            .values(job)
+            .get_result(conn)
     }
 }
 
@@ -138,6 +160,96 @@ impl Into<jobsrv::Job> for Job {
             job.set_worker(worker);
         };
 
+        job.set_target(self.target.clone());
         job
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
+#[table_name = "groups"]
+pub struct Group {
+    #[serde(with = "db_id_format")]
+    pub id: i64,
+    pub group_state: String,
+    pub project_name: String,
+    pub target: String,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+impl Group {
+    pub fn get_queued(project_name: &str, target: &str, conn: &PgConnection) -> QueryResult<Group> {
+        Counter::DBCall.increment();
+        groups::table
+            .filter(groups::project_name.eq(project_name))
+            .filter(groups::group_state.eq("Queued"))
+            .filter(groups::target.eq(target))
+            .get_result(conn)
+    }
+}
+
+impl Into<jobsrv::JobGroup> for Group {
+    fn into(self) -> jobsrv::JobGroup {
+        let mut group = jobsrv::JobGroup::new();
+
+        group.set_id(self.id as u64);
+
+        let group_state = self.group_state.parse::<jobsrv::JobGroupState>().unwrap();
+        group.set_state(group_state);
+        group.set_created_at(self.created_at.unwrap().to_rfc3339());
+        group.set_project_name(self.project_name);
+        group.set_target(self.target);
+
+        group
+    }
+}
+
+pub struct NewBusyWorker<'a> {
+    pub target: &'a str,
+    pub ident: &'a str,
+    pub job_id: i64,
+    pub quarantined: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
+#[table_name = "busy_workers"]
+pub struct BusyWorker {
+    pub target: String,
+    pub ident: String,
+    pub job_id: i64,
+    pub quarantined: bool,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+impl BusyWorker {
+    pub fn list(conn: &PgConnection) -> QueryResult<Vec<BusyWorker>> {
+        Counter::DBCall.increment();
+        busy_workers::table.get_results(conn)
+    }
+
+    pub fn create(req: &NewBusyWorker, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
+        diesel::insert_into(busy_workers::table)
+            .values((
+                busy_workers::target.eq(req.target),
+                busy_workers::ident.eq(req.ident),
+                busy_workers::job_id.eq(req.job_id),
+                busy_workers::quarantined.eq(req.quarantined),
+            ))
+            .on_conflict((busy_workers::ident, busy_workers::job_id))
+            .do_update()
+            .set(busy_workers::quarantined.eq(req.quarantined))
+            .execute(conn)
+    }
+
+    pub fn delete(ident: &str, job_id: i64, conn: &PgConnection) -> QueryResult<usize> {
+        Counter::DBCall.increment();
+        diesel::delete(
+            busy_workers::table
+                .filter(busy_workers::ident.eq(ident))
+                .filter(busy_workers::job_id.eq(job_id)),
+        )
+        .execute(conn)
     }
 }

--- a/components/builder-db/src/schema/jobs.rs
+++ b/components/builder-db/src/schema/jobs.rs
@@ -23,6 +23,7 @@ table! {
         channel -> Nullable<Text>,
         sync_count -> Integer,
         worker -> Nullable<Text>,
+        target -> Text,
     }
 }
 
@@ -33,6 +34,7 @@ table! {
         id -> BigInt,
         group_state -> Text,
         project_name -> Text,
+        target -> Text,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
     }
@@ -56,7 +58,8 @@ table! {
 table! {
     use diesel::sql_types::{BigInt, Bool, Text, Nullable, Timestamptz};
 
-    busy_workers(ident, job_id) {
+    busy_workers (ident, job_id) {
+        target -> Text,
         ident -> Text,
         job_id -> BigInt,
         quarantined -> Bool,

--- a/components/builder-jobsrv/src/migrations/2019-01-23-202244_windows-workers/up.sql
+++ b/components/builder-jobsrv/src/migrations/2019-01-23-202244_windows-workers/up.sql
@@ -1,0 +1,49 @@
+ALTER TABLE busy_workers ADD COLUMN target Text DEFAULT 'x86_64-linux';
+ALTER TABLE jobs ADD COLUMN target Text DEFAULT 'x86_64-linux';
+ALTER TABLE jobs ALTER COLUMN job_state SET DEFAULT 'Pending';
+ALTER TABLE groups ADD COLUMN target Text DEFAULT 'x86_64-linux';
+ALTER TABLE group_projects ADD COLUMN target Text DEFAULT 'x86_64-linux';
+
+CREATE OR REPLACE FUNCTION insert_group_v3(root_project text, project_names text[], project_idents text[], p_target text) RETURNS SETOF groups
+    LANGUAGE sql
+    AS $$
+  WITH my_group AS (
+          INSERT INTO groups (project_name, group_state, target)
+          VALUES (root_project, 'Queued', p_target) RETURNING *
+      ), my_project AS (
+          INSERT INTO group_projects (owner_id, project_name, project_ident, project_state)
+          SELECT g.id, project_info.name, project_info.ident, 'NotStarted'
+          FROM my_group AS g, unnest(project_names, project_idents) AS project_info(name, ident)
+      )
+  SELECT * FROM my_group;
+$$;
+
+CREATE OR REPLACE FUNCTION insert_job_v3(p_owner_id bigint, p_project_id bigint, p_project_name text, p_project_owner_id bigint, p_project_plan_path text, p_vcs text, p_vcs_arguments text[], p_channel text, p_target text) RETURNS SETOF jobs
+    LANGUAGE sql
+    AS $$
+      INSERT INTO jobs (owner_id, job_state, project_id, project_name, project_owner_id, project_plan_path, vcs, vcs_arguments, channel, target)
+      VALUES (p_owner_id, 'Pending', p_project_id, p_project_name, p_project_owner_id, p_project_plan_path, p_vcs, p_vcs_arguments, p_channel, p_target)
+      RETURNING *;
+$$;
+
+CREATE OR REPLACE FUNCTION next_pending_job_v2(p_worker text, p_target text) RETURNS SETOF jobs
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    r jobs % rowtype;
+BEGIN
+    FOR r IN
+        SELECT * FROM jobs
+        WHERE job_state = 'Pending' AND target = p_target
+        ORDER BY created_at ASC
+        FOR UPDATE SKIP LOCKED
+        LIMIT 1
+    LOOP
+        UPDATE jobs SET job_state='Dispatched', scheduler_sync=false, worker=p_worker, updated_at=now()
+        WHERE id=r.id
+        RETURNING * INTO r;
+        RETURN NEXT r;
+    END LOOP;
+  RETURN;
+END
+$$;

--- a/components/builder-protocol/protocols/jobsrv.proto
+++ b/components/builder-protocol/protocols/jobsrv.proto
@@ -45,6 +45,7 @@ message BusyWorker {
   optional string ident = 1;
   optional uint64 job_id = 2;
   optional bool quarantined = 3;
+  optional string target = 4;
 }
 
 message Job {
@@ -65,6 +66,7 @@ message Job {
   repeated originsrv.OriginProjectIntegration project_integrations = 14;
   optional string worker = 15;
   repeated originsrv.OriginSecretDecrypted secrets = 16;
+  optional string target = 17;
 }
 
 message JobGet {
@@ -75,6 +77,7 @@ message JobSpec {
   optional uint64 owner_id = 1;
   optional originsrv.OriginProject project = 2;
   optional string channel = 3;
+  optional string target = 4;
 }
 
 message JobLogChunk {
@@ -185,6 +188,7 @@ message JobGroup {
   repeated JobGroupProject projects = 3;
   optional string created_at = 4;
   optional string project_name = 5;
+  optional string target = 6;
 }
 
 message JobGraphPackageCreate {

--- a/components/builder-protocol/src/error.rs
+++ b/components/builder-protocol/src/error.rs
@@ -25,6 +25,7 @@ pub enum ProtocolError {
     BadJobGroupState(String),
     BadJobState(String),
     BadOriginPackageVisibility(String),
+    BadOs(String),
     Decode(protobuf::ProtobufError),
     Encode(protobuf::ProtobufError),
     IdentityDecode(FromUtf8Error),
@@ -44,6 +45,7 @@ impl fmt::Display for ProtocolError {
             ProtocolError::BadOriginPackageVisibility(ref e) => {
                 format!("Bad Origin Package Visibility {}", e)
             }
+            ProtocolError::BadOs(ref e) => format!("Bad OS {}", e),
             ProtocolError::Decode(ref e) => format!("Unable to decode protocol message, {}", e),
             ProtocolError::Encode(ref e) => format!("Unable to encode protocol message, {}", e),
             ProtocolError::IdentityDecode(ref e) => {
@@ -66,6 +68,7 @@ impl error::Error for ProtocolError {
             ProtocolError::BadOriginPackageVisibility(_) => {
                 "Origin package visibility cannot be parsed"
             }
+            ProtocolError::BadOs(_) => "OS cannot be parsed",
             ProtocolError::Decode(_) => "Unable to decode protocol message",
             ProtocolError::Encode(_) => "Unable to encode protocol message",
             ProtocolError::IdentityDecode(_) => "Unable to decode identity message part",

--- a/components/builder-protocol/src/jobsrv.rs
+++ b/components/builder-protocol/src/jobsrv.rs
@@ -35,6 +35,7 @@ impl Into<Job> for JobSpec {
         job.set_owner_id(self.get_owner_id());
         job.set_state(JobState::default());
         job.set_project(self.take_project());
+        job.set_target(self.take_target());
         if self.has_channel() {
             job.set_channel(self.take_channel());
         }
@@ -416,6 +417,30 @@ impl Serialize for JobGroupOriginResponse {
         let mut strukt = serializer.serialize_struct("job_group_origin_response", 1)?;
         strukt.serialize_field("name", &self.get_job_groups())?;
         strukt.end()
+    }
+}
+
+impl fmt::Display for Os {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let value = match *self {
+            Os::Linux => "linux",
+            Os::Windows => "windows",
+            Os::Darwin => "darwin",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+impl FromStr for Os {
+    type Err = ProtocolError;
+
+    fn from_str(value: &str) -> result::Result<Self, Self::Err> {
+        match value.to_lowercase().as_ref() {
+            "linux" => Ok(Os::Linux),
+            "windows" => Ok(Os::Windows),
+            "darwin" => Ok(Os::Darwin),
+            _ => Err(ProtocolError::BadOs(value.to_string())),
+        }
     }
 }
 

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -28,7 +28,7 @@ EOT
 
 mkdir -p /hab/svc/builder-api
 cat <<EOT > /hab/svc/builder-api/user.toml
-log_level = "debug,tokio_core=error,tokio_reactor=error,zmq=error"
+log_level = "debug,tokio_core=error,tokio_reactor=error,zmq=error,hyper=error"
 
 [http]
 handler_count = 15
@@ -80,7 +80,7 @@ EOT
 
 mkdir -p /hab/svc/builder-jobsrv
 cat <<EOT > /hab/svc/builder-jobsrv/user.toml
-log_level = "debug,tokio_core=error,tokio_reactor=error,zmq=error"
+log_level = "debug,tokio_core=error,tokio_reactor=error,zmq=error,postgres=error"
 
 [http]
 handler_count = 15

--- a/test/builder-api/src/jobs.js
+++ b/test/builder-api/src/jobs.js
@@ -48,18 +48,6 @@ describe('Jobs API', function () {
         });
     });
 
-    it('does not schedule a build for Windows', function (done) {
-      request.post('/depot/pkgs/schedule/neurosis/testapp?target=x86_64-windows')
-        .type('application/json')
-        .accept('application/json')
-        .set('Authorization', global.boboBearer)
-        .expect(400)
-        .end(function (err, res) {
-          expect(res.text).to.be.empty;
-          done(err);
-        });
-    });
-
     it('does not schedule a build for Linux kernel2', function (done) {
       request.post('/depot/pkgs/schedule/neurosis/testapp?target=x86_64-linux-kernel2')
         .type('application/json')


### PR DESCRIPTION
This change updates key Builder services (api, jobsrv, worker) to plumb in build targets and orchestrate builds of multiple build targets through the system. A new config has been added to the builder-api to be able to enable/disable build targets.

Currently, non-Linux builds can only be kicked off via the API (cli support via the hab command line is in progress, and UI changes will follow later).

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-173636630](https://user-images.githubusercontent.com/13542112/51724497-78d16600-2012-11e9-80d8-8da2e4816e53.gif)
