### PR TITLE
Perf improvement for package versioning

### DIFF
--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -581,7 +581,7 @@ fn do_get_channel_package(req: &HttpRequest<AppState>,
         Err(e) => return Err(e.into()),
     };
 
-    let pkg = match Channel::get_latest_package(
+    let pkg: Package = match Channel::get_latest_package(
         &GetLatestPackage {
             ident: &BuilderPackageIdent(ident.clone()),
             channel,
@@ -594,7 +594,7 @@ fn do_get_channel_package(req: &HttpRequest<AppState>,
         },
         &*conn,
     ) {
-        Ok(pkg) => pkg,
+        Ok(pkg) => pkg.into(),
         Err(NotFound) => {
             let mut memcache = req.state().memcache.borrow_mut();
             memcache.set_package(&req_ident, None, channel, &target, opt_session_id);

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -1317,7 +1317,7 @@ fn do_get_package(req: &HttpRequest<AppState>,
             },
             &*conn,
         ) {
-            Ok(pkg) => pkg,
+            Ok(pkg) => pkg.into(),
             Err(NotFound) => {
                 let mut memcache = req.state().memcache.borrow_mut();
                 memcache.set_package(

--- a/components/builder-db/src/migrations/2019-05-16-004032_version_perf/up.sql
+++ b/components/builder-db/src/migrations/2019-05-16-004032_version_perf/up.sql
@@ -1,0 +1,24 @@
+DROP VIEW origin_packages_with_version_array;
+
+CREATE OR REPLACE VIEW origin_packages_with_version_array AS
+    SELECT
+        id,
+        owner_id,
+        name,
+        ident,
+        ident_array,
+        checksum,
+        manifest,
+        config,
+        target,
+        deps,
+        tdeps,
+        exposes,
+        created_at,
+        updated_at,
+        visibility,
+        origin,
+        build_deps,
+        build_tdeps,
+        regexp_matches(ident_array[3], '([\d\.]+)(.+)?') as version_array
+    FROM origin_packages;

--- a/components/builder-db/src/schema/package.rs
+++ b/components/builder-db/src/schema/package.rs
@@ -26,11 +26,28 @@ table! {
 }
 
 table! {
-    use diesel::sql_types::{Array, BigInt, Text};
+    use crate::models::package::PackageVisibilityMapping;
+    use diesel::sql_types::{Array, BigInt, Integer, Text,  Nullable, Timestamptz};
     origin_packages_with_version_array {
         id -> BigInt,
+        owner_id -> BigInt,
+        name -> Text,
+        ident -> Text,
         ident_array -> Array<Text>,
-        version_array -> Array<Text>,
+        checksum -> Text,
+        manifest -> Text,
+        config -> Text,
+        target -> Text,
+        deps -> Array<Text>,
+        tdeps -> Array<Text>,
+        exposes -> Array<Integer>,
+        created_at -> Nullable<Timestamptz>,
+        updated_at -> Nullable<Timestamptz>,
+        visibility -> PackageVisibilityMapping,
+        origin -> Text,
+        build_deps -> Array<Text>,
+        build_tdeps -> Array<Text>,
+        version_array -> Array<Nullable<Text>>,
     }
 }
 
@@ -79,5 +96,4 @@ use super::origin::{origins,
                     origins_with_stats};
 
 joinable!(origin_packages -> origins (origin));
-joinable!(origin_packages -> origin_packages_with_version_array (id));
 joinable!(origin_packages -> origins_with_stats (origin));


### PR DESCRIPTION
This resolves a perf issue with the latest package query by eliminating an extra join that was causing significant degradation.  The query performance is now back to the original perf prior to the regexp change.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-171589004](https://user-images.githubusercontent.com/13542112/57872442-8b89c980-77c0-11e9-9f64-16ede172ead8.gif)
