### PR TITLE
Add enabled config for Segment usage

### DIFF
--- a/components/builder-api/src/server/resources/authenticate.rs
+++ b/components/builder-api/src/server/resources/authenticate.rs
@@ -72,9 +72,7 @@ fn do_authenticate(req: &HttpRequest<AppState>, code: &str) -> Result<originsrv:
     let session = session_create_oauth(req, &token, &user, &oauth.config.provider)?;
 
     let id_str = session.get_id().to_string();
-    if let Err(e) = req.state().segment.identify(&id_str) {
-        debug!("Error identifying a user in segment, {}", e);
-    }
+    req.state().segment.identify(&id_str);
 
     Ok(session)
 }

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -439,12 +439,7 @@ fn schedule_job_group((qschedule, req): (Query<Schedule>, HttpRequest<AppState>)
     match route_message::<jobsrv::JobGroupSpec, jobsrv::JobGroup>(&req, &request) {
         Ok(group) => {
             let msg = format!("Scheduled job group for {}", group.get_project_name());
-
-            // We don't really want to abort anything just because a call to segment failed. Let's
-            // just log it and move on.
-            if let Err(e) = req.state().segment.track(&session.get_name(), &msg) {
-                debug!("Error tracking scheduling of job group in segment, {}", e);
-            }
+            req.state().segment.track(&session.get_name(), &msg);
 
             HttpResponse::Created().header(http::header::CACHE_CONTROL, headers::NO_CACHE)
                                    .json(group)

--- a/components/segment-api-client/src/config.rs
+++ b/components/segment-api-client/src/config.rs
@@ -23,12 +23,15 @@ pub struct SegmentCfg {
     pub url: String,
     /// Write key used for Segment API requests
     pub write_key: String,
+    /// Whether Segment reporting is enabled
+    pub enabled: bool,
 }
 
 impl Default for SegmentCfg {
     fn default() -> Self {
         SegmentCfg { url:       DEFAULT_SEGMENT_URL.to_string(),
-                     write_key: "".to_string(), }
+                     write_key: "".to_string(),
+                     enabled:   false, }
     }
 }
 

--- a/components/segment-api-client/src/main.rs
+++ b/components/segment-api-client/src/main.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 // NOTE: This is only here to allow manual testing of the API client.
-#[macro_use]
-extern crate log;
 use segment_api_client as segment;
 
 use std::{env,
@@ -34,18 +32,6 @@ fn main() {
     }
 
     let client = SegmentClient::new(config);
-    match client.identify("abc123") {
-        Ok(_) => (),
-        Err(e) => {
-            debug!("Error calling identify. e = {:?}", e);
-            exit(1);
-        }
-    }
-    match client.track("abc123", "tested tracking") {
-        Ok(_) => (),
-        Err(e) => {
-            debug!("Error calling identify. e = {:?}", e);
-            exit(1);
-        }
-    }
+    client.identify("abc123");
+    client.track("abc123", "tested tracking");
 }


### PR DESCRIPTION
This change adds a config setting for Segment reporting capability. By default, the reporting will be disabled as it can cause issues with some on-premise infra. 

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-215477758](https://user-images.githubusercontent.com/13542112/54939322-88234180-4ee5-11e9-9ead-dea20d10b352.gif)
