### PR TITLE
Convert Linux (non-airlock) to Docker Studio

### DIFF
--- a/components/builder-worker/src/runner/workspace.rs
+++ b/components/builder-worker/src/runner/workspace.rs
@@ -26,12 +26,13 @@ use crate::error::{Error,
                    Result};
 
 pub struct Workspace {
-    pub job: Job,
-    out:     PathBuf,
-    src:     PathBuf,
-    studio:  PathBuf,
-    ns_dir:  PathBuf,
-    root:    PathBuf,
+    pub job:  Job,
+    out:      PathBuf,
+    src:      PathBuf,
+    studio:   PathBuf,
+    key_path: PathBuf,
+    ns_dir:   PathBuf,
+    root:     PathBuf,
 }
 
 impl Workspace {
@@ -44,6 +45,7 @@ impl Workspace {
                     out: root.join("out"),
                     src: root.join("src"),
                     studio: root.join("studio"),
+                    key_path: root.join("keys"),
                     ns_dir: root.join("airlock-ns"),
                     root }
     }
@@ -82,6 +84,9 @@ impl Workspace {
 
     /// Directory containing the studio for the build
     pub fn studio(&self) -> &Path { &self.studio }
+
+    /// Directory containing the keys for the build
+    pub fn key_path(&self) -> &Path { &self.key_path }
 
     /// Directory containing the airlock namespace state for the build
     pub fn ns_dir(&self) -> &Path { &self.ns_dir }

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -295,6 +295,7 @@ fn init_users() -> Result<()> {
     let gid = users::get_gid_by_name(studio::STUDIO_GROUP).ok_or(Error::NoStudioGroup)?;
     let mut home = studio::STUDIO_HOME.lock().unwrap();
     *home = users::get_home_for_user(studio::STUDIO_USER).ok_or(Error::NoStudioGroup)?;
+    debug!("Setting STUDIO_HOME to {:?}", *home);
     studio::set_studio_uid(uid);
     studio::set_studio_gid(gid);
     Ok(())


### PR DESCRIPTION
This converts Linux builder to use Docker studio in non-Airlock mode. It is the next step toward consolidating all the builder workers to use Docker studio. More changes forthcoming.

Signed-off-by: Salim Alam <salam@chef.io>