### PR TITLE
Use target when checking idents dependencies

### DIFF
--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -365,25 +365,6 @@ impl DataStore {
         Ok(packages)
     }
 
-    pub fn get_job_graph_package(&self, ident: &str) -> Result<originsrv::OriginPackage> {
-        let conn = self.pool.get()?;
-        let visibilities = vec![PackageVisibility::Public,
-                                PackageVisibility::Private,
-                                PackageVisibility::Hidden,];
-        let rows = &conn.query("SELECT * FROM get_origin_package_v5($1, $2)",
-                               &[&ident, &visibilities])
-                        .map_err(Error::JobGraphPackagesGet)?;
-
-        if rows.is_empty() {
-            error!("No package found");
-            return Err(Error::UnknownJobGraphPackage);
-        }
-
-        assert!(rows.len() == 1);
-        let package = self.row_to_origin_package(&rows.get(0))?;
-        Ok(package)
-    }
-
     pub fn is_job_group_active(&self, project_name: &str) -> Result<bool> {
         let conn = self.pool.get()?;
 


### PR DESCRIPTION
This change ensures we are using ident and target when checking dependencies.  This resolves https://github.com/habitat-sh/builder/issues/1019

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-209586595](https://user-images.githubusercontent.com/13542112/55982770-7ca67900-5c4e-11e9-8dc8-eb564d8b6192.gif)
