### PR TITLE
Update origin_packages constraint

### DIFF
--- a/components/builder-db/src/migrations/2019-04-05-002317_update_package_constraints/up.sql
+++ b/components/builder-db/src/migrations/2019-04-05-002317_update_package_constraints/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE origin_packages DROP CONSTRAINT origin_packages_ident_key;
+ALTER TABLE origin_packages ADD CONSTRAINT origin_packages_ident_target_key UNIQUE(ident, target);


### PR DESCRIPTION
This change updates the builder package schema to update the constraint to be (ident, target) uniqueness instead of just ident uniqueness. 

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-83245304](https://user-images.githubusercontent.com/13542112/55598080-acf98f00-5705-11e9-98df-3f076e250ec5.gif)
