### PR TITLE
Add target awareness to github webhook handling

### DIFF
--- a/components/builder-core/src/build_config.rs
+++ b/components/builder-core/src/build_config.rs
@@ -180,8 +180,8 @@ impl ProjectCfg {
         Pattern::from_str("habitat/*").unwrap()
     }
 
-    pub fn plan_file(&self) -> PathBuf {
-        self.plan_path.join("plan.sh")
+    pub fn plan_path(&self) -> &PathBuf {
+        &self.plan_path
     }
 
     /// Returns true if the given branch & file path combination should result in a new build

--- a/components/github-api-client/src/types.rs
+++ b/components/github-api-client/src/types.rs
@@ -94,6 +94,18 @@ impl Contents {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DirectoryEntry {
+    pub name: String,
+    pub path: String,
+    pub sha: String,
+    pub size: usize,
+    pub url: String,
+    pub html_url: String,
+    pub git_url: String,
+    pub download_url: Option<String>,
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct GitHubWebhookPush {


### PR DESCRIPTION
This change adds target awareness to the github hook handlers - which allows us to auto schedule Windows builds in addition to Linux builds.  Support for Linux2 will be added in a follow up change.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-97055373](https://user-images.githubusercontent.com/13542112/52158319-f79a5480-264b-11e9-8adb-400513848bbb.gif)
