### PR TITLE
Enable firewall for Linux2 worker

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -511,6 +511,7 @@ resource "aws_instance" "linux2-worker" {
 
   provisioner "remote-exec" {
     inline = [
+      "sudo ufw --force enable",
       "chmod +x /tmp/install_linux2_packages.sh",
       "sudo /tmp/install_linux2_packages.sh",
       "sudo mv /tmp/hab-sup.init /etc/init/hab-sup.conf",


### PR DESCRIPTION
The last piece of the puzzle for Linux2 builder - this enables the firewall on the node so that the Docker iptables additions function as expected.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-151841827](https://user-images.githubusercontent.com/13542112/53657918-51bb1500-3c0c-11e9-9b3a-06155bb801a5.gif)
