### PR TITLE
Add artifactory object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "artifactory-client"
+version = "0.0.0"
+dependencies = [
+ "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
+ "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +970,7 @@ version = "0.0.0"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "artifactory-client 0.0.0",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ debug = true
 
 [workspace]
 members = [
+  "components/artifactory-client",
   "components/builder-api",
   "components/builder-core",
   "components/builder-db",

--- a/components/artifactory-client/Cargo.toml
+++ b/components/artifactory-client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "artifactory-client"
+version = "0.0.0"
+authors = ["The Habitat Maintainers <humans@habitat.sh>"]
+workspace = "../../"
+edition = "2018"
+
+[dependencies]
+reqwest = "0.8.1"
+log = "*"
+serde = "*"
+serde_derive = "*"
+hyper = "0.11"
+
+[dependencies.habitat_core]
+git = "https://github.com/habitat-sh/core.git"

--- a/components/artifactory-client/src/client.rs
+++ b/components/artifactory-client/src/client.rs
@@ -1,0 +1,140 @@
+// Copyright (c) 2019 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap,
+          env,
+          fs::File,
+          path::PathBuf};
+
+use reqwest::{header::{Headers,
+                       UserAgent},
+              Client,
+              Proxy,
+              Response};
+
+use crate::{config::ArtifactoryCfg,
+            error::{ArtifactoryError,
+                    ArtifactoryResult}};
+
+use crate::hab_core::package::{PackageArchive,
+                               PackageIdent,
+                               PackageTarget};
+
+const USER_AGENT: &str = "Habitat-Builder";
+header! { (XJFrogArtApi, "X-JFrog-Art-Api") => [String] }
+
+#[derive(Clone)]
+pub struct ArtifactoryClient {
+    inner:       Client,
+    pub api_url: String,
+    pub api_key: String,
+    pub repo:    String,
+}
+
+impl ArtifactoryClient {
+    pub fn new(config: ArtifactoryCfg) -> Self {
+        let mut headers = Headers::new();
+        headers.set(UserAgent::new(USER_AGENT));
+        headers.set(XJFrogArtApi(config.api_key.to_owned()));
+
+        let mut client = Client::builder();
+        client.default_headers(headers);
+
+        if let Ok(url) = env::var("HTTP_PROXY") {
+            debug!("Using HTTP_PROXY: {}", url);
+            match Proxy::http(&url) {
+                Ok(p) => {
+                    client.proxy(p);
+                }
+                Err(e) => warn!("Invalid proxy url: {}, err: {:?}", url, e),
+            }
+        }
+
+        if let Ok(url) = env::var("HTTPS_PROXY") {
+            debug!("Using HTTPS_PROXY: {}", url);
+            match Proxy::https(&url) {
+                Ok(p) => {
+                    client.proxy(p);
+                }
+                Err(e) => warn!("Invalid proxy url: {}, err: {:?}", url, e),
+            }
+        }
+
+        ArtifactoryClient { inner:   client.build().unwrap(),
+                            api_url: config.api_url,
+                            api_key: config.api_key,
+                            repo:    config.repo, }
+    }
+
+    pub fn upload(&self,
+                  source_path: &PathBuf,
+                  ident: &PackageIdent,
+                  target: PackageTarget)
+                  -> ArtifactoryResult<Response> {
+        debug!("ArtifactoryClient upload request for file path: {:?}",
+               source_path);
+
+        let url = self.url_path_for(ident, target);
+        debug!("ArtifactoryClient upload url = {}", url);
+
+        let file = File::open(source_path).map_err(ArtifactoryError::IO)?;
+
+        self.inner
+            .put(&url)
+            .body(file)
+            .send()
+            .map_err(ArtifactoryError::HttpClient)
+    }
+
+    pub fn download(&self,
+                    destination_path: &PathBuf,
+                    ident: &PackageIdent,
+                    target: PackageTarget)
+                    -> ArtifactoryResult<PackageArchive> {
+        debug!("ArtifactoryClient download request for {} ({}) to destination path: {:?}",
+               ident, target, destination_path);
+
+        let url = self.url_path_for(ident, target);
+        debug!("ArtifactoryClient download url = {}", url);
+
+        let mut resp = self.inner
+                           .get(&url)
+                           .send()
+                           .map_err(ArtifactoryError::HttpClient)?;
+
+        debug!("Artifactory response status: {:?}", resp.status());
+
+        if resp.status().is_success() {
+            let mut file = File::create(destination_path).map_err(ArtifactoryError::IO)?;
+            std::io::copy(&mut resp, &mut file)?;
+            Ok(PackageArchive::new(destination_path))
+        } else {
+            Err(ArtifactoryError::ApiError(resp.status(), HashMap::new()))
+        }
+    }
+
+    fn url_path_for(&self, ident: &PackageIdent, target: PackageTarget) -> String {
+        let hart_name = ident.archive_name_with_target(target)
+                             .expect("ident is fully qualified");
+
+        let url = format!("{}/artifactory/{}/{}/{}/{}",
+                          self.api_url,
+                          self.repo,
+                          ident.iter().collect::<Vec<&str>>().join("/"),
+                          target.iter().collect::<Vec<&str>>().join("/"),
+                          hart_name);
+
+        url
+    }
+}

--- a/components/artifactory-client/src/config.rs
+++ b/components/artifactory-client/src/config.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// URL to GitHub API endpoint
+pub const DEFAULT_ARTIFACTORY_API_URL: &str = "http://localhost:8081";
+
+/// Default repository name
+pub const DEFAULT_ARTIFACTORY_REPO: &str = "habitat-artifact-store";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ArtifactoryCfg {
+    /// URL to Artifactory API
+    pub api_url: String,
+    /// Artifactory API key
+    pub api_key: String,
+    // Repo name
+    pub repo: String,
+}
+
+impl Default for ArtifactoryCfg {
+    fn default() -> Self {
+        ArtifactoryCfg { api_url: DEFAULT_ARTIFACTORY_API_URL.to_string(),
+                         api_key: "".to_string(),
+                         repo:    DEFAULT_ARTIFACTORY_REPO.to_string(), }
+    }
+}

--- a/components/artifactory-client/src/error.rs
+++ b/components/artifactory-client/src/error.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap,
+          error,
+          fmt,
+          io};
+
+use reqwest;
+
+pub type ArtifactoryResult<T> = Result<T, ArtifactoryError>;
+
+#[derive(Debug)]
+pub enum ArtifactoryError {
+    ApiError(reqwest::StatusCode, HashMap<String, String>),
+    HttpClient(reqwest::Error),
+    IO(io::Error),
+}
+
+impl fmt::Display for ArtifactoryError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            ArtifactoryError::ApiError(ref code, ref response) => {
+                format!("Received a non-200 response, status={}, response={:?}",
+                        code, response)
+            }
+            ArtifactoryError::HttpClient(ref e) => format!("{}", e),
+            ArtifactoryError::IO(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for ArtifactoryError {
+    fn description(&self) -> &str {
+        match *self {
+            ArtifactoryError::ApiError(..) => "Response returned a non-200 status code.",
+            ArtifactoryError::HttpClient(ref err) => err.description(),
+            ArtifactoryError::IO(ref err) => err.description(),
+        }
+    }
+}
+
+impl From<io::Error> for ArtifactoryError {
+    fn from(err: io::Error) -> Self { ArtifactoryError::IO(err) }
+}

--- a/components/artifactory-client/src/lib.rs
+++ b/components/artifactory-client/src/lib.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate hyper;
+
+pub mod client;
+pub mod config;
+pub mod error;
+
+use habitat_core as hab_core;
+
+pub use crate::{client::ArtifactoryClient,
+                config::ArtifactoryCfg,
+                error::{ArtifactoryError,
+                        ArtifactoryResult}};

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -61,6 +61,9 @@ features = [ "suggestions", "color", "unstable" ]
 git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
+[dependencies.artifactory-client]
+path = "../artifactory-client"
+
 [dependencies.oauth-client]
 path = "../oauth-client"
 

--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -17,6 +17,9 @@ app_private_key = "{{pkg.svc_files_path}}/builder-github-app.pem"
 [s3]
 {{toToml cfg.s3}}
 
+[artifactory]
+{{toToml cfg.artifactory}}
+
 [segment]
 {{toToml cfg.segment}}
 

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -27,6 +27,7 @@ use std::{env,
 
 use num_cpus;
 
+use artifactory_client::config::ArtifactoryCfg;
 use github_api_client::config::GitHubCfg;
 use oauth_client::config::OAuth2Cfg;
 use segment_api_client::SegmentCfg;
@@ -52,30 +53,32 @@ pub trait GatewayCfg {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
-    pub api:       ApiCfg,
-    pub github:    GitHubCfg,
-    pub http:      HttpCfg,
-    pub oauth:     OAuth2Cfg,
-    pub s3:        S3Cfg,
-    pub segment:   SegmentCfg,
-    pub ui:        UiCfg,
-    pub memcache:  MemcacheCfg,
-    pub jobsrv:    JobsrvCfg,
-    pub datastore: DataStoreCfg,
+    pub api:         ApiCfg,
+    pub artifactory: ArtifactoryCfg,
+    pub github:      GitHubCfg,
+    pub http:        HttpCfg,
+    pub oauth:       OAuth2Cfg,
+    pub s3:          S3Cfg,
+    pub segment:     SegmentCfg,
+    pub ui:          UiCfg,
+    pub memcache:    MemcacheCfg,
+    pub jobsrv:      JobsrvCfg,
+    pub datastore:   DataStoreCfg,
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Config { api:       ApiCfg::default(),
-                 github:    GitHubCfg::default(),
-                 http:      HttpCfg::default(),
-                 oauth:     OAuth2Cfg::default(),
-                 s3:        S3Cfg::default(),
-                 segment:   SegmentCfg::default(),
-                 ui:        UiCfg::default(),
-                 memcache:  MemcacheCfg::default(),
-                 jobsrv:    JobsrvCfg::default(),
-                 datastore: DataStoreCfg::default(), }
+        Config { api:         ApiCfg::default(),
+                 artifactory: ArtifactoryCfg::default(),
+                 github:      GitHubCfg::default(),
+                 http:        HttpCfg::default(),
+                 oauth:       OAuth2Cfg::default(),
+                 s3:          S3Cfg::default(),
+                 segment:     SegmentCfg::default(),
+                 ui:          UiCfg::default(),
+                 memcache:    MemcacheCfg::default(),
+                 jobsrv:      JobsrvCfg::default(),
+                 datastore:   DataStoreCfg::default(), }
     }
 }
 

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -39,6 +39,7 @@ use crate::{bldr_core::rpc::RpcClient,
                  DbPool}};
 use github_api_client::GitHubClient;
 
