### PR TITLE
Ignore generated files

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -53,3 +53,6 @@ trailing_semicolon = true
 type_punctuation_density = "Wide"
 where_single_line = false
 wrap_comments = true
+ignore = [
+  "components/builder-protocol/src/message",
+]


### PR DESCRIPTION
I'm aware that `components/builder-protocol/src/message/mod.rs` is _not_ a generated file, but typically this file is problematic as well, and it's quite small, so ignoring it should make the silly CI errors stop.

![](https://media.giphy.com/media/yE72eDy7lj3JS/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>