### PR TITLE
Add target to worker heartbeats

### DIFF
--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -767,11 +767,9 @@ impl WorkerMgr {
         let mut worker = match self.workers.remove(&worker_ident) {
             Some(worker) => worker,
             None => {
-                // TODO: Plumb in full package target into worker heartbeat
-                let worker_target = match heartbeat.get_os() {
-                    jobsrv::Os::Linux => PackageTarget::from_str("x86_64-linux").unwrap(),
-                    jobsrv::Os::Windows => PackageTarget::from_str("x86_64-windows").unwrap(),
-                    _ => panic!("Unhandled worker heartbeat OS"),
+                let worker_target = match PackageTarget::from_str(heartbeat.get_target()) {
+                    Ok(t) => t,
+                    Err(_) => target::X86_64_LINUX,
                 };
 
                 if heartbeat.get_state() == jobsrv::WorkerState::Ready {

--- a/components/builder-protocol/protocols/jobsrv.proto
+++ b/components/builder-protocol/protocols/jobsrv.proto
@@ -39,6 +39,7 @@ message Heartbeat {
   optional string endpoint = 1;
   optional Os os = 2;
   optional WorkerState state = 3;
+  optional string target = 4;
 }
 
 message BusyWorker {

--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -4,6 +4,8 @@ key_dir = '{{pkg.svc_files_path}}'
 log_path = '{{pkg.svc_path}}/logs'
 bldr_channel = "{{cfg.bldr_channel}}"
 features_enabled = "{{cfg.features_enabled}}"
+target = "{{cfg.target}}"
+
 {{~#eachAlive bind.depot.members as |member|}}
 {{~#if @first}}
 bldr_url = "{{member.cfg.url}}"

--- a/components/builder-worker/habitat/default.toml
+++ b/components/builder-worker/habitat/default.toml
@@ -5,6 +5,7 @@ bldr_url = "https://bldr.habitat.sh"
 features_enabled = ""
 airlock_enabled = false
 recreate_ns_dir = false
+target = "x86_64-linux"
 
 [github]
 api_url = "https://api.github.com"

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -16,8 +16,10 @@
 
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use crate::hab_core::config::ConfigFile;
+use crate::hab_core::package::PackageTarget;
 use crate::hab_core::url;
 use github_api_client::config::GitHubCfg;
 
@@ -52,6 +54,7 @@ pub struct Config {
     pub recreate_ns_dir: bool,
     pub network_interface: Option<String>,
     pub network_gateway: Option<IpAddr>,
+    pub target: PackageTarget,
 }
 
 impl Config {
@@ -87,6 +90,7 @@ impl Default for Config {
             recreate_ns_dir: false,
             network_interface: None,
             network_gateway: None,
+            target: PackageTarget::from_str("x86_64-linux").unwrap(),
         }
     }
 }
@@ -130,6 +134,7 @@ mod tests {
         recreate_ns_dir = true
         network_interface = "eth1"
         network_gateway = "192.168.10.1"
+        target = "x86_64-linux-kernel2"
 
         [[jobsrv]]
         host = "1:1:1:1:1:1:1:1"
@@ -160,6 +165,10 @@ mod tests {
         assert_eq!(
             config.network_gateway,
             Some(IpAddr::V4(Ipv4Addr::new(192, 168, 10, 1)))
+        );
+        assert_eq!(
+            config.target,
+            PackageTarget::from_str("x86_64-linux-kernel2").unwrap()
         );
     }
 }

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -65,7 +65,7 @@ impl Server {
     pub fn new(config: Config) -> Self {
         let net_ident = bldr_core::socket::srv_ident();
         let fe_sock = (**DEFAULT_CONTEXT).as_mut().socket(zmq::DEALER).unwrap();
-        let hb_cli = HeartbeatCli::new(net_ident.clone());
+        let hb_cli = HeartbeatCli::new(net_ident.clone(), config.target.to_string());
         let runner_cli = RunnerCli::new();
         fe_sock.set_identity(net_ident.as_bytes()).unwrap();
         Server {


### PR DESCRIPTION
This change adds a target field to build worker heartbeats. This is in readiness for new Windows and Linux2 build workers.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-263998835](https://user-images.githubusercontent.com/13542112/52393196-f60cca00-2a59-11e9-8507-86157ffdc326.gif)
