### PR TITLE
Remove package from cache after deletion

### DIFF
--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -396,7 +396,13 @@ fn delete_package((qtarget, req): (Query<Target>, HttpRequest<AppState>)) -> Htt
                                           target: BuilderPackageTarget(target), },
                           &*conn).map_err(Error::DieselError)
     {
-        Ok(_) => HttpResponse::NoContent().finish(),
+        Ok(_) => {
+            req.state()
+               .memcache
+               .borrow_mut()
+               .clear_cache_for_package(&ident);
+            HttpResponse::NoContent().finish()
+        }
         Err(err) => {
             debug!("{}", err);
             err.into()

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -460,6 +460,16 @@ describe('Working with packages', function () {
         });
     });
 
+    it('requires a member of the origin', function (done) {
+      request.delete(`/depot/pkgs/neurosis/testapp3/0.1.0/${release9}`)
+        .set('Authorization', global.mystiqueBearer)
+        .expect(403)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
     it('fails for package in stable channel', function (done) {
       request.delete(`/depot/pkgs/neurosis/testapp3/0.1.0/${release9}`)
         .set('Authorization', global.boboBearer)
@@ -490,6 +500,20 @@ describe('Working with packages', function () {
         });
     });
 
+    it('returns the package in the latest call', function (done) {
+      request.get('/depot/pkgs/neurosis/testapp3/latest')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.ident.origin).to.equal('neurosis');
+          expect(res.body.ident.name).to.equal('testapp3');
+          expect(res.body.ident.version).to.equal('0.1.0');
+          expect(res.body.ident.release).to.equal(release9);
+          done(err);
+        });
+    });
+
     it('succeeds for non-stable, leaf packages', function (done) {
       request.delete(`/depot/pkgs/neurosis/testapp3/0.1.0/${release9}`)
         .set('Authorization', global.boboBearer)
@@ -497,6 +521,17 @@ describe('Working with packages', function () {
         .end(function (err, res) {
           expect(res.text).to.be.empty;
           done(err)
+        });
+    });
+
+    it('doesnt return the package in the latest call', function (done) {
+      request.get('/depot/pkgs/neurosis/testapp3/latest')
+        .type('application/json')
+        .accept('application/json')
+        .expect(404)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty
+          done(err);
         });
     });
   });


### PR DESCRIPTION
This fixes a missed case in the package deletion flow, where we did not remove the package from memcache upon deletion. Also adds a few more tests.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-103527359](https://user-images.githubusercontent.com/13542112/55185652-113eb080-5152-11e9-9dec-4cb90dbbba60.gif)
