### PR TITLE
Use full set of bastions for Windows workers

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -685,7 +685,7 @@ data "template_file" "windows_worker_user_data" {
   vars {
     environment = "${var.env}"
     password    = "${var.admin_password}"
-    peer        = "${var.peers[0]}"
+    flags       = "--no-color --peer ${join(" ", var.peers)}"
     bldr_url    = "${var.bldr_url}"
     channel     = "${var.release_channel}"
   }

--- a/terraform/templates/windows_worker_user_data
+++ b/terraform/templates/windows_worker_user_data
@@ -40,7 +40,7 @@
   # Add config to HabService.dll.config
   $svcPath = Join-Path $env:SystemDrive "hab\svc\windows-service"
   [xml]$configXml = Get-Content (Join-Path $svcPath HabService.dll.config)
-  $configXml.configuration.appSettings.add[2].value = "--no-color --peer ${peer}"
+  $configXml.configuration.appSettings.add[2].value = "${flags}"
   $configXml.Save((Join-Path $svcPath HabService.dll.config))
 
   # Start service


### PR DESCRIPTION
Small change to plumb in the full set of bastions into the Windows builder worker

Signed-off-by: Salim Alam <salam@chef.io>