### PR TITLE
Use habitat-sh/rust-zmq instead of erickt/rust-zmq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.3 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
+ "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
 ]
 
 [[package]]
@@ -1015,7 +1015,7 @@ dependencies = [
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.3 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
+ "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
 ]
 
 [[package]]
@@ -1107,7 +1107,7 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.3 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
+ "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
 ]
 
 [[package]]
@@ -1135,7 +1135,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.3 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
+ "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
 ]
 
 [[package]]
@@ -3416,17 +3416,17 @@ dependencies = [
 [[package]]
 name = "zmq"
 version = "0.8.3"
-source = "git+https://github.com/erickt/rust-zmq?branch=release/v0.8#0d371fec87b6e3f13ea91c873e215319661cf176"
+source = "git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8#0d371fec87b6e3f13ea91c873e215319661cf176"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq-sys 0.8.3 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
+ "zmq-sys 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
 ]
 
 [[package]]
 name = "zmq-sys"
 version = "0.8.3"
-source = "git+https://github.com/erickt/rust-zmq?branch=release/v0.8#0d371fec87b6e3f13ea91c873e215319661cf176"
+source = "git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8#0d371fec87b6e3f13ea91c873e215319661cf176"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3780,5 +3780,5 @@ dependencies = [
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-"checksum zmq 0.8.3 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)" = "<none>"
-"checksum zmq-sys 0.8.3 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)" = "<none>"
+"checksum zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)" = "<none>"
+"checksum zmq-sys 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)" = "<none>"

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -58,7 +58,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq"
+git = "https://github.com/habitat-sh/rust-zmq"
 branch = "release/v0.8"
 
 [dependencies.artifactory-client]

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -27,7 +27,7 @@ toml = { version = "*", default-features = false }
 walkdir = "*"
 reqwest = "0.8.1"
 hyper = "^0.11.9"
-zmq = { git = "https://github.com/erickt/rust-zmq", branch = "release/v0.8" }
+zmq = { git = "https://github.com/habitat-sh/rust-zmq", branch = "release/v0.8" }
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -49,7 +49,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq"
+git = "https://github.com/habitat-sh/rust-zmq"
 branch = "release/v0.8"
 
 [dependencies.habitat_core]

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -36,7 +36,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq"
+git = "https://github.com/habitat-sh/rust-zmq"
 branch = "release/v0.8"
 
 [dependencies.github-api-client]


### PR DESCRIPTION
As can be seen by the changes in `Cargo.lock`, this is the exact same
code, but it comes from a fork we control.


Signed-off-by: Christopher Maier <cmaier@chef.io>