### PR TITLE
Remove unneeded account

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -349,13 +349,6 @@ DEV_MODE=true
 
 load_env_config
 
-touch /etc/subuid
-touch /etc/subgid
-hab pkg exec core/shadow groupadd --force krangschnak
-if ! hab pkg exec core/coreutils id -u krangschnak > /dev/null; then
-  hab pkg exec core/shadow useradd --groups=tty --create-home -g krangschnak krangschnak
-fi
-
 trap local_cleanup EXIT
 
 welcome


### PR DESCRIPTION
Remove un-needed usage of worker account. Resolves https://app.zenhub.com/workspaces/57e1e83308ec936f021c876a/issues/habitat-sh/builder/980

Signed-off-by: Salim Alam <salam@chef.io>