### PR TITLE
Clean up migrations

### DIFF
--- a/components/builder-db/src/migrations/2018-10-10-198563_enum_visibility/up.sql
+++ b/components/builder-db/src/migrations/2018-10-10-198563_enum_visibility/up.sql
@@ -1,5 +1,3 @@
-CREATE EXTENSION semver;
-
 CREATE TYPE origin_package_visibility AS ENUM ('public', 'private', 'hidden');
 
 ALTER TABLE origin_packages ALTER COLUMN visibility DROP DEFAULT;

--- a/components/builder-db/src/migrations/2018-11-02-111111_diesel_query_improvements/up.sql
+++ b/components/builder-db/src/migrations/2018-11-02-111111_diesel_query_improvements/up.sql
@@ -87,3 +87,5 @@ CREATE OR REPLACE VIEW origin_package_versions AS
     MAX(ident_array[4]) as latest, ARRAY_AGG(DISTINCT target) as platforms
     FROM origin_packages
     GROUP BY ident_array[3], origin, name, visibility;
+
+CREATE INDEX ident_index ON origin_packages USING gin(ident_vector);

--- a/components/builder-db/src/migrations/2019-05-13-223900_regex_version/up.sql
+++ b/components/builder-db/src/migrations/2019-05-13-223900_regex_version/up.sql
@@ -14,5 +14,3 @@ CREATE OR REPLACE VIEW origin_packages_with_version_array AS
         ident_array,
         regexp_matches(ident_array[3], '([\d\.]+)(.+)?') as version_array
     FROM origin_packages;
-
-DROP EXTENSION semver;

--- a/components/builder-db/src/migrations/2108-11-03-111111_search_index/up.sql
+++ b/components/builder-db/src/migrations/2108-11-03-111111_search_index/up.sql
@@ -1,1 +1,0 @@
-CREATE INDEX ident_index ON origin_packages USING gin(ident_vector);


### PR DESCRIPTION
This does some cleanup of migrations - 1) remove all references to semver extension (this allows clean non-extension enabled Postgres instances to come up), and 2) remove and replace an incorrectly named migration.

Signed-off-by: Salim Alam <salam@chef.io>