### PR TITLE
Temporarily add bootstrap utilities to PATH, instead of binlinking

### DIFF
--- a/terraform/scripts/create_bootstrap_bundle.sh
+++ b/terraform/scripts/create_bootstrap_bundle.sh
@@ -137,26 +137,26 @@ archive_name=${this_bootstrap_bundle}.tar
 log "Generating archive: ${archive_name}"
 
 tar --create \
-       --verbose \
-       --file="${archive_name}" \
-       --directory="${sandbox_dir}"/hab/cache \
-       artifacts >&2
+    --verbose \
+    --file="${archive_name}" \
+    --directory="${sandbox_dir}"/hab/cache \
+    artifacts >&2
 
 # We'll need a hab binary to bootstrap ourselves; let's take the one
 # we just downloaded, shall we?
 hab_pkg_dir=$(echo "${sandbox_dir}"/hab/pkgs/core/hab/"${hab_version}"/*)
 tar --append \
-       --verbose \
-       --file="${archive_name}" \
-       --directory="${hab_pkg_dir}" \
-       bin >&2
+    --verbose \
+    --file="${archive_name}" \
+    --directory="${hab_pkg_dir}" \
+    bin >&2
 
 # We're also going to need the public origin key(s)!
 tar --append \
-       --verbose \
-       --file="${archive_name}" \
-       --directory="${sandbox_dir}"/hab/cache \
-       keys >&2
+    --verbose \
+    --file="${archive_name}" \
+    --directory="${sandbox_dir}"/hab/cache \
+    keys >&2
 
 ########################################################################
 # Upload to S3


### PR DESCRIPTION
When running this script on a pre-existing Linux system, we would try
to binlink common utilities that the script uses. However, this would
end up trying to overwrite system utilities like `awk` and `tar`,
which we don't necessarily want to do.

Now, instead of binlinking, we'll just prepend the paths to the
relevant binaries to `PATH`, making them available for the remainder
of the script, but leaving system binaries intact.