### PR TITLE
Update jobsrv metrics with targets

### DIFF
--- a/components/builder-jobsrv/src/server/metrics.rs
+++ b/components/builder-jobsrv/src/server/metrics.rs
@@ -18,10 +18,11 @@
 use std::borrow::Cow;
 
 use crate::bldr_core::metrics;
+use crate::hab_core::package::PackageTarget;
 
 pub enum Counter {
-    CompletedJobs,
-    FailedJobs,
+    CompletedJobs(PackageTarget),
+    FailedJobs(PackageTarget),
 }
 
 impl metrics::CounterMetric for Counter {}
@@ -29,18 +30,18 @@ impl metrics::CounterMetric for Counter {}
 impl metrics::Metric for Counter {
     fn id(&self) -> Cow<'static, str> {
         match *self {
-            Counter::CompletedJobs => "jobsrv.completed".into(),
-            Counter::FailedJobs => "jobsrv.failed".into(),
+            Counter::CompletedJobs(ref t) => format!("jobsrv.completed.{}", t).into(),
+            Counter::FailedJobs(ref t) => format!("jobsrv.failed.{}", t).into(),
         }
     }
 }
 
 pub enum Gauge {
-    WaitingJobs,
-    WorkingJobs,
-    Workers,
-    BusyWorkers,
-    ReadyWorkers,
+    WaitingJobs(PackageTarget),
+    WorkingJobs(PackageTarget),
+    Workers(PackageTarget),
+    BusyWorkers(PackageTarget),
+    ReadyWorkers(PackageTarget),
 }
 
 impl metrics::GaugeMetric for Gauge {}
@@ -48,17 +49,17 @@ impl metrics::GaugeMetric for Gauge {}
 impl metrics::Metric for Gauge {
     fn id(&self) -> Cow<'static, str> {
         match *self {
-            Gauge::WaitingJobs => "jobsrv.waiting".into(),
-            Gauge::WorkingJobs => "jobsrv.working".into(),
-            Gauge::Workers => "jobsrv.workers".into(),
-            Gauge::BusyWorkers => "jobsrv.workers.busy".into(),
-            Gauge::ReadyWorkers => "jobsrv.workers.ready".into(),
+            Gauge::WaitingJobs(ref t) => format!("jobsrv.waiting.{}", t).into(),
+            Gauge::WorkingJobs(ref t) => format!("jobsrv.working.{}", t).into(),
+            Gauge::Workers(ref t) => format!("jobsrv.workers.{}", t).into(),
+            Gauge::BusyWorkers(ref t) => format!("jobsrv.workers.busy.{}", t).into(),
+            Gauge::ReadyWorkers(ref t) => format!("jobsrv.workers.ready.{}", t).into(),
         }
     }
 }
 
 pub enum Histogram {
-    JobCompletionTime,
+    JobCompletionTime(PackageTarget),
 }
 
 impl metrics::HistogramMetric for Histogram {}
@@ -66,7 +67,7 @@ impl metrics::HistogramMetric for Histogram {}
 impl metrics::Metric for Histogram {
     fn id(&self) -> Cow<'static, str> {
         match *self {
-            Histogram::JobCompletionTime => "jobsrv.completion_time".into(),
+            Histogram::JobCompletionTime(ref t) => format!("jobsrv.completion_time.{}", t).into(),
         }
     }
 }

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -285,17 +285,19 @@ impl WorkerMgr {
                 if let Err(err) = self.process_cancelations() {
                     warn!("Worker-manager unable to process cancels: err {:?}", err);
                 }
-                if let Err(err) = self.process_work(target::X86_64_LINUX) {
-                    warn!("Worker-manager unable to process work: err {:?}", err);
-                }
-                if let Err(err) = self.process_work(target::X86_64_WINDOWS) {
-                    warn!("Worker-manager unable to process work: err {:?}", err);
+
+                for target in PackageTarget::supported_targets() {
+                    if let Err(err) = self.process_work(*target) {
+                        warn!("Worker-manager unable to process work: err {:?}", err);
+                    }
                 }
                 last_processed = now;
             }
 
-            if let Err(err) = self.process_metrics() {
-                warn!("Worker-manager unable to process metrics: err {:?}", err);
+            for target in PackageTarget::supported_targets() {
+                if let Err(err) = self.process_metrics(*target) {
+                    warn!("Worker-manager unable to process metrics: err {:?}", err);
+                }
             }
         }
     }
@@ -362,23 +364,28 @@ impl WorkerMgr {
         Ok(())
     }
 
-    fn process_metrics(&mut self) -> Result<()> {
-        Gauge::Workers.set(self.workers.len() as f64);
+    fn process_metrics(&mut self, target: PackageTarget) -> Result<()> {
+        Gauge::Workers(target).set(
+            self.workers
+                .iter()
+                .filter(|t| (t.1.target == target))
+                .count() as f64,
+        );
 
         let ready_workers = self
             .workers
             .iter()
-            .filter(|t| t.1.state == jobsrv::WorkerState::Ready)
+            .filter(|t| (t.1.target == target) && (t.1.state == jobsrv::WorkerState::Ready))
             .count();
 
         let busy_workers = self
             .workers
             .iter()
-            .filter(|t| t.1.state == jobsrv::WorkerState::Busy)
+            .filter(|t| (t.1.target == target) && (t.1.state == jobsrv::WorkerState::Busy))
             .count();
 
-        Gauge::ReadyWorkers.set(ready_workers as f64);
-        Gauge::BusyWorkers.set(busy_workers as f64);
+        Gauge::ReadyWorkers(target).set(ready_workers as f64);
+        Gauge::BusyWorkers(target).set(busy_workers as f64);
 
         Ok(())
     }


### PR DESCRIPTION
This change updates the job server to start sending per-target job metrics to statsd

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-80430890](https://user-images.githubusercontent.com/13542112/52451306-3bc9a100-2af3-11e9-95bb-1bc0c43a39ef.gif)
