### PR TITLE
Adds channel to channel pro/demotion api

### DIFF
--- a/components/builder-api/src/server/helpers.rs
+++ b/components/builder-api/src/server/helpers.rs
@@ -56,6 +56,12 @@ pub struct PaginatedResults<'a, T: 'a> {
     data:        &'a [T],
 }
 
+#[derive(Deserialize)]
+pub struct ToChannel {
+    #[serde(default)]
+    pub channel: String,
+}
+
 pub fn package_results_json<T: Serialize>(packages: &[T],
                                           count: isize,
                                           start: isize,

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -36,6 +36,7 @@ use crate::{bldr_core::metrics::CounterMetric,
 
 use crate::db::models::{channel::*,
                         package::{BuilderPackageIdent,
+                                  GetPackageGroup,
                                   Package}};
 
 use crate::server::{authorize::authorize_session,
@@ -46,7 +47,8 @@ use crate::server::{authorize::authorize_session,
                               req_state,
                               visibility_for_optional_session,
                               Pagination,
-                              Target},
+                              Target,
+                              ToChannel},
                     services::metrics::Counter,
                     AppState};
 
@@ -80,6 +82,10 @@ impl Channels {
                   web::get().to(get_latest_package_for_origin_channel_package_version))
            .route("/depot/channels/{origin}/{channel}/pkgs/{pkg}/{version}/{release}",
                   web::get().to(get_package_fully_qualified))
+           .route("/depot/channels/{origin}/{channel}/pkgs/promote",
+                  web::put().to(promote_channel_packages))
+           .route("/depot/channels/{origin}/{channel}/pkgs/demote",
+                  web::put().to(demote_channel_packages))
            .route("/depot/channels/{origin}/{channel}/pkgs/{pkg}/{version}/{release}/promote",
                   web::put().to(promote_package))
            .route("/depot/channels/{origin}/{channel}/pkgs/{pkg}/{version}/{release}/demote",
@@ -187,6 +193,186 @@ fn delete_channel(req: HttpRequest,
             err.into()
         }
     }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn promote_channel_packages(req: HttpRequest,
+                            path: Path<(String, String)>,
+                            state: Data<AppState>,
+                            to_channel: Query<ToChannel>)
+                            -> HttpResponse {
+    let (origin, channel) = path.into_inner();
+
+    let session = match authorize_session(&req, Some(&origin)) {
+        Ok(session) => session,
+        Err(_) => return HttpResponse::new(StatusCode::UNAUTHORIZED),
+    };
+
+    let conn = match state.db.get_conn().map_err(Error::DbError) {
+        Ok(conn_ref) => conn_ref,
+        Err(err) => return err.into(),
+    };
+
+    let ch_source = ChannelIdent::from(channel);
+    let ch_target = ChannelIdent::from(to_channel.channel.as_ref());
+
+    match do_promote_or_demote_channel_packages(&req,
+                                                &ch_source,
+                                                &ch_target,
+                                                &origin,
+                                                true,
+                                                session.get_id() as i64)
+    {
+        Ok(pkg_ids) => {
+            match PackageGroupChannelAudit::audit(
+                PackageGroupChannelAudit {
+                    origin: &origin,
+                    channel: &ch_target.as_str(),
+                    package_ids: pkg_ids,
+                    operation: PackageChannelOperation::Promote,
+                    trigger: helpers::trigger_from_request_model(&req),
+                    requester_id: session.get_id() as i64,
+                    requester_name: session.get_name(),
+                    group_id: 0 as i64,
+                },
+                &*conn,
+            ) {
+                Ok(_) => {}
+                Err(e) => debug!("Failed to save rank change to audit log: {}", e),
+            };
+            HttpResponse::new(StatusCode::OK)
+        }
+        Err(e) => {
+            debug!("{}", e);
+            e.into()
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn demote_channel_packages(req: HttpRequest,
+                           path: Path<(String, String)>,
+                           state: Data<AppState>,
+                           to_channel: Query<ToChannel>)
+                           -> HttpResponse {
+    let (origin, channel) = path.into_inner();
+    let conn = match state.db.get_conn().map_err(Error::DbError) {
+        Ok(conn_ref) => conn_ref,
+        Err(err) => return err.into(),
+    };
+
+    let session = match authorize_session(&req, Some(&origin)) {
+        Ok(session) => session,
+        Err(_) => return HttpResponse::new(StatusCode::UNAUTHORIZED),
+    };
+
+    let ch_source = ChannelIdent::from(channel);
+    let ch_target = ChannelIdent::from(to_channel.channel.as_ref());
+
+    match do_promote_or_demote_channel_packages(&req,
+                                                &ch_source,
+                                                &ch_target,
+                                                &origin,
+                                                false,
+                                                session.get_id() as i64)
+    {
+        Ok(pkg_ids) => {
+            match PackageGroupChannelAudit::audit(
+                PackageGroupChannelAudit {
+                    origin: &origin,
+                    channel: &ch_target.as_str(),
+                    package_ids: pkg_ids,
+                    operation: PackageChannelOperation::Demote,
+                    trigger: helpers::trigger_from_request_model(&req),
+                    requester_id: session.get_id() as i64,
+                    requester_name: session.get_name(),
+                    group_id: 0 as i64,
+                },
+                &*conn,
+            ) {
+                Ok(_) => {}
+                Err(e) => debug!("Failed to save rank change to audit log: {}", e),
+            };
+            HttpResponse::new(StatusCode::OK)
+        }
+        Err(e) => {
+            debug!("{}", e);
+            e.into()
+        }
+    }
+}
+
+fn do_promote_or_demote_channel_packages(req: &HttpRequest,
+                                         ch_source: &ChannelIdent,
+                                         ch_target: &ChannelIdent,
+                                         origin: &str,
+                                         promote: bool,
+                                         session_id: i64)
+                                         -> Result<Vec<i64>> {
+    Counter::AtomicChannelRequests.increment();
+    let conn = req_state(req).db.get_conn().map_err(Error::DbError)?;
+    let mut pkg_ids = Vec::new();
+
+    // Simple guards to protect users from bad decisioning
+    if !promote
+       && (*ch_target == ChannelIdent::unstable() || *ch_source == ChannelIdent::unstable())
+    {
+        return Err(Error::BadRequest);
+    }
+
+    if *ch_target == *ch_source {
+        return Err(Error::BadRequest);
+    }
+
+    if promote && *ch_target == ChannelIdent::unstable() {
+        return Err(Error::BadRequest);
+    }
+
+    let pkgs = do_get_all_channel_packages(&req, &origin, &ch_source)?;
+
+    #[rustfmt::skip]
+    let channel = match Channel::get(&origin, &ch_target, &*conn) {
+        Ok(channel) => channel,
+        Err(NotFound) => {
+            if (ch_target != &ChannelIdent::stable()) && (ch_target != &ChannelIdent::unstable()) {
+                Channel::create(
+                    &CreateChannel {
+                        name:     &ch_target.as_str(),
+                        origin:   &origin,
+                        owner_id: session_id,
+                    },
+                &*conn)?
+            } else {
+                warn!("Unable to retrieve target channel: {}", &ch_target);
+                return Err(Error::DieselError(NotFound));
+            }
+        }
+        Err(e) => {
+            info!("Unable to retrieve channel, err: {:?}", e);
+            return Err(Error::DieselError(e));
+        }
+    };
+
+    #[rustfmt::skip]
+    let op = Package::get_group(
+        GetPackageGroup {
+            pkgs,
+            visibility: helpers::all_visibilities()
+        },
+    &*conn)?;
+
+    let mut ids: Vec<i64> = op.iter().map(|x| x.id).collect();
+
+    pkg_ids.append(&mut ids);
+
+    if promote {
+        debug!("Bulk promoting Pkg IDs: {:?}", &pkg_ids);
+        Channel::promote_packages(channel.id, &pkg_ids, &*conn)?;
+    } else {
+        debug!("Bulk demoting Pkg IDs: {:?}", &pkg_ids);
+        Channel::demote_packages(channel.id, &pkg_ids, &*conn)?;
+    }
+    Ok(pkg_ids)
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -512,6 +698,18 @@ fn do_get_channel_packages(req: &HttpRequest,
         &*conn,
     )
     .map_err(Error::DieselError)
+}
+
+fn do_get_all_channel_packages(req: &HttpRequest,
+                               origin: &str,
+                               channel: &ChannelIdent)
+                               -> Result<(Vec<BuilderPackageIdent>)> {
+    let conn = req_state(req).db.get_conn().map_err(Error::DbError)?;
+
+    Channel::list_all_packages(&ListAllChannelPackages { visibility: &helpers::all_visibilities(),
+                                                         origin: &origin,
+                                                         channel },
+                               &*conn).map_err(Error::DieselError)
 }
 
 fn do_get_channel_package(req: &HttpRequest,

--- a/components/builder-api/src/server/services/metrics.rs
+++ b/components/builder-api/src/server/services/metrics.rs
@@ -29,6 +29,7 @@ pub enum Counter {
     MultipartUploadRequests,
     DownloadRequests,
     UploadFailures,
+    AtomicChannelRequests,
 }
 
 impl metrics::CounterMetric for Counter {}
@@ -46,6 +47,7 @@ impl metrics::Metric for Counter {
             Counter::MultipartUploadRequests => "upload-multi".into(),
             Counter::DownloadRequests => "download-packages".into(),
             Counter::UploadFailures => "upload-failures".into(),
+            Counter::AtomicChannelRequests => "channel-to-channel".into(),
         }
     }
 }

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -289,6 +289,12 @@ pub struct GetPackage {
 }
 
 #[derive(Debug)]
+pub struct GetPackageGroup {
+    pub pkgs:       Vec<BuilderPackageIdent>,
+    pub visibility: Vec<PackageVisibility>,
+}
+
+#[derive(Debug)]
 pub struct DeletePackage {
     pub ident:  BuilderPackageIdent,
     pub target: BuilderPackageTarget,
@@ -416,6 +422,12 @@ impl Package {
                 .filter(origin_packages::target.eq(req.target)),
         )
         .execute(conn)
+    }
+
+    pub fn get_group(req: GetPackageGroup, conn: &PgConnection) -> QueryResult<Vec<Package>> {
+        Self::all().filter(origin_packages::ident.eq(any(req.pkgs)))
+                   .filter(origin_packages::visibility.eq(any(req.visibility)))
+                   .get_results(conn)
     }
 
     pub fn get_all(req_ident: BuilderPackageIdent,

--- a/test/builder-api/src/channels.js
+++ b/test/builder-api/src/channels.js
@@ -376,4 +376,171 @@ describe('Channels API', function () {
         });
     });
   });