+use artifactory_client::client::ArtifactoryClient;
 use oauth_client::client::OAuth2Client;
 use segment_api_client::SegmentClient;
 
@@ -64,20 +65,22 @@ use crate::config::{Config,
 features! {
     pub mod feat {
         const List = 0b0000_0001,
-        const Jobsrv = 0b0000_0010
+        const Jobsrv = 0b0000_0010,
+        const Artifactory = 0b0000_0100
     }
 }
 
 // Application state
 pub struct AppState {
-    config:   Config,
-    packages: S3Handler,
-    github:   GitHubClient,
-    jobsrv:   RpcClient,
-    oauth:    OAuth2Client,
-    segment:  SegmentClient,
-    memcache: RefCell<MemcacheClient>,
-    db:       DbPool,
+    config:      Config,
+    packages:    S3Handler,
+    github:      GitHubClient,
+    jobsrv:      RpcClient,
+    oauth:       OAuth2Client,
+    segment:     SegmentClient,
+    memcache:    RefCell<MemcacheClient>,
+    artifactory: ArtifactoryClient,
+    db:          DbPool,
 }
 
 impl AppState {
@@ -89,13 +92,15 @@ impl AppState {
                    oauth: OAuth2Client::new(config.oauth.clone()),
                    segment: SegmentClient::new(config.segment.clone()),
                    memcache: RefCell::new(MemcacheClient::new(&config.memcache.clone())),
+                   artifactory: ArtifactoryClient::new(config.artifactory.clone()),
                    db }
     }
 }
 
 fn enable_features(config: &Config) {
-    let features: HashMap<_, _> =
-        HashMap::from_iter(vec![("LIST", feat::List), ("JOBSRV", feat::Jobsrv)]);
+    let features: HashMap<_, _> = HashMap::from_iter(vec![("LIST", feat::List),
+                                                          ("JOBSRV", feat::Jobsrv),
+                                                          ("ARTIFACTORY", feat::Artifactory)]);
     let features_enabled = config.api
                                  .features_enabled
                                  .split(',')


### PR DESCRIPTION
This change enables use of JFrog Artifactory as an optional back end store. This feature is an early preview, and can be enabled via use of a feature flag. It is not turned on by default. When enabled, the configuration for Artifactory should be provided via the builder-api config toml - the config parameters currently supported are the Artifactory REST URL, the Artifactory API key, and a repo name.  The repo must be pre-created in Artifactory.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-102355203](https://user-images.githubusercontent.com/13542112/55905304-93819880-5b86-11e9-8a3b-82f2d7cd50e9.gif)
