### PR TITLE
Use regexp for package version ordering

### DIFF
--- a/components/builder-db/src/migrations/2019-05-13-223900_regex_version/up.sql
+++ b/components/builder-db/src/migrations/2019-05-13-223900_regex_version/up.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW origin_package_versions AS
+    SELECT origin, name, visibility,
+    ident_array[3] as version,
+    COUNT(ident_array[4]) as release_count, 
+    MAX(ident_array[4]) as latest,
+    ARRAY_AGG(DISTINCT target) as platforms,
+    regexp_matches(ident_array[3], '([\d\.]+)(.+)?') as version_array
+    FROM origin_packages
+    GROUP BY ident_array[3], origin, name, visibility;
+
+CREATE OR REPLACE VIEW origin_packages_with_version_array AS
+    SELECT
+        id,
+        ident_array,
+        regexp_matches(ident_array[3], '([\d\.]+)(.+)?') as version_array
+    FROM origin_packages;
+
+DROP EXTENSION semver;

--- a/components/builder-db/src/schema/channel.rs
+++ b/components/builder-db/src/schema/channel.rs
@@ -19,13 +19,16 @@ table! {
 }
 
 use super::{origin::origins,
-            package::origin_packages};
+            package::{origin_packages,
+                      origin_packages_with_version_array}};
 
 joinable!(origin_channel_packages -> origin_packages (package_id));
+joinable!(origin_channel_packages -> origin_packages_with_version_array (package_id));
 joinable!(origin_channel_packages -> origin_channels (channel_id));
 joinable!(origin_channels -> origins (origin));
 
 allow_tables_to_appear_in_same_query!(origin_channels,
                                       origin_channel_packages,
                                       origin_packages,
+                                      origin_packages_with_version_array,
                                       origins);

--- a/components/builder-db/src/schema/package.rs
+++ b/components/builder-db/src/schema/package.rs
@@ -26,6 +26,15 @@ table! {
 }
 
 table! {
+    use diesel::sql_types::{Array, BigInt, Text};
+    origin_packages_with_version_array {
+        id -> BigInt,
+        ident_array -> Array<Text>,
+        version_array -> Array<Text>,
+    }
+}
+
+table! {
     use crate::models::package::PackageVisibilityMapping;
     use diesel::sql_types::{Array, BigInt, Integer, Text, Nullable, Timestamptz};
     use diesel_full_text_search::TsVector;
@@ -70,4 +79,5 @@ use super::origin::{origins,
                     origins_with_stats};
 
 joinable!(origin_packages -> origins (origin));
+joinable!(origin_packages -> origin_packages_with_version_array (id));
 joinable!(origin_packages -> origins_with_stats (origin));

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -749,50 +749,48 @@ describe('Working with packages', function () {
         });
     });
 
-    // FAILING TEST - incorrect semver sort
+    it('returns the latest release of package oddversion1', function (done) {
+      request.get('/depot/pkgs/neurosis/oddversion1/latest')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.ident.origin).to.equal('neurosis');
+          expect(res.body.ident.name).to.equal('oddversion1');
+          expect(res.body.ident.version).to.equal('R16B03-1');
+          expect(res.body.ident.release).to.equal(ov13release);
+          done(err);
+        });
+    });
 
-    // it('returns the latest release of package oddversion1', function (done) {
-    //   request.get('/depot/pkgs/neurosis/oddversion1/latest')
-    //     .type('application/json')
-    //     .accept('application/json')
-    //     .expect(200)
-    //     .end(function (err, res) {
-    //       expect(res.body.ident.origin).to.equal('neurosis');
-    //       expect(res.body.ident.name).to.equal('oddversion1');
-    //       expect(res.body.ident.version).to.equal('R16B03-1');
-    //       expect(res.body.ident.release).to.equal(ov13release);
-    //       done(err);
-    //     });
-    // });
+    it('returns the latest package oddversion1 in unstable channel', function (done) {
+      request.get('/depot/channels/neurosis/unstable/pkgs/oddversion1/latest')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.ident.origin).to.equal('neurosis');
+          expect(res.body.ident.name).to.equal('oddversion1');
+          expect(res.body.ident.version).to.equal('R16B03-1');
+          expect(res.body.ident.release).to.equal(ov13release);
+          done(err);
+        });
+    });
 
