### PR TITLE
Fix crypto compatibility

### DIFF
--- a/components/builder-api/src/server/resources/origins.rs
+++ b/components/builder-api/src/server/resources/origins.rs
@@ -1279,7 +1279,7 @@ fn get_origin_integration(req: HttpRequest<AppState>) -> HttpResponse {
     };
 
     match OriginIntegration::get(&origin, &integration, &name, &*conn).map_err(Error::DieselError) {
-        Ok(integration) => match decrypt(&req, &WrappedSealedBox::from(integration.body)) {
+        Ok(integration) => match decrypt(&req, &integration.body) {
             Ok(decrypted) => {
                 let val = serde_json::from_str(&decrypted).unwrap();
                 let mut map: serde_json::Map<String, serde_json::Value> =
@@ -1381,7 +1381,7 @@ fn encrypt(req: &HttpRequest<AppState>, content: &Bytes) -> Result<String> {
         .map_err(Error::BuilderCore)
 }
 
-fn decrypt(req: &HttpRequest<AppState>, content: &WrappedSealedBox) -> Result<String> {
+fn decrypt(req: &HttpRequest<AppState>, content: &str) -> Result<String> {
     let bytes = bldr_core::integrations::decrypt(&req.state().config.api.key_path, content)?;
     Ok(String::from_utf8(bytes)?)
 }

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -527,10 +527,7 @@ impl WorkerMgr {
             Ok(oir) => {
                 for i in oir {
                     let mut oi = originsrv::OriginIntegration::new();
-                    let plaintext = match bldr_core::integrations::decrypt(
-                        &self.key_dir,
-                        &WrappedSealedBox::from(i.body),
-                    ) {
+                    let plaintext = match bldr_core::integrations::decrypt(&self.key_dir, &i.body) {
                         Ok(b) => match String::from_utf8(b) {
                             Ok(s) => s,
                             Err(e) => {


### PR DESCRIPTION
This change fixes some backward compatibility breakages that inadvertently happened while moving to a new crypto data type.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-242928097](https://user-images.githubusercontent.com/13542112/52678246-d821e800-2ee5-11e9-9ddb-a9c9a5f1e8d2.gif)
