### PR TITLE
Fix origin deletion error and add tests

### DIFF
--- a/components/builder-api/src/server/authorize.rs
+++ b/components/builder-api/src/server/authorize.rs
@@ -16,8 +16,7 @@ use actix_web::HttpRequest;
 
 use crate::{bldr_core::{access_token::BUILDER_ACCOUNT_ID,
                         privilege::*},
-            db::models::{origin::*,
-                         package::Package},
+            db::models::origin::*,
             protocol::originsrv};
 
 use crate::server::{error::{Error,
@@ -99,9 +98,4 @@ pub fn check_origin_member(req: &HttpRequest<AppState>,
         let conn = req.state().db.get_conn().map_err(Error::DbError)?;
         Origin::check_membership(origin, account_id as i64, &*conn).map_err(Error::DieselError)
     }
-}
-pub fn check_origin_empty(req: &HttpRequest<AppState>, origin: &str) -> Result<bool> {
-    let conn = req.state().db.get_conn().map_err(Error::DbError)?;
-    let count = Package::count_origin_packages(&origin, &*conn).map_err(Error::DieselError)?;
-    Ok(count == 0)
 }

--- a/test/builder-api/src/origins.js
+++ b/test/builder-api/src/origins.js
@@ -2,6 +2,17 @@ const expect = require('chai').expect;
 const supertest = require('supertest');
 const request = supertest('http://localhost:9636/v1');
 
+// These magic values correspond to the testpp repo in the habitat-sh org
+const installationId = 56940;
+const repoId = 114932712;
+const projectCreatePayload = {
+  origin: 'umbrella',
+  plan_path: 'plan.sh',
+  installation_id: installationId,
+  repo_id: repoId,
+  auto_build: true
+};
+
 describe('Origin API', function () {
   describe('Create neurosis origin', function () {
     it('requires authentication', function (done) {
@@ -43,17 +54,30 @@ describe('Origin API', function () {
   });
 
   describe('Create Umbrella Corp. origin', function () {
-      it('returns the created origin', function (done) {
-        request.post('/depot/origins')
-          .set('Authorization', global.weskerBearer)
-          .send({ 'name': 'umbrella' })
-          .expect(201)
-          .end(function (err, res) {
-            expect(res.body.name).to.equal('umbrella');
-            global.originUmbrella = res.body;
-            done(err);
-          });
-      });
+    it('returns the created origin', function (done) {
+      request.post('/depot/origins')
+        .set('Authorization', global.weskerBearer)
+        .send({ 'name': 'umbrella' })
+        .expect(201)
+        .end(function (err, res) {
+          expect(res.body.name).to.equal('umbrella');
+          global.originUmbrella = res.body;
+          done(err);
+        });
+    });
+
+    it('succeeds in creating a project', function (done) {
+      this.timeout(5000);
+      request.post('/projects')
+        .type('application/json')
+        .accept('application/json')
+        .set('Authorization', global.weskerBearer)
+        .send(projectCreatePayload)
+        .expect(201)
+        .end(function (err, res) {
+          done(err);
+        });
+    });
   });
 
   describe('Create xmen origin', function () {
@@ -158,26 +182,59 @@ describe('Origin API', function () {
           done(err);
         });
     });
+
+    // TODO - add a successful deletion test
   });
 
-  // TODO - add a successful deletion test
-  describe('Origin deletion', function () {                               
-    it('requires authentication', function (done) {                              
-      request.delete('/depot/origins/umbrella')                       
-        .expect(401)                                                             
-        .end(function (err, res) {                                               
-          expect(res.text).to.be.empty;                                          
-          done(err);                                                             
-        });                                                                      
-    });     
+  describe('Origin deletion', function () {
+    it('requires authentication', function (done) {
+      request.delete('/depot/origins/umbrella')
+        .expect(401)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('requires membership in the origin', function (done) {
+      request.delete('/depot/origins/umbrella')
+        .set('Authorization', global.boboBearer)
+        .expect(403)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('fails with a conflict when not deletable', function (done) {
+      request.delete('/depot/origins/umbrella')
+        .set('Authorization', global.weskerBearer)
+        .expect(409)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('succeeds in deleting the associated project', function (done) {
+      request.delete('/projects/umbrella/testapp')
+        .type('application/json')
+        .accept('application/json')
+        .set('Authorization', global.weskerBearer)
+        .expect(204)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
 
     it('succeeds', function (done) {
       request.delete('/depot/origins/umbrella')
         .set('Authorization', global.weskerBearer)
         .expect(204)
         .end(function (err, res) {
-            expect(res.text).to.be.empty;
-            done(err);
+          expect(res.text).to.be.empty;
+          done(err);
         });
     });
   });

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -175,7 +175,7 @@ describe('Working with packages', function () {
     it('is not allowed', function (done) {
       request.delete('/depot/origins/neurosis')
         .set('Authorization', global.boboBearer)
-        .expect(422)
+        .expect(409)
         .end(function (err, res) {
           expect(res.text).to.be.empty;
           done(err)

--- a/test/builder-api/test.sh
+++ b/test/builder-api/test.sh
@@ -9,7 +9,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 clean_test_artifacts() {
    local sql origins
-  origins=( neurosis xmen )
+  origins=( neurosis xmen umbrella )
 
   # clean origins
   local origins origin_tables


### PR DESCRIPTION
This fixes up origin deletion where we were returning error 500 for cases where the origin was not 'empty' - eg, if a project was created for the origin. Now we will fail with a 409 conflict if the origin deletion does not succeed due to associated artifacts in the DB.

Also added a few more tests to validate the origin deletion behavior.

This resolves https://github.com/habitat-sh/builder/issues/1031

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-59883593](https://user-images.githubusercontent.com/13542112/56384431-3367a380-61d1-11e9-9de3-8d807364a960.gif)


