### PR TITLE
Workaround hab 0.79 binlink bug

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -71,6 +71,14 @@ install-packages() {
   core/curl \
   core/aws-cli \
   -b -c stable
+
+  # workaround for https://github.com/habitat-sh/habitat/issues/6418
+  hab pkg binlink core/cacerts
+  hab pkg binlink core/net-tools
+  hab pkg binlink core/procps-ng
+  hab pkg binlink core/shadow
+  hab pkg binlink core/curl
+  hab pkg binlink core/aws-cli
 }
 
 _build-builder-component() {

--- a/test/builder-api/test.sh
+++ b/test/builder-api/test.sh
@@ -97,6 +97,8 @@ build-builder > /dev/null
 echo "BUILDER BUILT build-builder returned $?"
 
 hab pkg install -b core/node
+# workaround for https://github.com/habitat-sh/habitat/issues/6418
+hab pkg binlink core/node
 cd /src/test/builder-api
 npm install mocha
 hab pkg binlink core/coreutils -d /usr/bin env


### PR DESCRIPTION
This works around a hab bug where the binlink folder is not correct - https://github.com/habitat-sh/habitat/issues/6418

Signed-off-by: Salim Alam <salam@chef.io>