### PR TITLE
Set up panic hook for builder worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,7 @@ dependencies = [
 name = "habitat_builder_worker"
 version = "0.0.0"
 dependencies = [
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+backtrace = "*"
 bitflags = "*"
 clippy = {version = "*", optional = true}
 chrono = { version = "*", features = ["serde"] }


### PR DESCRIPTION
This sets up a custom panic hook for builder worker.  In the (rare) case that the builder worker panics on a thread, it will print out the backtrace and panic info, and then exit the process. The process will be restarted by the supervisor. We prefer this behavior to the default, where a single thread (eg, runner) can die, and leave the heartbeat thread running so it appears that the runner is in a working state when it has actually died.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-129272970](https://user-images.githubusercontent.com/13542112/54246375-e87faf80-44f1-11e9-81f5-3c0d2623edc6.gif)
