### PR TITLE
Add check for build_target when triggering web hook

### DIFF
--- a/components/builder-api/src/server/services/github.rs
+++ b/components/builder-api/src/server/services/github.rs
@@ -239,6 +239,11 @@ fn build_plans(
             }
         }
 
+        if !req.state().config.api.build_targets.contains(&plan.1) {
+            debug!("Rejecting build with target: {:?}", plan.1);
+            continue;
+        }
+
         if feat::is_enabled(feat::Jobsrv) {
             debug!("Scheduling, {:?} ({})", plan.0, plan.1);
             request.set_origin(plan.0.origin.clone());


### PR DESCRIPTION
Add a missed check for enabled build targets when kicking off webhook-triggered builds

Signed-off-by: Salim Alam <salam@chef.io>