### PR TITLE
All tests are in public verify now, so we don't need this def

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -12,5 +12,3 @@ pipelines:
   - verify:
       description: Pull Request validation tests
       public: true
-  - verify_private:
-      description: Pull Request validation tests requiring credentials


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

cleanup from https://github.com/habitat-sh/builder/pull/1103