### PR TITLE
Add custom panic handler for jobsrv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,7 @@ name = "habitat_builder_jobsrv"
 version = "0.0.0"
 dependencies = [
  "actix-web 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+backtrace = "*"
 bitflags = "*"
 builder_core = { path = "../builder-core" }
 clippy = {version = "*", optional = true}


### PR DESCRIPTION
This  change adds a custom (global) panic handler that will exit the jobsrv process if any of the threads panics. The process will be restarted by hab if running under the supervisor.  This should make us a bit more resilient to panics that could stall build jobs if one of the threads panicked but the process continued to run.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-70911739](https://user-images.githubusercontent.com/13542112/59716628-3419b780-91cb-11e9-8ca2-c5659515a7b9.gif)
