### PR TITLE
Fix the worker for 0.81.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,7 @@ matrix:
         - COMPONENTS=srv
         - AFFECTED_FILES="Cargo.lock .travis.yml .envrc .studiorc"
         - AFFECTED_DIRS=".secrets support $_RUST_BLDR_BIN_COMPONENTS $_RUST_BLDR_LIB_COMPONENTS"
+        - HAB_LICENSE="accept-no-persist"
       rust: 1.34.0
       sudo: required
       addons:

--- a/test/builder-api/test.sh
+++ b/test/builder-api/test.sh
@@ -96,9 +96,7 @@ echo "BUILDING BUILDER"
 build-builder > /dev/null
 echo "BUILDER BUILT build-builder returned $?"
 
-hab pkg install -b core/node
-# workaround for https://github.com/habitat-sh/habitat/issues/6418
-hab pkg binlink core/node
+hab pkg install core/node -b
 cd /src/test/builder-api
 npm install mocha
 hab pkg binlink core/coreutils -d /usr/bin env
@@ -132,7 +130,7 @@ else
   clean_test_artifacts # start with a clean slate
 
   if ! command -v npm >/dev/null 2>&1; then
-    hab pkg install -b core/node
+    hab pkg install core/node -b
   fi
 
   if ! [ -f /usr/bin/env ]; then


### PR DESCRIPTION
* All the imports at the top are the same, I just deleted the spaces between them so they're organized like all the other imports now.
* The license boilerplate isn't needed any more.
* The only meaningful change is adding the 2 environment variables for license acceptance and removing the `--no-tty` and `--non-interactive` flags (those got removed in 0.80.0 - the docker studio should auto-detect ttys now).

Please note:  these changes are _entirely untested_.  I'm in the middle of testing them now but running into time constraints so I'm putting this PR up now so y'all can see what I did.

Signed-off-by: Josh Black <raskchanky@gmail.com>