### PR TITLE
Stop Docker build job when canceling

### DIFF
--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -31,6 +31,8 @@ use std::{fs,
                    JoinHandle},
           time::Duration};
 
+use std::process::Command;
+
 use chrono::Utc;
 use retry::retry;
 use zmq;
@@ -431,6 +433,14 @@ impl Runner {
                 Ok(None) => {
                     if self.is_canceled() {
                         debug!("Canceling job: {}", self.job().get_id());
+                        {
+                            let mut cmd = Command::new(&"docker");
+                            cmd.arg("rm");
+                            cmd.arg("builder");
+                            cmd.arg("--force");
+                            let output = cmd.output().expect("Failed to cancel docker job");
+                            debug!("docker rm status: {}", output.status);
+                        }
                         if let Err(err) = child.kill() {
                             debug!("Failed to kill child, err: {:?}", err);
                         }

--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -118,6 +118,8 @@ impl<'a> Studio<'a> {
         // for progress on this front.
         cmd.env("HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL", "true");
 
+        cmd.env("HAB_DOCKER_OPTS", "--name builder");
+
         for secret in self.workspace.job.get_secrets() {
             cmd.env(format!("HAB_STUDIO_SECRET_{}",
                             secret.get_decrypted_secret().get_name()),


### PR DESCRIPTION
This change stops the Docker studio container when a job is cancelled.  Without this change, leftover studios continue running on the system even when jobs are cancelled.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-163058191](https://user-images.githubusercontent.com/13542112/54617440-81488a80-4a1e-11e9-9f68-2faaa81b9867.gif)
