### PR TITLE
Fix cancel job groups button to show up when jobs are in progress and pending

### DIFF
--- a/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.html
@@ -56,7 +56,7 @@
           <h4 class="jobgroup-overview-item-title">&nbsp;</h4>
           <div class="jobgroup-overview-item-value">
             <span class="jobgroup-actions">
-              <a *ngIf="pendingCount > 0" class="cancel" (click)="cancel(id)">
+              <a *ngIf="cancelableCount > 0" class="cancel" (click)="cancel(id)">
                 <hab-icon symbol="no"></hab-icon>
                 Cancel remaining jobs
               </a>

--- a/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.ts
@@ -36,6 +36,7 @@ export class OriginJobDetailComponent implements OnInit, OnDestroy {
   private parentSub: Subscription;
   private poll: number;
   private completedStates = ['success', 'failure'];
+  private cancelableStates = ['notstarted', 'inprogress'];
 
   constructor(
     private route: ActivatedRoute,
@@ -68,8 +69,12 @@ export class OriginJobDetailComponent implements OnInit, OnDestroy {
     window.clearInterval(this.poll);
   }
 
-  get pendingCount() {
-    return (this.store.getState().jobGroups.selected.projects_by_state.inprogress || []).length;
+  get cancelableCount() {
+    return this.cancelableStates.reduce((total, state) => {
+      const stateList = this.group.projects_by_state[state];
+      total += stateList ? stateList.length : 0;
+      return total;
+    }, 0);
   }
 
   get completedCount() {
@@ -122,7 +127,7 @@ export class OriginJobDetailComponent implements OnInit, OnDestroy {
       .open(JobCancelDialog, {
         width: '480px',
         data: {
-          pendingCount: this.pendingCount
+          cancelableCount: this.cancelableCount
         }
       })
       .afterClosed()

--- a/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-job-detail/origin-job-detail.component.ts
@@ -69,7 +69,7 @@ export class OriginJobDetailComponent implements OnInit, OnDestroy {
   }
 
   get pendingCount() {
-    return (this.store.getState().jobGroups.selected.projects_by_state.notstarted || []).length;
+    return (this.store.getState().jobGroups.selected.projects_by_state.inprogress || []).length;
   }
 
   get completedCount() {

--- a/components/builder-web/app/shared/dialog/job-cancel/job-cancel.dialog.html
+++ b/components/builder-web/app/shared/dialog/job-cancel/job-cancel.dialog.html
@@ -8,7 +8,7 @@
       Completed packages will remain in the <b>unstable</b> channel. Remaining jobs will be canceled.
     </p>
     <p>
-      Remaining build jobs: <b>{{ pendingCount }}</b>
+      Remaining build jobs: <b>{{ cancelableCount }}</b>
     </p>
   </section>
   <section class="controls">

--- a/components/builder-web/app/shared/dialog/job-cancel/job-cancel.dialog.ts
+++ b/components/builder-web/app/shared/dialog/job-cancel/job-cancel.dialog.ts
@@ -38,8 +38,8 @@ export class JobCancelDialog {
     return this.data.action || 'do it';
   }
 
-  get pendingCount() {
-    return this.data.pendingCount;
+  get cancelableCount() {
+    return this.data.cancelableCount;
   }
 
   ok() {


### PR DESCRIPTION
When fixing the link part of #819 and running build after build. I never saw the cancel button surface. Following the logic, I think we want the cancel button to show up when build jobs are in progress. Currently, the cancel button is set to surface when jobs are `Pending`. We could also make it surface for both `InProgress` and `Pending`, happy for some direction as the page also currently says `Cancel Remaining Jobs` and the mocks say `Cancel Unfinished Jobs`.

Signed-off-by: shadae <sholmes@chef.io>