### PR TITLE
Run Linux2 build with Docker Studio

### DIFF
--- a/components/builder-worker/habitat/x86_64-linux-kernel2/plan.sh
+++ b/components/builder-worker/habitat/x86_64-linux-kernel2/plan.sh
@@ -5,7 +5,7 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(habitat/airlock core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
+pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
   core/libarchive core/zlib core/hab-studio core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)


### PR DESCRIPTION
Update builder-worker to run Linux2 builds with a Docker-based studio.  

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-262955428](https://user-images.githubusercontent.com/13542112/53534427-a5feb180-3ab3-11e9-9990-8706421aa7a3.gif)
