### PR TITLE
Add reverse dependency grouping API

### DIFF
--- a/components/builder-api/doc/api.raml
+++ b/components/builder-api/doc/api.raml
@@ -572,6 +572,43 @@ securitySchemes:
                         description: Package not found
                     500:
                         description: Internal server error
+
+    /{origin}:
+        /{name}:
+            /group:
+                get:
+                    description: |
+                        Retrieves the list of reverse dependencies for this package,
+                        collated into build groups that can be build in parallel
+                    responses:
+                        200:
+                            body:
+                                application/json:
+                                    example: |
+                                        {
+                                        "origin": "core",
+                                        "name": "linux-headers",
+                                        "rdeps": [
+                                            {
+                                                "group": 0,
+                                                "idents": [
+                                                "core/redis",
+                                                "core/protobuf"
+                                                ]
+                                            },
+                                            {
+                                                "group": 1,
+                                                "idents": [
+                                                "core/node"
+                                                ]
+                                            }
+                                        ]
+                                        }
+                        404:
+                            description: Package not found
+                        500:
+                            description: Internal server error
+
 /user:
     /invitations:
         get:

--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -91,6 +91,9 @@ fn handle_rpc((req, msg): (HttpRequest<AppState>, Json<RpcMessage>)) -> HttpResp
         "JobGraphPackageReverseDependenciesGet" => {
             handlers::job_graph_package_reverse_dependencies_get(&msg, req.state())
         }
+        "JobGraphPackageReverseDependenciesGroupedGet" => {
+            handlers::job_graph_package_reverse_dependencies_grouped_get(&msg, req.state())
+        }
 
         _ => {
             let err = format!("Unknown RPC message received: {}", msg.id);

--- a/components/builder-protocol/protocols/jobsrv.proto
+++ b/components/builder-protocol/protocols/jobsrv.proto
@@ -212,3 +212,20 @@ message JobGraphPackageReverseDependencies {
   optional string name = 2;
   repeated string rdeps = 3;
 }
+
+message JobGraphPackageReverseDependenciesGroupedGet {
+  optional string origin = 1;
+  optional string name = 2;
+  optional string target = 3;
+}
+
+message JobGraphPackageReverseDependencyGroup {
+  optional uint32 group_id = 1;
+  repeated string idents = 2;
+}
+
+message JobGraphPackageReverseDependenciesGrouped {
+  optional string origin = 1;
+  optional string name = 2;
+  repeated JobGraphPackageReverseDependencyGroup rdeps = 3;
+}

--- a/components/builder-protocol/src/jobsrv.rs
+++ b/components/builder-protocol/src/jobsrv.rs
@@ -403,6 +403,33 @@ impl Serialize for JobGraphPackageReverseDependencies {
     }
 }
 
+impl Serialize for JobGraphPackageReverseDependencyGroup {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut strukt =
+            serializer.serialize_struct("job_graph_package_reverse_dependency_group", 2)?;
+        strukt.serialize_field("group", &self.get_group_id())?;
+        strukt.serialize_field("idents", &self.get_idents())?;
+        strukt.end()
+    }
+}
+
+impl Serialize for JobGraphPackageReverseDependenciesGrouped {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut strukt =
+            serializer.serialize_struct("job_graph_package_reverse_dependencies_grouped", 3)?;
+        strukt.serialize_field("origin", &self.get_origin())?;
+        strukt.serialize_field("name", &self.get_name())?;
+        strukt.serialize_field("rdeps", &self.get_rdeps())?;
+        strukt.end()
+    }
+}
+
 impl Serialize for JobGroupOriginResponse {
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
This change adds a new reverse dependency API that returns the rdeps collated into build groups that can be built in parallel.  This API is a step toward opening up the builder platform to integrate further with external systems.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-143857615](https://user-images.githubusercontent.com/13542112/52172947-0efe3e00-272f-11e9-95c7-1008dc3b29d9.gif)
