### PR TITLE
Change datastore host config from IPAddr to String

### DIFF
--- a/components/builder-db/src/config.rs
+++ b/components/builder-db/src/config.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use std::{error::Error,
-          fmt,
-          net::{IpAddr,
-                Ipv4Addr}};
+          fmt};
 
 use num_cpus;
 use postgres_shared::params::{ConnectParams,
@@ -27,7 +25,7 @@ use url::percent_encoding::{utf8_percent_encode,
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct DataStoreCfg {
-    pub host: IpAddr,
+    pub host: String,
     pub port: u16,
     pub user: String,
     pub password: Option<String>,
@@ -44,7 +42,7 @@ pub struct DataStoreCfg {
 
 impl Default for DataStoreCfg {
     fn default() -> Self {
-        DataStoreCfg { host:                   IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        DataStoreCfg { host:                   String::from("localhost"),
                        port:                   5432,
                        user:                   String::from("hab"),
                        password:               None,


### PR DESCRIPTION
This change allows the datastore config host to be a regular hostname instead of just an IP address. Both hostname and IP address will work, so the change is backward compatible. This will let us use the RDS DNS endpoint as the hostname in order to allow correct failover.

Signed-off-by: Salim Alam <salam@chef.io>