### PR TITLE
Update builder-worker to use hardcoded hab / docker exporter

### DIFF
--- a/components/builder-worker/build.rs
+++ b/components/builder-worker/build.rs
@@ -5,9 +5,20 @@ use std::env;
 
 fn main() {
     builder::common();
+    write_hab_pkg_ident();
     write_studio_pkg_ident();
     write_docker_exporter_pkg_ident();
     write_docker_pkg_ident();
+}
+
+fn write_hab_pkg_ident() {
+    let ident = match env::var("PLAN_HAB_PKG_IDENT") {
+        // Use the value provided by the build system if present
+        Ok(ident) => ident,
+        // Use the latest installed package as a default for development
+        _ => String::from("core/hab"),
+    };
+    util::write_out_dir_file("HAB_PKG_IDENT", ident);
 }
 
 fn write_studio_pkg_ident() {

--- a/components/builder-worker/habitat-dev/plan.sh
+++ b/components/builder-worker/habitat-dev/plan.sh
@@ -9,6 +9,11 @@ do_prepare() {
   DEP_Z_ROOT="$(pkg_path_for zlib)"
   DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
 
+  # Compile the fully-qualified hab cli package identifier into the binary
+  PLAN_HAB_PKG_IDENT=$(pkg_path_for hab | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_HAB_PKG_IDENT
+  build_line "Setting PLAN_HAB_PKG_IDENT=$PLAN_HAB_PKG_IDENT"
+
   # Compile the fully-qualified Studio package identifier into the binary
   PLAN_STUDIO_PKG_IDENT=$(pkg_path_for hab-studio | sed "s,^$HAB_PKG_PATH/,,")
   export PLAN_STUDIO_PKG_IDENT

--- a/components/builder-worker/habitat/plan.ps1
+++ b/components/builder-worker/habitat/plan.ps1
@@ -8,6 +8,7 @@ $pkg_deps = @(
     "core/zlib",
     "core/libarchive",
     "core/libsodium",
+    "core/hab",
     "core/hab-studio",
     "core/hab-pkg-export-docker",
     "core/docker"
@@ -63,6 +64,18 @@ function Invoke-Prepare {
     # Used to set the active package target for the binaries at build time
     $env:PLAN_PACKAGE_TARGET = "$pkg_target"
     Write-BuildLine "Setting env:PLAN_PACKAGE_TARGET=$env:PLAN_PACKAGE_TARGET"
+
+    # Compile the fully-qualified hab package identifier into the binary
+    $env:PLAN_HAB_PKG_IDENT = $(Get-HabPackagePath "hab").replace("$HAB_PKG_PATH\","")
+    Write-BuildLine "Setting env:PLAN_HAB_PKG_IDENT=$env:PLAN_HAB_PKG_IDENT"
+
+    # Compile the fully-qualified Studio package identifier into the binary
+    $env:PLAN_STUDIO_PKG_IDENT = $(Get-HabPackagePath "hab-studio").replace("$HAB_PKG_PATH\","")
+    Write-BuildLine "Setting env:PLAN_STUDIO_PKG_IDENT=$env:PLAN_STUDIO_PKG_IDENT"
+
+    # Compile the fully-qualified Docker exporter package identifier into the binary
+    $env:PLAN_DOCKER_EXPORTER_PKG_IDENT = $(Get-HabPackagePath "hab-pkg-export-docker").replace("$HAB_PKG_PATH\","")
+    Write-BuildLine "Setting env:PLAN_DOCKER_EXPORTER_PKG_IDENT=$env:PLAN_DOCKER_EXPORTER_PKG_IDENT"
 }
 
 function Invoke-BuildConfig {

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_deps=(habitat/airlock core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
-  core/libarchive core/zlib core/hab-studio core/hab-pkg-export-docker
+  core/libarchive core/zlib core/hab core/hab-studio core/hab-pkg-export-docker
   core/docker core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
@@ -25,6 +25,11 @@ do_prepare() {
   export DEP_Z_ROOT DEP_Z_INCLUDE
   DEP_Z_ROOT="$(pkg_path_for zlib)"
   DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
+
+  # Compile the fully-qualified hab cli package identifier into the binary
+  PLAN_HAB_PKG_IDENT=$(pkg_path_for hab | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_HAB_PKG_IDENT
+  build_line "Setting PLAN_HAB_PKG_IDENT=$PLAN_HAB_PKG_IDENT"
 
   # Compile the fully-qualified Studio package identifier into the binary
   PLAN_STUDIO_PKG_IDENT=$(pkg_path_for hab-studio | sed "s,^$HAB_PKG_PATH/,,")

--- a/components/builder-worker/habitat/x86_64-linux-kernel2/plan.sh
+++ b/components/builder-worker/habitat/x86_64-linux-kernel2/plan.sh
@@ -6,7 +6,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
-  core/libarchive core/zlib core/hab-studio core/curl)
+  core/libarchive core/zlib core/hab core/hab-studio core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
 pkg_binds=(
@@ -34,6 +34,11 @@ do_prepare() {
   export DEP_Z_ROOT DEP_Z_INCLUDE
   DEP_Z_ROOT="$(pkg_path_for zlib)"
   DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
+
+  # Compile the fully-qualified hab cli package identifier into the binary
+  PLAN_HAB_PKG_IDENT=$(pkg_path_for hab | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_HAB_PKG_IDENT
+  build_line "Setting PLAN_HAB_PKG_IDENT=$PLAN_HAB_PKG_IDENT"
 
   # Compile the fully-qualified Studio package identifier into the binary
   PLAN_STUDIO_PKG_IDENT=$(pkg_path_for hab-studio | sed "s,^$HAB_PKG_PATH/,,")

--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -48,6 +48,12 @@ lazy_static! {
         include_str!(concat!(env!("OUT_DIR"), "/STUDIO_PKG_IDENT")),
     );
 
+    /// Absolute path to the hab cli
+    static ref HAB_CLI: PathBuf = fs::resolve_cmd_in_pkg(
+        "hab",
+        include_str!(concat!(env!("OUT_DIR"), "/HAB_PKG_IDENT")),
+    );
+
     pub static ref STUDIO_HOME: Mutex<PathBuf> = {
         Mutex::new(PathBuf::new())
     };
@@ -253,10 +259,10 @@ impl<'a> Studio<'a> {
         let mut cmd = if self.target == target::X86_64_LINUX {
             Command::new(&*STUDIO_PROGRAM)
         } else {
-            Command::new(&"hab") // Linux2 builder uses the hab cli instead of the
-                                 // explict STUDIO_PROGRAM path. This is required for
-                                 // use of Docker studio.
-                                 // TODO (SA): Consider the same change for Linux
+            Command::new(&*HAB_CLI) // Linux2 builder uses the hab cli instead of the
+                                    // explict STUDIO_PROGRAM path. This is required for
+                                    // use of Docker studio.
+                                    // TODO (SA): Consider the same change for Linux
         };
         cmd.env_clear();
 
@@ -270,10 +276,10 @@ impl<'a> Studio<'a> {
 
     #[cfg(windows)]
     fn studio_command_not_airlock(&self) -> Result<Command> {
-        let mut cmd = Command::new(&"hab"); // Windows builder uses the hab cli instead of the
-                                            // explict STUDIO_PROGRAM path. This is required for
-                                            // use of Docker studio.
-                                            // TODO (SA): Consider the same change for Linux
+        let mut cmd = Command::new(&*HAB_CLI); // Windows builder uses the hab cli instead of the
+                                               // explict STUDIO_PROGRAM path. This is required for
+                                               // use of Docker studio.
+                                               // TODO (SA): Consider the same change for Linux
 
         // Note - Windows builder does not clear the env
         // TODO (SA): Consider the same change for Linux


### PR DESCRIPTION
This change locks the version of the hab cli that is used to execute the studio for the Linux2 and Windows build workers. Also a similar change for the Windows docker exporter. This brings things in line with how we are operating with the Linux worker.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-56335803](https://user-images.githubusercontent.com/13542112/53831770-6e23be00-3f3a-11e9-8a92-4bbc8ea66416.gif)
