### PR TITLE
Adjust build worker Docker storage

### DIFF
--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -106,7 +106,7 @@ impl<'a> Studio<'a> {
         cmd.env("HAB_LICENSE", "accept-no-persist");
         cmd.env("HAB_STUDIO_SECRET_HAB_LICENSE", "accept-no-persist");
 
-        cmd.env("HAB_DOCKER_OPTS", "--name builder");
+        cmd.env("HAB_DOCKER_OPTS", "--name builder --storage-opt size=20G");
 
         for secret in self.workspace.job.get_secrets() {
             cmd.env(format!("HAB_STUDIO_SECRET_{}",


### PR DESCRIPTION
Bump up the storage size for Docker build workers in order to prevent some out of space errors

Signed-off-by: Salim Alam <salam@chef.io>