### PR TITLE
Add new supervisor logging to Terraform

### DIFF
--- a/terraform/files/sup_log.yml
+++ b/terraform/files/sup_log.yml
@@ -1,0 +1,25 @@
+# ALWAYS keep this key in the configuration; removing it means changes
+# to config won't get picked up without a restart.
+#
+# Uses humantime to parse the duration; see 
+# https://docs.rs/humantime/1.2.0/humantime/fn.parse_duration.html
+refresh_rate: 5 seconds
+
+appenders:
+  stdout:
+    kind: console
+    encoder:
+      # See https://docs.rs/log4rs/0.8.3/log4rs/#configuration for
+      # formatting options
+      pattern: "[{d(%Y-%m-%dT%H:%M:%SZ)(utc)} {l} {module}] {message}{n}"
+
+root:
+  level: error
+  appenders:
+    - stdout
+
+loggers:
+  habitat_common::sync:
+    # "warn" will show "deadlock likely" messages;
+    # "trace" will also show which threads are stuck
+    level: warn

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -91,11 +91,18 @@ resource "aws_instance" "api" {
     destination = "/home/ubuntu/hab-sup.service"
   }
 
+  provisioner "file" {
+    source      = "${path.module}/files/sup_log.yml"
+    destination = "/tmp/sup_log.yml"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/install_base_packages.sh",
       "sudo /tmp/install_base_packages.sh habitat/builder-api",
       "sudo mv /home/ubuntu/hab-sup.service /etc/systemd/system/hab-sup.service",
+      "sudo mkdir -p /hab/sup/default/config",
+      "sudo mv /tmp/sup_log.yml /hab/sup/default/config/log.yml",
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
@@ -202,11 +209,18 @@ resource "aws_instance" "jobsrv" {
     destination = "/home/ubuntu/hab-sup.service"
   }
 
+  provisioner "file" {
+    source      = "${path.module}/files/sup_log.yml"
+    destination = "/tmp/sup_log.yml"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/install_base_packages.sh",
       "sudo /tmp/install_base_packages.sh habitat/builder-jobsrv",
       "sudo mv /home/ubuntu/hab-sup.service /etc/systemd/system/hab-sup.service",
+      "sudo mkdir -p /hab/sup/default/config",
+      "sudo mv /tmp/sup_log.yml /hab/sup/default/config/log.yml",
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
@@ -312,6 +326,11 @@ resource "aws_instance" "worker" {
     destination = "/home/ubuntu/hab-sup.service"
   }
 
+  provisioner "file" {
+    source      = "${path.module}/files/sup_log.yml"
+    destination = "/tmp/sup_log.yml"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/install_base_packages.sh",
@@ -319,6 +338,8 @@ resource "aws_instance" "worker" {
       "sudo iptables -I DOCKER-USER -p tcp -s 10.0.0.0/24 -j DROP",
       "sudo iptables -I DOCKER-USER -p udp -s 10.0.0.0/24 -m multiport --sports 0:52,54:65535 -j DROP",
       "sudo mv /home/ubuntu/hab-sup.service /etc/systemd/system/hab-sup.service",
+      "sudo mkdir -p /hab/sup/default/config",
+      "sudo mv /tmp/sup_log.yml /hab/sup/default/config/log.yml",
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
@@ -386,6 +407,11 @@ resource "aws_instance" "linux2-worker" {
   }
 
   provisioner "file" {
+    source      = "${path.module}/files/sup_log.yml"
+    destination = "/tmp/sup_log.yml"
+  }
+
+  provisioner "file" {
     source      = "${path.module}/files/linux2-worker.user.toml"
     destination = "/tmp/worker.user.toml"
   }
@@ -404,6 +430,8 @@ resource "aws_instance" "linux2-worker" {
       "sudo iptables -I DOCKER -p tcp -s 10.0.0.0/24 -j DROP",
       "sudo iptables -I DOCKER -p udp -s 10.0.0.0/24 -m multiport --sports 0:52,54:65535 -j DROP",
       "sudo mv /tmp/hab-sup.init /etc/init/hab-sup.conf",
+      "sudo mkdir -p /hab/sup/default/config",
+      "sudo mv /tmp/sup_log.yml /hab/sup/default/config/log.yml",
       "sudo service hab-sup start",
       "sleep 10",
       "sudo hab svc load habitat/builder-worker --group ${var.env} --bind jobsrv:builder-jobsrv.${var.env} --bind depot:builder-api-proxy.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",

--- a/terraform/templates/hab-sup.service
+++ b/terraform/templates/hab-sup.service
@@ -2,6 +2,9 @@
 Description=Habitat Supervisor
 
 [Service]
+# Note: The RUST_LOG line below is meant only for the services
+# Currently, the launcher also uses this but that will not always be the case
+# Related issue: https://github.com/habitat-sh/habitat/issues/6632
 Environment=RUST_LOG=${log_level}
 Environment=HAB_STATS_ADDR=localhost:8125
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem"


### PR DESCRIPTION
This adds a new logging config for the supervisor to the Builder service instances (all instances except the Windows worker for now)

Signed-off-by: Salim Alam <salam@chef.io>