### PR TITLE
Fix build worker package upload/promotion

### DIFF
--- a/components/builder-worker/src/runner/publisher.rs
+++ b/components/builder-worker/src/runner/publisher.rs
@@ -46,6 +46,7 @@ impl Publisher {
 
         let client = ApiClient::new(&self.url);
         let ident = archive.ident().unwrap();
+        let target = archive.target().unwrap();
 
         match retry(RETRIES,
                     RETRY_WAIT,
@@ -99,7 +100,7 @@ impl Publisher {
 
             match retry(RETRIES,
                         RETRY_WAIT,
-                        || client.promote_package(&ident, channel, auth_token),
+                        || client.promote_package((&ident, target), channel, auth_token),
                         |res| {
                             if res.is_err() {
                                 let msg = format!("Promote {} to {}: {:?}", ident, channel, res);


### PR DESCRIPTION
This fixes builder upload and promotion for non-Linux targets, which now need to have a target query param specified appropriately.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-195263166](https://user-images.githubusercontent.com/13542112/55596151-09f04780-56fc-11e9-870d-d89f4ab848b6.gif)
