### PR TITLE
Add private windows verify pipeline

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -12,3 +12,5 @@ pipelines:
   - verify:
       description: Pull Request validation tests
       public: true
+  - verify_private:
+      description: Pull Request validation tests requiring credentials

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -1,0 +1,19 @@
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 30
+
+steps:
+#######################################################################
+# Whatever needs to happen!
+#######################################################################
+
+  - label: "[test_type] :windows: component"
+    command:
+      - dir
+    agents:
+      queue: 'default-windows-privileged'
+    retry:
+      automatic:
+        limit: 1
+


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

We don't have windows public builders yet, so we'll run the windows tests in the private pipelines for the moment.