### PR TITLE
Improved job cancel

### DIFF
--- a/components/builder-worker/src/runner/job_streamer.rs
+++ b/components/builder-worker/src/runner/job_streamer.rs
@@ -114,7 +114,7 @@ impl JobStreamer {
     /// * If the `stderr` consuming thread cannot be spawned--this would most likely happen on a
     /// resource starved system and indicates a possible health issue of the host
     pub fn consume_child(&self, child: &mut Child) -> Result<()> {
-        let stdout_handle = {
+        let _stdout_handle = {
             let target = self.target.clone();
             let id = self.id;
             let stdout = child.stdout.take().expect("Child stdout was not captured");
@@ -123,7 +123,7 @@ impl JobStreamer {
                 .spawn(move || consume_stream(target, id, stdout))
                 .expect("Failed to spawn stdout thread")
         };
-        let stderr_handle = {
+        let _stderr_handle = {
             let target = self.target.clone();
             let id = self.id;
             let stderr = child.stderr.take().expect("Child stderr was not captured");
@@ -132,13 +132,6 @@ impl JobStreamer {
                 .spawn(move || consume_stream(target, id, stderr))
                 .expect("Failed to spawn stderr thread")
         };
-
-        // TODO fn: not entirely decided if we should join and block on the output-processing
-        // threads or let them run to completion and return this method to wait on the termination
-        // of the Child process. Chances are that the choice will be very clear, very shortly.
-        for handle in vec![stdout_handle, stderr_handle] {
-            handle.join().expect("Consuming thread could not join")?;
-        }
 
         Ok(())
     }

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -19,6 +19,8 @@ use std::path::Path;
 #[cfg(windows)]
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 use zmq;
 
@@ -38,6 +40,9 @@ use crate::heartbeat::{HeartbeatCli, HeartbeatMgr};
 use crate::log_forwarder::LogForwarder;
 use crate::network::NetworkNamespace;
 use crate::runner::{studio, RunnerCli, RunnerMgr};
+
+/// Interval for main thread to check cancel status
+pub const BUILD_CANCEL_WAIT_SECS : u64 = 15;
 
 enum State {
     Ready,
@@ -155,16 +160,13 @@ impl Server {
 
     fn cancel_job(&mut self) -> Result<()> {
         self.runner_cli.cancel_job(&self.msg)?;
+        thread::sleep(Duration::new(BUILD_CANCEL_WAIT_SECS, 0));
         {
             let reply = self.runner_cli.recv_ack()?;
             self.fe_sock.send(reply, 0)?;
         }
-
-        // Currently, there's no good way to cancel a studio build that is in progress.
-        // Terminate the worker process (it will get restarted by the supervisor) in
-        // order to handle the case where a build is hung.
-        warn!("Exiting worker (cancel received)");
-        ::std::process::exit(0);
+        self.set_ready()?;
+        Ok(())
     }
 
     fn reject_job(&mut self) -> Result<()> {


### PR DESCRIPTION
This change fixes the build worker job cancellation handling. Instead of force exiting the worker process, which left orphaned child processes running, this change lets the worker kill only the studio process directly, which cleans up the studio process as expected.

Signed-off-by: Salim Alam <salam@chef.io>