### PR TITLE
Add config for build_on_upload

### DIFF
--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -4,6 +4,7 @@ log_level = "info"
 features_enabled = "jobsrv"
 targets = ["x86_64-linux", "x86_64-linux-kernel2", "x86_64-windows"]
 build_targets = ["x86_64-linux", "x86_64-windows"]
+build_on_upload = true
 
 [http]
 listen = "0.0.0.0"

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -145,6 +145,7 @@ pub struct ApiCfg {
     pub targets: Vec<PackageTarget>,
     pub build_targets: Vec<PackageTarget>,
     pub features_enabled: String,
+    pub build_on_upload: bool,
 }
 
 impl Default for ApiCfg {
@@ -160,6 +161,7 @@ impl Default for ApiCfg {
             ],
             build_targets: vec![target::X86_64_LINUX, target::X86_64_WINDOWS],
             features_enabled: String::from("jobsrv"),
+            build_on_upload: true,
         }
     }
 }
@@ -291,6 +293,7 @@ mod tests {
         targets = ["x86_64-linux", "x86_64-linux-kernel2", "x86_64-windows"]
         build_targets = ["x86_64-linux"]
         features_enabled = "foo, bar"
+        build_on_upload = false
 
         [http]
         listen = "0:0:0:0:0:0:0:1"
@@ -359,6 +362,7 @@ mod tests {
         assert_eq!(config.api.build_targets[0], target::X86_64_LINUX);
 
         assert_eq!(&config.api.features_enabled, "foo, bar");
+        assert_eq!(config.api.build_on_upload, false);
 
         assert_eq!(&format!("{}", config.http.listen), "::1");
 

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -1029,7 +1029,10 @@ fn do_upload_package_finish(
 
     // Schedule re-build of dependent packages (if requested)
     // Don't schedule builds if the upload is being done by the builder
-    if qupload.builder.is_none() && feat::is_enabled(feat::Jobsrv) {
+    if qupload.builder.is_none()
+        && feat::is_enabled(feat::Jobsrv)
+        && req.state().config.api.build_on_upload
+    {
         let mut request = jobsrv::JobGroupSpec::new();
         request.set_origin(ident.origin.to_string());
         request.set_package(ident.name.to_string());


### PR DESCRIPTION
This adds a config to let us turn off the auto-build on package upload functionality. This is useful in cases where we are expecting a large number of uploads we don't want to trigger builds for - eg, base plan refreshes.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-124190331](https://user-images.githubusercontent.com/13542112/51765833-c808ac80-208d-11e9-9f8e-21f36951cc31.gif)
