### PR TITLE
Process pending jobs per target

### DIFF
--- a/components/builder-db/src/models/jobs.rs
+++ b/components/builder-db/src/models/jobs.rs
@@ -201,6 +201,14 @@ impl Group {
                      .filter(groups::target.eq(target))
                      .get_result(conn)
     }
+
+    pub fn get_pending(target: PackageTarget, conn: &PgConnection) -> QueryResult<Group> {
+        Counter::DBCall.increment();
+        groups::table.filter(groups::group_state.eq("Pending"))
+                     .filter(groups::target.eq(target.to_string()))
+                     .order(groups::created_at.asc())
+                     .get_result(conn)
+    }
 }
 
 impl Into<jobsrv::JobGroup> for Group {

--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -14,8 +14,10 @@
 
 //! Configuration for a Habitat JobSrv service
 
-use std::{env,
+use std::{collections::HashSet,
+          env,
           io,
+          iter::FromIterator,
           net::{IpAddr,
                 Ipv4Addr,
                 SocketAddr,
@@ -52,7 +54,7 @@ pub struct Config {
     /// Max time (in minutes) allowed for a build job
     pub job_timeout: u64,
     /// Supported build targets
-    pub build_targets: Vec<PackageTarget>,
+    pub build_targets: HashSet<PackageTarget>,
 }
 
 impl Default for Config {
@@ -67,7 +69,8 @@ impl Default for Config {
                  key_dir: PathBuf::from("/hab/svc/hab-depot/files"),
                  log_path: PathBuf::from("/tmp"),
                  job_timeout: 60,
-                 build_targets: vec![target::X86_64_LINUX, target::X86_64_WINDOWS] }
+                 build_targets: HashSet::from_iter(vec![target::X86_64_LINUX,
+                                                        target::X86_64_WINDOWS]) }
     }
 }
 
@@ -253,7 +256,7 @@ mod tests {
         assert_eq!(&format!("{}", config.net.log_ingestion_listen), "2.2.2.2");
 
         assert_eq!(config.build_targets.len(), 1);
-        assert_eq!(config.build_targets[0], target::X86_64_LINUX);
+        assert!(config.build_targets.contains(&target::X86_64_LINUX));
 
         assert_eq!(config.net.worker_command_port, 9000);
         assert_eq!(config.net.worker_heartbeat_port, 9000);

--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -20,8 +20,9 @@ mod metrics;
 mod scheduler;
 mod worker_manager;
 
-use std::sync::{Arc,
-                RwLock};
+use std::{collections::HashSet,
+          sync::{Arc,
+                 RwLock}};
 use time::PreciseTime;
 
 use actix;
@@ -58,7 +59,7 @@ pub struct AppState {
     db:            DbPool,
     graph:         Arc<RwLock<TargetGraph>>,
     log_dir:       LogDirectory,
-    build_targets: Vec<PackageTarget>,
+    build_targets: HashSet<PackageTarget>,
 }
 
 impl AppState {
@@ -138,7 +139,7 @@ pub fn run(config: Config) -> Result<()> {
     let db_pool = DbPool::new(&config.datastore.clone());
 
     WorkerMgr::start(&config, &datastore, db_pool.clone())?;
-    ScheduleMgr::start(&datastore, db_pool.clone(), &config.log_path)?;
+    ScheduleMgr::start(&config, &datastore, db_pool.clone())?;
 
     info!("builder-jobsrv listening on {}:{}",
           cfg.listen_addr(),


### PR DESCRIPTION
This change updates the job scheduler to process work per target. This fixes the case where not having available build workers for a given target can stall builds from getting issued for other targets where workers are actually available.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-208191453](https://user-images.githubusercontent.com/13542112/53918954-596c2680-401d-11e9-92ab-747ffed97a49.gif)