-    // it('returns the latest package oddversion1 in unstable channel', function (done) {
-    //   request.get('/depot/channels/neurosis/unstable/pkgs/oddversion1/latest')
-    //     .type('application/json')
-    //     .accept('application/json')
-    //     .expect(200)
-    //     .end(function (err, res) {
-    //       expect(res.body.ident.origin).to.equal('neurosis');
-    //       expect(res.body.ident.name).to.equal('oddversion1');
-    //       expect(res.body.ident.version).to.equal('R16B03-1');
-    //       expect(res.body.ident.release).to.equal(ov13release);
-    //       done(err);
-    //     });
-    // });
-
-    // it('lists all versions of the package oddversion1', function (done) {
-    //   request.get('/depot/pkgs/neurosis/oddversion1/versions')
-    //     .type('application/json')
-    //     .accept('application/json')
-    //     .expect(200)
-    //     .end(function (err, res) {
-    //       expect(res.body.length).to.equal(5);
-    //       expect(res.body[0].origin).to.equal('neurosis');
-    //       expect(res.body[0].name).to.equal('oddversion1');
-    //       expect(res.body[0].version).to.equal('R16B03-1');
-    //       expect(res.body[0].latest).to.equal(ov13release);
-    //       done(err);
-    //     });
-    // });
+    it('lists all versions of the package oddversion1', function (done) {
+      request.get('/depot/pkgs/neurosis/oddversion1/versions')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.length).to.equal(5);
+          expect(res.body[0].origin).to.equal('neurosis');
+          expect(res.body[0].name).to.equal('oddversion1');
+          expect(res.body[0].version).to.equal('R16B03-1');
+          expect(res.body[0].latest).to.equal(ov13release);
+          done(err);
+        });
+    });
 
     it('Uploads odd version package21', function (done) {
       request.post(`/depot/pkgs/neurosis/oddversion2/19.209-37/${ov21release}`)
@@ -1031,50 +1029,48 @@ describe('Working with packages', function () {
         });
     });
 
-    // FAILING TEST - bad semver value
+    it('returns the latest release of package oddversion5', function (done) {
+      request.get('/depot/pkgs/neurosis/oddversion5/latest')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.ident.origin).to.equal('neurosis');
+          expect(res.body.ident.name).to.equal('oddversion5');
+          expect(res.body.ident.version).to.equal('1.7.3');
+          expect(res.body.ident.release).to.equal(ov52release);
+          done(err);
+        });
+    });
 
-    // it('returns the latest release of package oddversion5', function (done) {
-    //   request.get('/depot/pkgs/neurosis/oddversion5/latest')
-    //     .type('application/json')
-    //     .accept('application/json')
-    //     .expect(200)
-    //     .end(function (err, res) {
-    //       expect(res.body.ident.origin).to.equal('neurosis');
-    //       expect(res.body.ident.name).to.equal('oddversion5');
-    //       expect(res.body.ident.version).to.equal('1.7.3');
-    //       expect(res.body.ident.release).to.equal(ov52release);
-    //       done(err);
-    //     });
-    // });
+    it('returns the latest package oddversion5 in unstable channel', function (done) {
+      request.get('/depot/channels/neurosis/unstable/pkgs/oddversion5/latest')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.ident.origin).to.equal('neurosis');
+          expect(res.body.ident.name).to.equal('oddversion5');
+          expect(res.body.ident.version).to.equal('1.7.3');
+          expect(res.body.ident.release).to.equal(ov52release);
+          done(err);
+        });
+    });
 
-    // it('returns the latest package oddversion5 in unstable channel', function (done) {
-    //   request.get('/depot/channels/neurosis/unstable/pkgs/oddversion5/latest')
-    //     .type('application/json')
-    //     .accept('application/json')
-    //     .expect(200)
-    //     .end(function (err, res) {
-    //       expect(res.body.ident.origin).to.equal('neurosis');
-    //       expect(res.body.ident.name).to.equal('oddversion5');
-    //       expect(res.body.ident.version).to.equal('1.7.3');
-    //       expect(res.body.ident.release).to.equal(ov52release);
-    //       done(err);
-    //     });
-    // });
-
-    // it('lists all versions of the package oddversion5', function (done) {
-    //   request.get('/depot/pkgs/neurosis/oddversion5/versions')
-    //     .type('application/json')
-    //     .accept('application/json')
-    //     .expect(200)
-    //     .end(function (err, res) {
-    //       expect(res.body.length).to.equal(2);
-    //       expect(res.body[0].origin).to.equal('neurosis');
-    //       expect(res.body[0].name).to.equal('oddversion5');
-    //       expect(res.body[0].version).to.equal('1.7.3');
-    //       expect(res.body[0].latest).to.equal(ov52release);
-    //       done(err);
-    //     });
-    // });
+    it('lists all versions of the package oddversion5', function (done) {
+      request.get('/depot/pkgs/neurosis/oddversion5/versions')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.length).to.equal(2);
+          expect(res.body[0].origin).to.equal('neurosis');
+          expect(res.body[0].name).to.equal('oddversion5');
+          expect(res.body[0].version).to.equal('1.7.3');
+          expect(res.body[0].latest).to.equal(ov52release);
+          done(err);
+        });
+    });
 
     it('Uploads odd version package61', function (done) {
       request.post(`/depot/pkgs/neurosis/oddversion6/1.2.3/${ov61release}`)


### PR DESCRIPTION
This change removes the usage of the Postgresql semver extension, and instead uses regexp for version ordering. With this change, we now match the regexp algorithm used for ident comparison in Rust code. Some test cases that used to fail with semver now succeed. In addition, this resolves failures such as https://github.com/habitat-sh/on-prem-builder/issues/141. 

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-255090621](https://user-images.githubusercontent.com/13542112/57667610-0d0f0b00-75b9-11e9-8726-a0dddc02cd79.gif)
