### PR TITLE
Fix idents generated during Windows builder-worker build

### DIFF
--- a/components/builder-worker/habitat/plan.ps1
+++ b/components/builder-worker/habitat/plan.ps1
@@ -66,15 +66,15 @@ function Invoke-Prepare {
     Write-BuildLine "Setting env:PLAN_PACKAGE_TARGET=$env:PLAN_PACKAGE_TARGET"
 
     # Compile the fully-qualified hab package identifier into the binary
-    $env:PLAN_HAB_PKG_IDENT = $(Get-HabPackagePath "hab").replace("$HAB_PKG_PATH\","")
+    $env:PLAN_HAB_PKG_IDENT = $(Get-HabPackagePath "hab").replace("$HAB_PKG_PATH\","").replace("\", "/")
     Write-BuildLine "Setting env:PLAN_HAB_PKG_IDENT=$env:PLAN_HAB_PKG_IDENT"
 
     # Compile the fully-qualified Studio package identifier into the binary
-    $env:PLAN_STUDIO_PKG_IDENT = $(Get-HabPackagePath "hab-studio").replace("$HAB_PKG_PATH\","")
+    $env:PLAN_STUDIO_PKG_IDENT = $(Get-HabPackagePath "hab-studio").replace("$HAB_PKG_PATH\","").replace("\", "/")
     Write-BuildLine "Setting env:PLAN_STUDIO_PKG_IDENT=$env:PLAN_STUDIO_PKG_IDENT"
 
     # Compile the fully-qualified Docker exporter package identifier into the binary
-    $env:PLAN_DOCKER_EXPORTER_PKG_IDENT = $(Get-HabPackagePath "hab-pkg-export-docker").replace("$HAB_PKG_PATH\","")
+    $env:PLAN_DOCKER_EXPORTER_PKG_IDENT = $(Get-HabPackagePath "hab-pkg-export-docker").replace("$HAB_PKG_PATH\","").replace("\", "/")
     Write-BuildLine "Setting env:PLAN_DOCKER_EXPORTER_PKG_IDENT=$env:PLAN_DOCKER_EXPORTER_PKG_IDENT"
 }
 


### PR DESCRIPTION
This fixes up the idents that are generated and pinned during the builder-worker Windows builds.

Signed-off-by: Salim Alam <salam@chef.io>