### PR TITLE
Returns non-standard versioned packages in /versions endpoint

### DIFF
--- a/components/builder-db/src/migrations/2019-06-24-198169_regex_update/up.sql
+++ b/components/builder-db/src/migrations/2019-06-24-198169_regex_update/up.sql
@@ -1,0 +1,11 @@
+DROP VIEW origin_package_versions;
+
+CREATE OR REPLACE VIEW origin_package_versions AS
+    SELECT origin, name, visibility,
+    ident_array[3] as version,
+    COUNT(ident_array[4]) as release_count, 
+    MAX(ident_array[4]) as latest,
+    ARRAY_AGG(DISTINCT target) as platforms,
+    regexp_matches(ident_array[3], '([\d\.]*\d+)(.+)?') as version_array
+    FROM origin_packages
+    GROUP BY ident_array[3], origin, name, visibility;

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -1243,6 +1243,21 @@ describe('Working with packages', function () {
         });
     });
 
+      it('returns all versions of package oddversion7', function (done) {
+          request.get('/depot/pkgs/neurosis/oddversion7/versions')
+            .type('application/json')
+            .accept('application/json')
+            .expect(200)
+              .end(function (err, res) {
+                expect(res.body.length).to.equal(3);
+                expect(res.body[2].origin).to.equal('neurosis');
+                expect(res.body[2].name).to.equal('oddversion7');
+                expect(res.body[2].version).to.equal('17.1.0-dev.cloud');
+                expect(res.body[2].latest).to.equal(ov71release);
+                done(err);
+              });
+      });
+
     it('returns the latest release of package oddversion7', function (done) {
       request.get('/depot/pkgs/neurosis/oddversion7/latest')
         .type('application/json')


### PR DESCRIPTION
Fixes: #1106 

Adds the updated regex to a package view that previously would error if uploaded packages had non-standard versions.

Signed-off-by: Ian Henry <ihenry@chef.io>