### PR TITLE
Add target params to pkg related APIs

### DIFF
--- a/components/builder-api/src/server/resources/jobs.rs
+++ b/components/builder-api/src/server/resources/jobs.rs
@@ -432,7 +432,11 @@ fn do_get_job(req: &HttpRequest<AppState>, job_id: u64) -> Result<String> {
 
             if job.get_package_ident().fully_qualified() {
                 let builder_package_ident = BuilderPackageIdent(job.get_package_ident().into());
-                let channels = channels_for_package_ident(req, &builder_package_ident, &*conn)?;
+                let channels =
+                    channels_for_package_ident(req,
+                                               &builder_package_ident,
+                                               PackageTarget::from_str(job.get_target()).unwrap(),
+                                               &*conn)?;
                 let platforms = platforms_for_package_ident(req, &builder_package_ident)?;
                 let mut job_json = serde_json::to_value(job).unwrap();
 

--- a/components/builder-db/src/models/channel.rs
+++ b/components/builder-db/src/models/channel.rs
@@ -29,7 +29,8 @@ use crate::{models::{package::{BuilderPackageIdent,
 
 use crate::{bldr_core::metrics::{CounterMetric,
                                  HistogramMetric},
-            hab_core::ChannelIdent,
+            hab_core::{package::PackageTarget,
+                       ChannelIdent},
             metrics::{Counter,
                       Histogram}};
 
@@ -268,11 +269,13 @@ pub struct OriginChannelPackage {
 
 pub struct OriginChannelPromote {
     pub ident:   BuilderPackageIdent,
+    pub target:  PackageTarget,
     pub origin:  String,
     pub channel: ChannelIdent,
 }
 pub struct OriginChannelDemote {
     pub ident:   BuilderPackageIdent,
+    pub target:  PackageTarget,
     pub origin:  String,
     pub channel: ChannelIdent,
 }
@@ -292,6 +295,7 @@ impl OriginChannelPackage {
                                                .get_result::<i64>(conn)?;
         let package_id =
             origin_packages::table.filter(origin_packages::ident.eq(package.ident.to_string()))
+                                  .filter(origin_packages::target.eq(package.target.to_string()))
                                   .select(origin_packages::id)
                                   .limit(1)
                                   .get_result::<i64>(conn)?;
@@ -324,6 +328,7 @@ impl OriginChannelPackage {
                         .eq(origin_packages::table
                             .select(origin_packages::id)
                             .filter(origin_packages::ident.eq(package.ident.to_string()))
+                            .filter(origin_packages::target.eq(package.target.to_string()))
                             .single_value()),
                 ),
         )

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -359,6 +359,7 @@ impl Package {
                                                                  .get_result::<Package>(conn)?;
 
         OriginChannelPackage::promote(OriginChannelPromote { ident:   package.ident.clone(),
+                                                             target:  package.target.0,
                                                              origin:  package.origin.clone(),
                                                              channel: ChannelIdent::unstable(), },
                                       conn)?;
@@ -441,6 +442,7 @@ impl Package {
     }
 
     pub fn list_package_channels(ident: &BuilderPackageIdent,
+                                 target: PackageTarget,
                                  visibility: Vec<PackageVisibility>,
                                  conn: &PgConnection)
                                  -> QueryResult<Vec<Channel>> {
@@ -449,6 +451,7 @@ impl Package {
             .inner_join(origin_channel_packages::table.inner_join(origin_channels::table))
             .select(origin_channels::table::all_columns())
             .filter(origin_packages::ident.eq(ident))
+            .filter(origin_packages::target.eq(target.to_string()))
             .filter(origin_packages::visibility.eq(any(visibility)))
             .order(origin_channels::name.desc())
             .get_results(conn)

--- a/test/builder-api/src/jobs.js
+++ b/test/builder-api/src/jobs.js
@@ -95,7 +95,7 @@ describe('Jobs API', function () {
         .expect(200)
         .end(function (err, res) {
           expect(res.body).to.not.be.empty;
-          expect(['Queued', 'Dispatching']).to.include(res.body.state);
+          expect(['Queued', 'Pending', 'Dispatching']).to.include(res.body.state);
           expect(res.body.project_name).to.equal('neurosis/testapp');
           done(err);
         });
@@ -111,7 +111,7 @@ describe('Jobs API', function () {
         .end(function (err, res) {
           expect(res.body).to.not.be.empty;
           expect(res.body.length).to.equal(1);
-          expect(['Queued', 'Dispatching']).to.include(res.body[0].state);
+          expect(['Queued', 'Pending', 'Dispatching']).to.include(res.body[0].state);
           expect(res.body[0].project_name).to.equal('neurosis/testapp');
           done(err);
         });


### PR DESCRIPTION
This change adds target query param handling to some package related APIs that were missing it - package promote, demote and channel list.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-172904196](https://user-images.githubusercontent.com/13542112/55451029-1783c100-5586-11e9-8313-9b12b62c8f46.gif)
