### PR TITLE
Remove datastore node

### DIFF
--- a/terraform/scripts/create_bootstrap_bundle.sh
+++ b/terraform/scripts/create_bootstrap_bundle.sh
@@ -93,7 +93,6 @@ fi
 # our bundle.
 builder_packages=(habitat/builder-api
                   habitat/builder-api-proxy
-                  habitat/builder-datastore
                   habitat/builder-jobsrv
                   habitat/builder-worker)
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -118,10 +118,6 @@ variable "instance_size_worker" {
   description = "AWS instance size for builder-worker server(s)"
 }
 
-variable "database_ebs_volume_id" {
-  description = "ID for EBS volume to attach to the database server"
-}
-
 variable "admin_password" {
   description = "Windows Administrator password to login as"
 }
@@ -136,10 +132,6 @@ variable "instance_size_windows_worker" {
 
 variable "instance_size_linux2_worker" {
   description = "AWS instance size for Linux2 worker server(s)"
-}
-
-variable "instance_size_datastore" {
-  description = "AWS instance size for DB server(s)"
 }
 
 variable "linux2_worker_count" {

--- a/terraform/volumes.tf
+++ b/terraform/volumes.tf
@@ -1,5 +1,0 @@
-resource "aws_volume_attachment" "database" {
-  device_name = "/dev/xvdf"
-  volume_id   = "${var.database_ebs_volume_id}"
-  instance_id = "${aws_instance.datastore.id}"
-}


### PR DESCRIPTION
Update Terraform to remove datastore node as we have migrated the DB to RDS.
Also minor tweak to AMI id for Windows worker.

Signed-off-by: Salim Alam <salam@chef.io>