### PR TITLE
Update ELB SSL cert management to use ACM cert

### DIFF
--- a/terraform/load-balancers.tf
+++ b/terraform/load-balancers.tf
@@ -1,3 +1,9 @@
+data "aws_acm_certificate" "ssl" {
+  domain      = "habitat.sh"
+  types       = ["AMAZON_ISSUED"]
+  most_recent = true
+}
+
 resource "aws_elb" "api" {
   name            = "builder-api-gateway-${var.env}"
   security_groups = ["${aws_security_group.gateway_elb.id}"]
@@ -10,7 +16,7 @@ resource "aws_elb" "api" {
     instance_protocol  = "HTTP"
     lb_port            = 443
     lb_protocol        = "HTTPS"
-    ssl_certificate_id = "${var.ssl_certificate_arn}"
+    ssl_certificate_id = "${data.aws_acm_certificate.ssl.arn}"
   }
 
   health_check {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,10 +69,6 @@ variable "http_listen_port" {
   default     = 9631
 }
 
-variable "ssl_certificate_arn" {
-  description = "Amazon Resource Name (ARN) for the environment's ssl certificate"
-}
-
 variable "public_subnet_id" {
   description = "Identifier for public AWS subnet"
 }


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/builder/issues/1012

We no longer need to manually muck with certs during Terraform setup.

There will be a corresponding PR in the cloud environments repo.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-2169262](https://user-images.githubusercontent.com/13542112/55821808-2b15b700-5ab3-11e9-89b3-37281b3433e5.gif)
