### PR TITLE
Fix clippy lints and update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ matrix:
         - cargo build --package habitat-builder-protocol
       script:
         - ./support/ci/rustfmt.sh
-        - cargo clippy -- -D warnings
+        - make lint
 
 #
 # Job for testing Builder Rust services

--- a/Makefile
+++ b/Makefile
@@ -38,19 +38,6 @@ unit-lib: $(addprefix unit-,$(LIB)) ## executes the library components' unit tes
 unit-srv: $(addprefix unit-,$(SRV)) ## executes the service components' unit test suites
 .PHONY: unit-srv
 
-lint: lint-bin lint-lib lint-srv ## executs all components' lints
-lint-all: lint
-.PHONY: lint lint-all
-
-lint-bin: $(addprefix lint-,$(BIN))
-.PHONY: lint-bin
-
-lint-lib: $(addprefix lint-,$(LIB))
-.PHONY: lint-lib
-
-lint-srv: $(addprefix lint-,$(SRV))
-.PHONY: lint-srv
-
 functional: functional-bin functional-lib functional-srv ## executes all the components' functional test suites
 functional-all: functional
 test: functional ## executes all components' test suites
@@ -110,12 +97,86 @@ unit-$1: linux ## executes the $1 component's unit test suite
 endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
-define LINT
-lint-$1: linux ## executes the $1 component's linter checks
-	sh -c 'cd components/$1 && cargo build --features clippy'
-.PHONY: lint-$1
-endef
-$(foreach component,$(ALL),$(eval $(call LINT,$(component))))
+# Lints we need to work through and decide as a team whether to allow or fix
+UNEXAMINED_LINTS =
+
+# Lints we disagree with and choose to keep in our code with no warning
+ALLOWED_LINTS = clippy::module_inception \
+                clippy::new_ret_no_self \
+                clippy::new_without_default
+
+# Known failing lints we want to receive warnings for, but not fail the build
+LINTS_TO_FIX =
+
+# Lints we don't expect to have in our code at all and want to avoid adding
+# even at the cost of failing the build
+DENIED_LINTS = clippy::assign_op_pattern \
+               clippy::blacklisted_name \
+               clippy::block_in_if_condition_stmt \
+               clippy::bool_comparison \
+               clippy::cast_lossless \
+               clippy::clone_on_copy \
+               clippy::cmp_owned \
+               clippy::collapsible_if \
+               clippy::const_static_lifetime \
+               clippy::correctness \
+               clippy::cyclomatic_complexity \
+               clippy::deref_addrof \
+               clippy::expect_fun_call \
+               clippy::for_kv_map \
+               clippy::get_unwrap \
+               clippy::identity_conversion \
+               clippy::if_let_some_result \
+               clippy::large_enum_variant \
+               clippy::len_without_is_empty \
+               clippy::len_zero \
+               clippy::let_and_return \
+               clippy::let_unit_value \
+               clippy::map_clone \
+               clippy::match_bool \
+               clippy::match_ref_pats \
+               clippy::needless_bool \
+               clippy::needless_collect \
+               clippy::needless_pass_by_value \
+               clippy::needless_range_loop \
+               clippy::needless_return \
+               clippy::needless_update \
+               clippy::ok_expect \
+               clippy::op_ref \
+               clippy::option_map_unit_fn \
+               clippy::or_fun_call \
+               clippy::println_empty_string \
+               clippy::ptr_arg \
+               clippy::question_mark \
+               clippy::redundant_closure \
+               clippy::redundant_field_names \
+               clippy::redundant_pattern_matching \
+               clippy::single_char_pattern \
+               clippy::single_match \
+               clippy::string_lit_as_bytes \
+               clippy::too_many_arguments \
+               clippy::toplevel_ref_arg \
+               clippy::trivially_copy_pass_by_ref \
+               clippy::unit_arg \
+               clippy::unnecessary_operation \
+               clippy::unreadable_literal \
+               clippy::unused_label \
+               clippy::unused_unit \
+               clippy::useless_asref \
+               clippy::useless_format \
+               clippy::useless_let_if_seq \
+               clippy::useless_vec \
+               clippy::write_with_newline \
+               clippy::wrong_self_convention \
+               renamed_and_removed_lints
+
+lint:
+	$(run) cargo clippy --all-targets --tests $(CARGO_FLAGS) -- \
+					$(addprefix -A ,$(UNEXAMINED_LINTS)) \
+					$(addprefix -A ,$(ALLOWED_LINTS)) \
+					$(addprefix -W ,$(LINTS_TO_FIX)) \
+					$(addprefix -D ,$(DENIED_LINTS))
+.PHONY: lint
 
 define FUNCTIONAL
 functional-$1: linux ## executes the $1 component's functional test suite

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -256,6 +256,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::cyclomatic_complexity)]
     fn config_from_file() {
         let content = r#"
         [api]

--- a/components/builder-core/src/build_config.rs
+++ b/components/builder-core/src/build_config.rs
@@ -205,7 +205,7 @@ impl Default for ProjectCfg {
 mod test {
     use super::*;
 
-    const CONFIG: &'static str = r#"
+    const CONFIG: &str = r#"
     [hab-sup]
     plan_path = "components/hab-sup"
     branches = [

--- a/components/builder-jobsrv/src/server/log_archiver/local.rs
+++ b/components/builder-jobsrv/src/server/log_archiver/local.rs
@@ -96,8 +96,8 @@ mod tests {
     #[test]
     fn local_archive_path() {
         let archiver = LocalArchiver(PathBuf::from("/archive"));
-        let job_id: u64 = 722543779847979008;
-        let expected_path = PathBuf::from("/archive/0a/6b/ef/ac/722543779847979008.log");
+        let job_id: u64 = 722_543_779_847_979_008;
+        let expected_path = PathBuf::from(format!("/archive/0a/6b/ef/ac/{}.log", job_id));
         let actual_path = archiver.archive_path(job_id);
         assert_eq!(actual_path, expected_path);
     }

--- a/components/builder-protocol/src/jobsrv.rs
+++ b/components/builder-protocol/src/jobsrv.rs
@@ -482,10 +482,7 @@ mod tests {
 
         log.strip_ansi();
 
-        let stripped_lines: Vec<String> = log.get_content()
-                                             .into_iter()
-                                             .map(|l| l.to_string())
-                                             .collect();
+        let stripped_lines: Vec<String> = log.get_content().to_vec();
 
         let expected = vec!["» Importing origin key from standard log",
                             "★ Imported secret origin key core-20160810182414.",

--- a/components/builder-worker/src/runner/workspace.rs
+++ b/components/builder-worker/src/runner/workspace.rs
@@ -183,7 +183,7 @@ impl Default for StudioBuild {
 mod tests {
     use super::*;
 
-    const LAST_BUILD: &'static str = "
+    const LAST_BUILD: &str = "
     pkg_origin=core
     pkg_name=valgrind
     pkg_version=3.12.0
@@ -194,7 +194,7 @@ mod tests {
     pkg_blake2bsum=3b38af666a8f307b89ae47ff098cb75503ee15892d1a8a98d0ae24da1cfd153b
     ";
 
-    const PRE_BUILD: &'static str = "
+    const PRE_BUILD: &str = "
     pkg_origin=core
     pkg_name=redis
     pkg_version=3.2.4


### PR DESCRIPTION
- Change the list of lints in the Makefile to have parity with habitat
- Update TravisCI to use the Makefile for running clippy
- Fix a few lints

See:
https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal
https://rust-lang.github.io/rust-clippy/master/index.html#cyclomatic_complexity
https://rust-lang.github.io/rust-clippy/master/index.html#const_static_lifetime
https://rust-lang.github.io/rust-clippy/master/index.html#into_iter_on_ref