### PR TITLE
Fix up web UI to use targets for promote/demote actions

### DIFF
--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -72,13 +72,13 @@ function clearPackageVersions() {
   };
 }
 
-export function demotePackage(origin: string, name: string, version: string, release: string, channel: string, token: string) {
+export function demotePackage(origin: string, name: string, version: string, release: string, target: string, channel: string, token: string) {
   return dispatch => {
-    depotApi.demotePackage(origin, name, version, release, channel, token)
+    depotApi.demotePackage(origin, name, version, release, target, channel, token)
       .then(response => {
         dispatch(addNotification({
           title: 'Package demoted',
-          body: `${origin}/${name}/${version}/${release} has been removed from the ${channel} channel.`,
+          body: `${origin}/${name}/${version}/${release} (${target}) has been removed from the ${channel} channel.`,
           type: SUCCESS
         }));
         dispatch(fetchLatestInChannel(origin, name, 'stable'));
@@ -222,13 +222,13 @@ export function populateDashboardRecent(data) {
   };
 }
 
-export function promotePackage(origin: string, name: string, version: string, release: string, channel: string, token: string) {
+export function promotePackage(origin: string, name: string, version: string, release: string, target: string, channel: string, token: string) {
   return dispatch => {
-    depotApi.promotePackage(origin, name, version, release, channel, token)
+    depotApi.promotePackage(origin, name, version, release, target, channel, token)
       .then(response => {
         dispatch(addNotification({
           title: 'Package promoted',
-          body: `${origin}/${name}/${version}/${release} has been promoted to the ${channel} channel.`,
+          body: `${origin}/${name}/${version}/${release} (${target}) has been promoted to the ${channel} channel.`,
           type: SUCCESS
         }));
         dispatch(fetchLatestInChannel(origin, name, 'stable'));

--- a/components/builder-web/app/client/depot-api.ts
+++ b/components/builder-web/app/client/depot-api.ts
@@ -60,8 +60,8 @@ function handleUnauthorized(response, reject) {
   return response;
 }
 
-export function demotePackage(origin: string, name: string, version: string, release: string, channel: string, token: string) {
-  const url = `${urlPrefix}/depot/channels/${origin}/${channel}/pkgs/${name}/${version}/${release}/demote`;
+export function demotePackage(origin: string, name: string, version: string, release: string, target: string, channel: string, token: string) {
+  const url = `${urlPrefix}/depot/channels/${origin}/${channel}/pkgs/${name}/${version}/${release}/demote?target=${target}`;
 
   return new Promise((resolve, reject) => {
     fetch(url, {
@@ -238,8 +238,8 @@ export function getPackageVersions(origin: string, pkg: string) {
   });
 }
 
-export function promotePackage(origin: string, name: string, version: string, release: string, channel: string, token: string) {
-  const url = `${urlPrefix}/depot/channels/${origin}/${channel}/pkgs/${name}/${version}/${release}/promote`;
+export function promotePackage(origin: string, name: string, version: string, release: string, target: string, channel: string, token: string) {
+  const url = `${urlPrefix}/depot/channels/${origin}/${channel}/pkgs/${name}/${version}/${release}/promote?target=${target}`;
 
   return new Promise((resolve, reject) => {
     fetch(url, {

--- a/components/builder-web/app/package/package-detail/package-detail.component.html
+++ b/components/builder-web/app/package/package-detail/package-detail.component.html
@@ -36,6 +36,7 @@
             [name]="package.ident.name"
             [version]="package.ident.version"
             [release]="package.ident.release"
+            [target]="package.target"
             channel="stable"
             *ngIf="promotable(package)">
           </hab-package-promote>

--- a/components/builder-web/app/package/package-detail/package-detail.component.spec.ts
+++ b/components/builder-web/app/package/package-detail/package-detail.component.spec.ts
@@ -32,7 +32,7 @@ class MockAppStore {
       }
     };
   }
-  dispatch() {}
+  dispatch() { }
 }
 
 class MockRoute {
@@ -53,9 +53,9 @@ describe('PackageDetailComponent', () => {
       declarations: [
         PackageDetailComponent,
         MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] }),
-        MockComponent({ selector: 'hab-channels', inputs: ['channels', 'canDemote'], outputs: ['demote']}),
+        MockComponent({ selector: 'hab-channels', inputs: ['channels', 'canDemote'], outputs: ['demote'] }),
         MockComponent({ selector: 'hab-package-list', inputs: ['currentPackage', 'packages'] }),
-        MockComponent({ selector: 'hab-package-promote', inputs: [ 'origin', 'name', 'version', 'release', 'channel' ] }),
+        MockComponent({ selector: 'hab-package-promote', inputs: ['origin', 'name', 'version', 'release', 'target', 'channel'] }),
         MockComponent({ selector: 'hab-copyable', inputs: ['text', 'style'] })
       ],
       providers: [

--- a/components/builder-web/app/package/package-detail/package-detail.component.ts
+++ b/components/builder-web/app/package/package-detail/package-detail.component.ts
@@ -24,7 +24,7 @@ import { demotePackage } from '../../actions/index';
 export class PackageDetailComponent {
   @Input() package: any;
 
-  constructor(private store: AppStore) {}
+  constructor(private store: AppStore) { }
 
   get channels() {
     return this.store.getState().packages.currentChannels;
@@ -52,7 +52,7 @@ export class PackageDetailComponent {
   handleDemote(channel) {
     let p = this.package.ident;
     let token = this.store.getState().session.token;
-    this.store.dispatch(demotePackage(p.origin, p.name, p.version, p.release, channel, token));
+    this.store.dispatch(demotePackage(p.origin, p.name, p.version, p.release, this.package.target, channel, token));
   }
 
   promotable(pkg) {

--- a/components/builder-web/app/package/package-promote/package-promote.component.ts
+++ b/components/builder-web/app/package/package-promote/package-promote.component.ts
@@ -14,6 +14,7 @@ export class PackagePromoteComponent {
   @Input() version: string;
   @Input() release: string;
   @Input() channel: string;
+  @Input() target: string;
 
   promoting: boolean = false;
 
@@ -41,7 +42,7 @@ export class PackagePromoteComponent {
 
           setTimeout(() => {
             this.store.dispatch(
-              promotePackage(this.origin, this.name, this.version, this.release, this.channel, this.store.getState().session.token)
+              promotePackage(this.origin, this.name, this.version, this.release, this.target, this.channel, this.store.getState().session.token)
             );
           }, 1000);
         }

--- a/components/builder-web/app/package/package-versions/package-versions.component.html
+++ b/components/builder-web/app/package/package-versions/package-versions.component.html
@@ -53,6 +53,7 @@
                 [name]="pkg.name"
                 [version]="pkg.version"
                 [release]="pkg.release"
+                [target]="pkg.target"
                 channel="stable"
                 *ngIf="promotable(pkg)">
               </hab-package-promote>

--- a/components/builder-web/app/package/package-versions/package-versions.component.spec.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.spec.ts
@@ -66,7 +66,7 @@ describe('PackageVersionsComponent', () => {
         MockComponent({ selector: 'hab-icon', inputs: ['symbol', 'title'] }),
         MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] }),
         MockComponent({ selector: 'hab-channels', inputs: ['channels', 'canDemote'] }),
-        MockComponent({ selector: 'hab-package-promote', inputs: ['origin', 'name', 'version', 'release', 'channel'] }),
+        MockComponent({ selector: 'hab-package-promote', inputs: ['origin', 'name', 'version', 'release', 'target', 'channel'] }),
         MockComponent({ selector: 'hab-copyable', inputs: ['text', 'style'] })
       ],
       providers: [

--- a/components/builder-web/app/package/package-versions/package-versions.component.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.ts
@@ -90,7 +90,7 @@ export class PackageVersionsComponent implements OnDestroy {
 
   handleDemote(pkg, channel) {
     let token = this.store.getState().session.token;
-    this.store.dispatch(demotePackage(pkg.origin, pkg.name, pkg.version, pkg.release, channel, token));
+    this.store.dispatch(demotePackage(pkg.origin, pkg.name, pkg.version, pkg.release, pkg.target, channel, token));
   }
 
   promotable(pkg) {


### PR DESCRIPTION
This fixes the promotion/demotion in the web UI by adding a package target query param to the API calls.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-17165340](https://user-images.githubusercontent.com/13542112/55664356-19958c00-57e1-11e9-99c7-28efd1ef9362.gif)
