### PR TITLE
Changes for clippy lint fixes from core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#e6312bf6d4fe1033526783000cbc5c0fcde91ebe"
+source = "git+https://github.com/habitat-sh/core.git#e9aba7b7732fa5c8682ef941a7164aa27c13788b"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "caps 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1154,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#e6312bf6d4fe1033526783000cbc5c0fcde91ebe"
+source = "git+https://github.com/habitat-sh/core.git#e9aba7b7732fa5c8682ef941a7164aa27c13788b"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#e6312bf6d4fe1033526783000cbc5c0fcde91ebe"
+source = "git+https://github.com/habitat-sh/core.git#e9aba7b7732fa5c8682ef941a7164aa27c13788b"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -1199,11 +1199,11 @@ fn do_get_package(req: &HttpRequest<AppState>,
 // Return a formatted string representing the filename of an archive for the given package
 // identifier pieces.
 fn archive_name(ident: &PackageIdent, target: PackageTarget) -> PathBuf {
-    PathBuf::from(ident.archive_name_with_target(&target).unwrap_or_else(|_| {
-                                                             panic!("Package ident should be \
-                                                                     fully qualified, ident={}",
-                                                                    &ident)
-                                                         }))
+    PathBuf::from(ident.archive_name_with_target(target).unwrap_or_else(|_| {
+                                                            panic!("Package ident should be fully \
+                                                                    qualified, ident={}",
+                                                                   &ident)
+                                                        }))
 }
 
 fn download_response_for_archive(archive: &PackageArchive, file_path: &PathBuf) -> HttpResponse {

--- a/components/builder-api/src/server/services/s3.rs
+++ b/components/builder-api/src/server/services/s3.rs
@@ -323,7 +323,7 @@ impl S3Handler {
 fn s3_key(ident: &PackageIdent, target: PackageTarget) -> Result<String> {
     // Calling this method first ensures that the ident is fully qualified and the correct errors
     // are returned in case of failure
-    let hart_name = ident.archive_name_with_target(&target)
+    let hart_name = ident.archive_name_with_target(target)
                          .map_err(Error::HabitatCore)?;
 
     Ok(format!("{}/{}/{}",


### PR DESCRIPTION
Fixing the clippy lints in `core` requires some downstream changes to consumer code.

Now that https://github.com/habitat-sh/core/pull/135 has merged, these fixes need to merge along with the `cargo update` that pulls in the new `core` code.