### PR TITLE
Terraform worker for Docker studio

### DIFF
--- a/terraform/files/51-studio-init.cfg
+++ b/terraform/files/51-studio-init.cfg
@@ -1,4 +1,0 @@
-# Enable Studio interface
-
-auto ens4
-iface ens4 inet dhcp

--- a/terraform/scripts/worker_bootstrap.sh
+++ b/terraform/scripts/worker_bootstrap.sh
@@ -4,3 +4,8 @@ set -eux
 
 # Add a very uniquely named user/group pair for worker builds to run under.
 sudo useradd --groups=tty --create-home krangschnak || echo "User 'krangschnak' already exists"
+
+# Install docker via apt-get for now until we hammer out the
+# steps with the hab package
+sudo apt-get update
+sudo apt-get -y install docker.io


### PR DESCRIPTION
This change modifies the Terraform script to set up build workers to leverage Docker studio. The "ens4" network that was required for Airlock is removed. This will allow us to use smaller worker sizes, with a significantly reduced cost.

Signed-off-by: Salim Alam <salam@chef.io>