### PR TITLE
Update proxy support for artifactory client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,12 +178,14 @@ dependencies = [
 name = "artifactory-client"
 version = "0.0.0"
 dependencies = [
+ "env_proxy 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/artifactory-client/Cargo.toml
+++ b/components/artifactory-client/Cargo.toml
@@ -6,11 +6,13 @@ workspace = "../../"
 edition = "2018"
 
 [dependencies]
+env_proxy = "*"
 reqwest = "0.8.1"
 log = "*"
 serde = "*"
 serde_derive = "*"
 hyper = "0.11"
+url = "*"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"

--- a/components/artifactory-client/src/client.rs
+++ b/components/artifactory-client/src/client.rs
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 use std::{collections::HashMap,
-          env,
           fs::File,
           path::PathBuf};
 
+use env_proxy;
 use reqwest::{header::{Headers,
                        UserAgent},
               Client,
-              Proxy,
               Response};
+use url::Url;
 
 use crate::{config::ArtifactoryCfg,
             error::{ArtifactoryError,
@@ -51,24 +51,31 @@ impl ArtifactoryClient {
         let mut client = Client::builder();
         client.default_headers(headers);
 
-        if let Ok(url) = env::var("HTTP_PROXY") {
-            debug!("Using HTTP_PROXY: {}", url);
-            match Proxy::http(&url) {
-                Ok(p) => {
-                    client.proxy(p);
-                }
-                Err(e) => warn!("Invalid proxy url: {}, err: {:?}", url, e),
-            }
-        }
+        let url = Url::parse(&config.api_url).expect("valid Artifactory url must be configured");
+        debug!("ArtifactoryClient checking proxy for url: {:?}", url);
 
-        if let Ok(url) = env::var("HTTPS_PROXY") {
-            debug!("Using HTTPS_PROXY: {}", url);
-            match Proxy::https(&url) {
-                Ok(p) => {
-                    client.proxy(p);
+        if let Some(proxy_url) = env_proxy::for_url(&url).to_string() {
+            if url.scheme() == "http" {
+                debug!("Setting http_proxy to {}", proxy_url);
+                match reqwest::Proxy::http(&proxy_url) {
+                    Ok(p) => {
+                        client.proxy(p);
+                    }
+                    Err(e) => warn!("Invalid proxy, err: {:?}", e),
                 }
-                Err(e) => warn!("Invalid proxy url: {}, err: {:?}", url, e),
             }
+
+            if url.scheme() == "https" {
+                debug!("Setting https proxy to {}", proxy_url);
+                match reqwest::Proxy::https(&proxy_url) {
+                    Ok(p) => {
+                        client.proxy(p);
+                    }
+                    Err(e) => warn!("Invalid proxy, err: {:?}", e),
+                }
+            }
+        } else {
+            debug!("No proxy configured for url: {:?}", url);
         }
 
         ArtifactoryClient { inner:   client.build().unwrap(),


### PR DESCRIPTION
Adds better support for proxies (including no_proxy support) for the artifactory client

Resolves https://github.com/habitat-sh/on-prem-builder/issues/142

Signed-off-by: Salim Alam <salam@chef.io>