### PR TITLE
Tweak a couple of debug traces

### DIFF
--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -767,13 +767,14 @@ impl WorkerMgr {
     fn process_heartbeat(&mut self) -> Result<()> {
         self.hb_sock.recv(&mut self.msg, 0)?;
         let heartbeat: jobsrv::Heartbeat = parse_from_bytes(&self.msg)?;
-        debug!("Got heartbeat: {:?}", heartbeat);
+        trace!("Got heartbeat: {:?}", heartbeat);
 
         let worker_ident = heartbeat.get_endpoint().to_string();
 
         let mut worker = match self.workers.remove(&worker_ident) {
             Some(worker) => worker,
             None => {
+                debug!("New worker detected, heartbeat: {:?}", heartbeat);
                 let worker_target = match PackageTarget::from_str(heartbeat.get_target()) {
                     Ok(t) => t,
                     Err(_) => target::X86_64_LINUX,

--- a/components/builder-worker/src/heartbeat.rs
+++ b/components/builder-worker/src/heartbeat.rs
@@ -219,7 +219,7 @@ impl HeartbeatMgr {
 
     // Broadcast to subscribers the HeartbeatMgr health and state
     fn pulse(&mut self) -> Result<()> {
-        debug!("heartbeat pulsed: {:?}", self.heartbeat);
+        trace!("heartbeat pulsed: {:?}", self.heartbeat);
         self.pub_sock.send(&message::encode(&self.heartbeat)?, 0)?;
         Ok(())
     }


### PR DESCRIPTION
Reduce verbosity of some of the jobsrv/worker debug output

Signed-off-by: Salim Alam <salam@chef.io>