### PR TITLE
Check PackageTarget before attempting docker export

### DIFF
--- a/components/builder-worker/habitat/x86_64-linux-kernel2/plan.sh
+++ b/components/builder-worker/habitat/x86_64-linux-kernel2/plan.sh
@@ -1,0 +1,42 @@
+# shellcheck disable=SC2034
+source "../../../../support/ci/builder-base-plan.sh"
+pkg_name=builder-worker
+pkg_origin=habitat
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_bin_dirs=(bin)
+pkg_deps=(habitat/airlock core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
+  core/libarchive core/zlib core/hab-studio core/curl)
+pkg_build_deps=(core/make core/cmake core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
+  core/rust core/gcc core/git core/pkg-config)
+pkg_binds=(
+  [jobsrv]="worker_port worker_heartbeat log_port"
+  [depot]="url"
+)
+pkg_svc_user="root"
+pkg_svc_group="root"
+bin="bldr-worker"
+
+# Copy hooks/config/default.toml from parent directory so we only maintain
+# one copy.
+do_begin() {
+  mkdir -p hooks
+  mkdir -p config
+  cp --no-clobber ../hooks/run hooks/run
+  cp --no-clobber ../config/config.toml config/config.toml
+  cp --no-clobber ../default.toml default.toml
+}
+
+do_prepare() {
+  do_builder_prepare
+
+  # Used by libssh2-sys
+  export DEP_Z_ROOT DEP_Z_INCLUDE
+  DEP_Z_ROOT="$(pkg_path_for zlib)"
+  DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
+
+  # Compile the fully-qualified Studio package identifier into the binary
+  PLAN_STUDIO_PKG_IDENT=$(pkg_path_for hab-studio | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_STUDIO_PKG_IDENT
+  build_line "Setting PLAN_STUDIO_PKG_IDENT=$PLAN_STUDIO_PKG_IDENT"
+}

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -40,6 +40,7 @@ use crate::bldr_core::socket::DEFAULT_CONTEXT;
 #[cfg(not(windows))]
 use crate::hab_core::os::users;
 use crate::hab_core::package::archive::PackageArchive;
+use crate::hab_core::package::target;
 #[cfg(not(windows))]
 use crate::hab_core::util::posix_perm;
 
@@ -331,10 +332,15 @@ impl Runner {
         Ok(archive)
     }
 
-    fn do_export(&mut self, tx: &mpsc::Sender<Job>, mut streamer: &mut JobStreamer) -> Result<()> {
+    fn do_export(
+        &mut self,
+        tx: &mpsc::Sender<Job>,
+        mut archive: &mut PackageArchive,
+        mut streamer: &mut JobStreamer,
+    ) -> Result<()> {
         self.check_cancel(tx)?;
 
-        match self.export(&mut streamer) {
+        match self.export(&mut archive, &mut streamer) {
             Ok(_) => (),
             Err(err) => {
                 self.fail(net::err(ErrCode::EXPORT, "wk:run:export"));
@@ -401,8 +407,8 @@ impl Runner {
         self.do_install_key(&tx, &mut streamer)?;
         self.do_clone(&tx, &mut streamer)?;
 
-        let archive = self.do_build(&tx, &mut streamer)?;
-        self.do_export(&tx, &mut streamer)?;
+        let mut archive = self.do_build(&tx, &mut streamer)?;
+        self.do_export(&tx, &mut archive, &mut streamer)?;
         self.do_postprocess(&tx, archive, &mut streamer)?;
 
         self.cleanup();
@@ -504,28 +510,34 @@ impl Runner {
         self.workspace.last_built()
     }
 
-    fn export(&mut self, streamer: &mut JobStreamer) -> Result<()> {
+    fn export(&mut self, archive: &mut PackageArchive, streamer: &mut JobStreamer) -> Result<()> {
         if self.has_docker_integration() {
-            // TODO fn: This check should be updated in PackageArchive is check for run hooks.
-            if self.workspace.last_built()?.is_a_service() {
-                debug!("Found runnable package, running docker export");
-                let mut section = streamer.start_section(Section::ExportDocker)?;
+            let pkg_target = archive.target()?;
+            match pkg_target {
+                target::X86_64_LINUX | target::X86_64_WINDOWS => {
+                    // TODO fn: This check should be updated in PackageArchive is check for run hooks.
+                    if self.workspace.last_built()?.is_a_service() {
+                        debug!("Found runnable package, running docker export");
+                        let mut section = streamer.start_section(Section::ExportDocker)?;
 
-                let status = DockerExporter::new(
-                    util::docker_exporter_spec(&self.workspace),
-                    &self.workspace,
-                    &self.config.bldr_url,
-                    &self.bldr_token,
-                )
-                .export(streamer)?;
+                        let status = DockerExporter::new(
+                            util::docker_exporter_spec(&self.workspace),
+                            &self.workspace,
+                            &self.config.bldr_url,
+                            &self.bldr_token,
+                        )
+                        .export(streamer)?;
 
-                if !status.success() {
-                    return Err(Error::ExportFailure(status.code().unwrap_or(-1)));
+                        if !status.success() {
+                            return Err(Error::ExportFailure(status.code().unwrap_or(-1)));
+                        }
+
+                        section.end()?;
+                    } else {
+                        debug!("Package not runnable, skipping docker export");
+                    }
                 }
-
-                section.end()?;
-            } else {
-                debug!("Package not runnable, skipping docker export");
+                _ => debug!("Exports for {} are not supported", pkg_target.as_ref()),
             }
         }
 


### PR DESCRIPTION
This updates builder-worker to check the PackageTarget for supported platforms (x86_64-linux, x86_64-windows) before attempting a docker export of a package, if exports are enabled.  It also introduces a plan variant for x86_64-linux-kernel2 with the docker dependencies removed. 

#### Question
The `use` statements for the docker export code are still present for the x86_64-linux-kernel2 builds, which contain a `lazy_static!` to determine the path to the `docker` command and `hab-pkg-export-docker` command. If I understand that correctly, that will be evaluated at run-time, which introduces a potential point of failure at run-time as those packages won't be present.  Looking at existing code, it should never be executed, however I'd feel safer if there was a way to not import that module based on the active package target.

Is there a way to do that? Is there a better way to ensure runtime safety in this case? 

closes #913 
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>