+
+  describe('Channel-to-Channel promotion', function () {
+    it('requires authentication to promote all packages in channel', function (done) {
+      request.put('/depot/channels/neurosis/foo/pkgs/promote?channel=throneroom')
+        .expect(401)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('requires origin membership to promote all packages', function (done) {
+      request.put('/depot/channels/neurosis/foo/pkgs/promote?channel=throneroom')
+        .set('Authorization', global.mystiqueBearer)
+        .expect(401)
+        .end(function (err, res) {
+          done(err);
+        });
+    });
+
+    it('rejects attempts to promote packages when source_channel and target_channel match', function (done) {
+      request.put('/depot/channels/neurosis/foo/pkgs/promote?channel=foo')
+        .set('Authorization', global.boboBearer)
+        .expect(400)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('rejects attempts to promote packages to target_channel if set to unstable', function (done) {
+      request.put('/depot/channels/neurosis/foo/pkgs/promote?channel=unstable')
+        .set('Authorization', global.boboBearer)
+        .expect(400)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('puts all channel packages into a specified channel', function (done) {
+      request.put('/depot/channels/neurosis/unstable/pkgs/promote?channel=foo')
+        .set('Authorization', global.boboBearer)
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('promotes between non-default channels channel', function (done) {
+      request.put('/depot/channels/neurosis/foo/pkgs/promote?channel=throneroom')
+        .set('Authorization', global.boboBearer)
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('should ignore packages promoted to a channel where the package already exists', function (done) {
+      request.put('/depot/channels/neurosis/unstable/pkgs/promote?channel=foo')
+        .set('Authorization', global.boboBearer)
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('will find all packages in a channel after promotion', function (done) {
+      request.get('/depot/channels/neurosis/foo/pkgs')
+        .type('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.range_start).to.equal(0);
+          expect(res.body.range_end).to.equal(30);
+          expect(res.body.total_count).to.equal(31);
+          expect(res.body.data.length).to.equal(31);
+          done(err);
+        });
+    });
+
+    it('can promote private packages', function (done) {
+      request.put('/depot/channels/neurosis/bar/pkgs/promote?channel=throneroom')
+        .set('Authorization', global.boboBearer)
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+  });
+
+  describe('Channel-to-channel Demotion', function () {
+    it('requires authentication to demote all packages in channel', function (done) {
+      request.put('/depot/channels/neurosis/foo/pkgs/demote')
+      .expect(401)
+      .end(function (err, res) {
+        expect(res.text).to.be.empty;
+        done(err);
+      });
+    });
+
+    it('requires origin membership to demote all packages in channel', function (done) {
+      request.put('/depot/channels/neurosis/foo/pkgs/demote')
+        .set('Authorization', global.mystiqueBearer)
+        .expect(401)
+        .end(function (err, res) {
+          done(err);
+        });
+    });
+
+    it('removes all packages from the specified channel', function (done) {
+      request.put('/depot/channels/neurosis/foo/pkgs/demote?channel=throneroom')
+        .set('Authorization', global.boboBearer)
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('rejects attempts to demote all packages from the unstable channel', function (done) {
+      request.put('/depot/channels/neurosis/unstable/pkgs/demote?channel=unstable')
+        .set('Authorization', global.boboBearer)
+        .expect(400)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('rejects attempts to demote packages when source_channel and target_channel match', function (done) {
+      request.put('/depot/channels/neurosis/foo/pkgs/demote?channel=foo')
+        .set('Authorization', global.boboBearer)
+        .expect(400)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('rejects attempts to demote packages when source_channel is unstable', function (done) {
+      request.put('/depot/channels/neurosis/unstable/pkgs/demote?channel=stable')
+        .set('Authorization', global.boboBearer)
+        .expect(400)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('will not find a package in a channel after it has been demoted', function (done) {
+      request.get('/depot/channels/neurosis/throneroom/pkgs')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.range_start).to.equal(0);
+          expect(res.body.range_end).to.equal(0);
+          expect(res.body.total_count).to.equal(0);
+          expect(res.body.data.length).to.equal(0);
+          done(err);
+        });
+    });
+  });
 });


### PR DESCRIPTION
This PR adds the backend and routes required for bulk promotion and demotion between channels.

Promotion leverages the route path to pull the "from" channel, and a query parameter for the "to" channel.

CLI client changes are inbound but for the sake of those who use builder via Curl promotion takes the following shape:

```
/depot/channels/<origin>/<channel_you_would_like_to_promote>/pkgs/promote\?channel\=<new_channel_you'd_like_to_promote_into>
```

Demotion is much simpler since we don't provide a "demote into" mechanism. We simply remove all packages from whatever channel you specify in the path like so:

```
/depot/channels/<origin>/<channel_to_demote>/pkgs/demote
```

Signed-off-by: Ian Henry <ihenry@chef.io>