### PR TITLE
Mount docker dir on main volume

### DIFF
--- a/terraform/scripts/worker_bootstrap.sh
+++ b/terraform/scripts/worker_bootstrap.sh
@@ -6,3 +6,7 @@ set -eux
 # steps with the hab package
 sudo apt-get update
 sudo apt-get -y install docker.io
+sudo systemctl stop docker
+sudo mv /var/lib/docker /mnt/docker
+sudo ln -s /mnt/docker /var/lib/docker
+sudo systemctl start docker


### PR DESCRIPTION
We need to mount the docker overlay directory on a volume with more storage as we can run out of room on large builds

Signed-off-by: Salim Alam <salam@chef.io>