### PR TITLE
Remove datastore binds from api and jobsrv

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -207,9 +207,9 @@ start-cache() {
 }
 
 declare -A svc_params=(
-  [api]="        -s at-once --bind memcached:builder-memcached.default --bind datastore:builder-datastore.default --bind jobsrv:builder-jobsrv.default"
+  [api]="        -s at-once --bind memcached:builder-memcached.default --bind jobsrv:builder-jobsrv.default"
   [api-proxy]="             --bind http:builder-api.default"
-  [jobsrv]="     -s at-once --bind datastore:builder-datastore.default"
+  [jobsrv]="     -s at-once"
   [worker]="     -s at-once --bind jobsrv:builder-jobsrv.default --bind depot:builder-api-proxy.default"
   [minio]="      -s at-once"
   [memcached]="  -s at-once"

--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -44,9 +44,3 @@ port = {{member.cfg.rpc_port}}
 
 [datastore]
 {{toToml cfg.datastore}}
-{{~#eachAlive bind.datastore.members as |member|}}
-{{~#if @first}}
-host = "{{member.sys.ip}}"
-port = {{member.cfg.port}}
-{{~/if}}
-{{~/eachAlive}}

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -49,3 +49,5 @@ database = "builder"
 connection_retry_ms = 300
 connection_timeout_sec = 3600
 db_workers = 4
+host = "127.0.0.1"
+port = 5432

--- a/components/builder-api/habitat/hooks/init
+++ b/components/builder-api/habitat/hooks/init
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 export PGPASSWORD="{{cfg.datastore.password}}"
-PSQL_ARGS="-w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U {{cfg.datastore.user}} {{cfg.datastore.database}}"
+PSQL_ARGS="-w -h {{cfg.datastore.host}} -p {{cfg.datastore.port}} -U {{cfg.datastore.user}} {{cfg.datastore.database}}"
 # shellcheck disable=SC2086
 # Create the DB or check that it exists
 createdb $PSQL_ARGS || psql -c ";" $PSQL_ARGS

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -14,7 +14,6 @@ pkg_exports=(
 pkg_exposes=(port)
 pkg_binds=(
   [memcached]="port"
-  [datastore]="port"
 )
 pkg_binds_optional=(
   [jobsrv]="rpc_port"

--- a/components/builder-jobsrv/habitat/config/config.toml
+++ b/components/builder-jobsrv/habitat/config/config.toml
@@ -6,12 +6,6 @@ features_enabled = "{{cfg.features_enabled}}"
 
 [datastore]
 {{toToml cfg.datastore}}
-{{~#eachAlive bind.datastore.members as |member|}}
-{{~#if @first}}
-host = "{{member.sys.ip}}"
-port = {{member.cfg.port}}
-{{~/if}}
-{{~/eachAlive}}
 
 [archive]
 local_dir = "{{pkg.svc_data_path}}"

--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -23,6 +23,8 @@ password = ""
 database = "builder"
 connection_retry_ms = 300
 connection_timeout_sec = 3600
+host = "127.0.0.1"
+port = 5432
 
 [archive]
 backend = "local"

--- a/components/builder-jobsrv/habitat/hooks/init
+++ b/components/builder-jobsrv/habitat/hooks/init
@@ -4,7 +4,7 @@ set -e
 
 export PGPASSWORD="{{cfg.datastore.password}}"
 
-PSQL_ARGS="-w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U {{cfg.datastore.user}} {{cfg.datastore.database}}"
+PSQL_ARGS="-w -h {{cfg.datastore.host}} -p {{cfg.datastore.port}} -U {{cfg.datastore.user}} {{cfg.datastore.database}}"
 # shellcheck disable=SC2086
 # Create the DB or check that it exists
 createdb $PSQL_ARGS || psql -c ";" $PSQL_ARGS

--- a/components/builder-jobsrv/habitat/plan.sh
+++ b/components/builder-jobsrv/habitat/plan.sh
@@ -15,7 +15,4 @@ pkg_exports=(
   [rpc_port]=http.port
 )
 pkg_exposes=(worker_port worker_heartbeat log_port rpc_port)
-pkg_binds=(
-  [datastore]="port"
-)
 bin="bldr-jobsrv"


### PR DESCRIPTION
In readiness for move to SaaS datastore to RDS, this removes the datastore binds from the builder-api and builder-jobsrv services.  The host and port will be passed in via config as needed.

Signed-off-by: Salim Alam <salam@chef.io>