### PR TITLE
Add build watchdog

### DIFF
--- a/components/builder-db/src/models/jobs.rs
+++ b/components/builder-db/src/models/jobs.rs
@@ -210,6 +210,15 @@ impl Group {
                      .get_results(conn)
     }
 
+    pub fn get_all_dispatching(target: PackageTarget,
+                               conn: &PgConnection)
+                               -> QueryResult<Vec<Group>> {
+        Counter::DBCall.increment();
+        groups::table.filter(groups::group_state.eq("Dispatching"))
+                     .filter(groups::target.eq(target.to_string()))
+                     .get_results(conn)
+    }
+
     pub fn get_pending(target: PackageTarget, conn: &PgConnection) -> QueryResult<Group> {
         Counter::DBCall.increment();
         groups::table.filter(groups::group_state.eq("Pending"))


### PR DESCRIPTION
This change adds a watcher to the job scheduler that can cancel stuck jobs. This is initially targeted at a couple of cases - 1) there are no buildable projects (eg, all projects are skipped due to some error); 2) the build job max limit has been exceeded. More updates to the watcher will be forthcoming once the base usage has been shown to be useful.

Signed-off-by: Salim Alam <salam@chef.io>

![](https://media0.giphy.com/media/SrqVyQvxtoEzS/200w.gif?cid=5a38a5a25d10285b494c634467de8711&rid=200w.gif)
