### PR TITLE
Add build_targets to bldr toml

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -48,6 +48,11 @@ paths = [
   "components/net/*",
   "support/ci/builder-base-plan.sh",
 ]
+build_targets = [
+  "x86_64-windows",
+  "x86_64-linux",
+  "x86_64-linux-kernel2"
+]
 
 [builder-minio]
 plan_path = "components/builder-minio/habitat"

--- a/components/github-api-client/src/types.rs
+++ b/components/github-api-client/src/types.rs
@@ -96,6 +96,7 @@ impl Contents {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct DirectoryEntry {
+    pub r#type: String,
     pub name: String,
     pub path: String,
     pub sha: String,


### PR DESCRIPTION
This change adds support for build targets in the bldr.toml file.  If no build_targets are specified explicitly, we default to X86_64_LINUX and X86_64_WINDOWS.  Therefore, in order to build Linux Kernel2 packages via github push, that build target will need to be explicitly specified in a bldr.toml. This decision is because we expect most plans will NOT need to automatically build Kernel2 packages.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-90272445](https://user-images.githubusercontent.com/13542112/53770380-b1772180-3e93-11e9-93e6-e50bf118d644.gif)
