### PR TITLE
Add no tty flags to builder-worker

### DIFF
--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -160,6 +160,8 @@ impl<'a> Studio<'a> {
         cmd.arg("build");
         if !dev_mode {
             cmd.arg("-D"); // Use Docker studio
+            cmd.arg("--no-tty"); // Need this as of hab 0.79.0
+            cmd.arg("--non-interactive"); // Need this as of hab 0.79.0
         }
 
         if self.target == target::X86_64_WINDOWS {


### PR DESCRIPTION
Need to add a couple of flags for studio builds to work with hab 0.79

Signed-off-by: Salim Alam <salam@chef.io>