### PR TITLE
Enabled use of cached certs for Builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "dogstatsd 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_proxy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_proxy 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
@@ -403,9 +403,9 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
+ "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed)",
 ]
 
 [[package]]
@@ -869,6 +869,15 @@ dependencies = [
 
 [[package]]
 name = "env_proxy"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_proxy"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1167,7 +1176,7 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth-client 0.0.0",
  "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1185,7 +1194,7 @@ dependencies = [
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
+ "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed)",
 ]
 
 [[package]]
@@ -1205,7 +1214,6 @@ dependencies = [
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/habitat.git)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-shared 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1217,7 +1225,7 @@ dependencies = [
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1282,7 +1290,7 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
+ "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed)",
 ]
 
 [[package]]
@@ -1310,7 +1318,7 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
+ "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed)",
 ]
 
 [[package]]
@@ -3567,17 +3575,17 @@ dependencies = [
 [[package]]
 name = "zmq"
 version = "0.8.3"
-source = "git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8#0d371fec87b6e3f13ea91c873e215319661cf176"
+source = "git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed#20a73b9225b3903778420c3211d8e9439bb73a2a"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq-sys 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)",
+ "zmq-sys 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed)",
 ]
 
 [[package]]
 name = "zmq-sys"
 version = "0.8.3"
-source = "git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8#0d371fec87b6e3f13ea91c873e215319661cf176"
+source = "git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed#20a73b9225b3903778420c3211d8e9439bb73a2a"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3668,6 +3676,7 @@ dependencies = [
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum enum-as-inner 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3d58266c97445680766be408285e798d3401c6d4c378ec5552e78737e681e37d"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
+"checksum env_proxy 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "700798562fcbc0a4c89546df5dfa8586e82345026e3992242646d527dec948e4"
 "checksum env_proxy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8731da06ff3731a69115a2910345ae5ee8d1fe09c846a9eca101b444a30ad454"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
@@ -3940,5 +3949,5 @@ dependencies = [
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-"checksum zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)" = "<none>"
-"checksum zmq-sys 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=release/v0.8)" = "<none>"
+"checksum zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed)" = "<none>"
+"checksum zmq-sys 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed)" = "<none>"

--- a/components/artifactory-client/src/client.rs
+++ b/components/artifactory-client/src/client.rs
@@ -44,16 +44,16 @@ pub struct ArtifactoryClient {
 }
 
 impl ArtifactoryClient {
-    pub fn new(config: ArtifactoryCfg) -> Self {
+    pub fn new(config: ArtifactoryCfg) -> ArtifactoryResult<Self> {
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT_BLDR.0.clone(), USER_AGENT_BLDR.1.clone());
         headers.insert(HeaderName::from_static(X_JFROG_ART_API),
                        HeaderValue::from_str(&config.api_key).expect("Invalid API key value"));
 
-        ArtifactoryClient { inner:   HttpClient::new(&config.api_url, headers),
-                            api_url: config.api_url,
-                            api_key: config.api_key,
-                            repo:    config.repo, }
+        Ok(ArtifactoryClient { inner:   HttpClient::new(&config.api_url, headers)?,
+                               api_url: config.api_url,
+                               api_key: config.api_key,
+                               repo:    config.repo, })
     }
 
     pub fn upload(&self,

--- a/components/builder-api/src/server/error.rs
+++ b/components/builder-api/src/server/error.rs
@@ -31,6 +31,7 @@ use protobuf;
 use reqwest;
 use rusoto_core::RusotoError;
 use rusoto_s3;
+use segment_api_client::SegmentError;
 use serde_json;
 
 use crate::{bldr_core,
@@ -64,6 +65,7 @@ pub enum Error {
     PartialUpload(RusotoError<rusoto_s3::UploadPartError>),
     PayloadError(actix_web::error::PayloadError),
     Protobuf(protobuf::ProtobufError),
+    Segment(SegmentError),
     SerdeJson(serde_json::Error),
     System,
     Unprocessable,
@@ -100,6 +102,7 @@ impl fmt::Display for Error {
             Error::PartialUpload(ref e) => format!("{}", e),
             Error::PayloadError(ref e) => format!("{}", e),
             Error::Protobuf(ref e) => format!("{}", e),
+            Error::Segment(ref e) => format!("{}", e),
             Error::SerdeJson(ref e) => format!("{}", e),
             Error::System => "Internal error".to_string(),
             Error::Unprocessable => "Unprocessable entity".to_string(),
@@ -137,6 +140,7 @@ impl error::Error for Error {
             Error::PartialUpload(ref err) => err.description(),
             Error::PayloadError(_) => "Http request stream error",
             Error::Protobuf(ref err) => err.description(),
+            Error::Segment(ref err) => err.description(),
             Error::SerdeJson(ref err) => err.description(),
             Error::System => "Internal error",
             Error::Unprocessable => "Unprocessable entity",
@@ -241,6 +245,14 @@ impl From<io::Error> for Error {
 
 impl From<OAuthError> for Error {
     fn from(err: OAuthError) -> Error { Error::OAuth(err) }
+}
+
+impl From<ArtifactoryError> for Error {
+    fn from(err: ArtifactoryError) -> Error { Error::Artifactory(err) }
+}
+
+impl From<SegmentError> for Error {
+    fn from(err: SegmentError) -> Error { Error::Segment(err) }
 }
 
 impl From<actix_web::error::PayloadError> for Error {

--- a/components/builder-api/src/server/resources/ext.rs
+++ b/components/builder-api/src/server/resources/ext.rs
@@ -103,7 +103,7 @@ fn do_validate_registry_credentials(body: Json<Body>, registry_type: &str) -> Re
                              CONTENT_TYPE_APPLICATION_JSON.clone()];
     let headers = HeaderMap::from_iter(header_values.into_iter());
 
-    let client = HttpClient::new(actual_url, headers);
+    let client = HttpClient::new(actual_url, headers)?;
     let sbody = serde_json::to_string(&body.into_inner()).unwrap();
 
     let body: reqwest::Body = sbody.into();

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -11,7 +11,8 @@ bitflags = "*"
 chrono = { version = "*", features = ["serde"] }
 clippy = { version = "*", optional = true }
 dogstatsd = "*"
-env_proxy = "*"
+# Unlock with url here and in builder-api-client
+env_proxy = "=0.3.1"
 glob = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
 lazy_static = "*"
@@ -27,7 +28,8 @@ time = "*"
 toml = { version = "*", default-features = false }
 walkdir = "*"
 reqwest = "=0.9.17"
-url = "*"
+# Unlock with env_proxy
+url = "=1.7.2"
 zmq = { git = "https://github.com/habitat-sh/rust-zmq", branch = "v0.8-symlinks-removed" }
 
 [dependencies.habitat_core]

--- a/components/builder-core/src/api_client.rs
+++ b/components/builder-core/src/api_client.rs
@@ -83,12 +83,12 @@ pub struct ApiClient {
 }
 
 impl ApiClient {
-    pub fn new(url: &str) -> Self {
+    pub fn new(url: &str) -> Result<Self> {
         let header_values = vec![USER_AGENT_BLDR.clone(), ACCEPT_APPLICATION_JSON.clone()];
         let headers = HeaderMap::from_iter(header_values.into_iter());
 
-        ApiClient { inner: HttpClient::new(url, headers),
-                    url:   url.to_owned(), }
+        Ok(ApiClient { inner: HttpClient::new(url, headers)?,
+                       url:   url.to_owned(), })
     }
 
     pub fn show_package<I>(&self,

--- a/components/builder-db/Cargo.toml
+++ b/components/builder-db/Cargo.toml
@@ -24,13 +24,13 @@ num_cpus = "*"
 protobuf = "*"
 fnv = "*"
 fallible-iterator = "*"
-percent-encoding = "*"
 postgres = "*"
 postgres-derive = "*"
 postgres-shared = "*"
 r2d2_postgres = "*"
 threadpool = "*"
-url = "*"
+# Unlock with builder_core
+url = "=1.7.2"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"

--- a/components/builder-db/src/config.rs
+++ b/components/builder-db/src/config.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use num_cpus;
-use percent_encoding::{utf8_percent_encode,
-                       PATH_SEGMENT_ENCODE_SET};
 use postgres_shared::params::{ConnectParams,
                               Host,
                               IntoConnectParams};
 use std::{error::Error,
           fmt};
+use url::percent_encoding::{utf8_percent_encode,
+                            PATH_SEGMENT_ENCODE_SET};
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]

--- a/components/builder-worker/src/error.rs
+++ b/components/builder-worker/src/error.rs
@@ -180,6 +180,10 @@ impl From<hab_core::Error> for Error {
     fn from(err: hab_core::Error) -> Error { Error::HabitatCore(err) }
 }
 
+impl From<github_api_client::HubError> for Error {
+    fn from(err: github_api_client::HubError) -> Error { Error::GithubAppAuthErr(err) }
+}
+
 impl From<protobuf::ProtobufError> for Error {
     fn from(err: protobuf::ProtobufError) -> Error { Error::Protobuf(err) }
 }

--- a/components/builder-worker/src/runner/publisher.rs
+++ b/components/builder-worker/src/runner/publisher.rs
@@ -45,7 +45,7 @@ impl Publisher {
         debug!("Publisher (url: {}, channel: {:?})",
                self.url, self.channel_opt);
 
-        let client = ApiClient::new(&self.url);
+        let client = ApiClient::new(&self.url)?;
         let ident = archive.ident().unwrap();
         let target = archive.target().unwrap();
 

--- a/components/builder-worker/src/vcs.rs
+++ b/components/builder-worker/src/vcs.rs
@@ -34,7 +34,7 @@ pub struct VCS {
 }
 
 impl VCS {
-    pub fn from_job(job: &Job, config: GitHubCfg) -> Self {
+    pub fn from_job(job: &Job, config: GitHubCfg) -> Result<Self> {
         match job.get_project().get_vcs_type() {
             "git" => {
                 let installation_id: Option<u32> = {
@@ -57,11 +57,11 @@ impl VCS {
                data: String,
                config: GitHubCfg,
                installation_id: Option<u32>)
-               -> Self {
-        VCS { vcs_type,
-              data,
-              github_client: GitHubClient::new(config),
-              installation_id }
+               -> Result<Self> {
+        Ok(VCS { vcs_type,
+                 data,
+                 github_client: GitHubClient::new(config)?,
+                 installation_id })
     }
 
     pub fn clone(&self, path: &Path) -> Result<()> {

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -84,17 +84,17 @@ pub struct GitHubClient {
 }
 
 impl GitHubClient {
-    pub fn new(config: GitHubCfg) -> Self {
+    pub fn new(config: GitHubCfg) -> HubResult<Self> {
         let header_values = vec![USER_AGENT_BLDR.clone(),
                                  ACCEPT_GITHUB_JSON.clone(),
                                  CONTENT_TYPE_APPLICATION_JSON.clone()];
         let headers = HeaderMap::from_iter(header_values.into_iter());
 
-        GitHubClient { inner:           HttpClient::new(&config.api_url, headers),
-                       api_url:         config.api_url,
-                       app_id:          config.app_id,
-                       app_private_key: config.app_private_key,
-                       webhook_secret:  config.webhook_secret, }
+        Ok(GitHubClient { inner:           HttpClient::new(&config.api_url, headers)?,
+                          api_url:         config.api_url,
+                          app_id:          config.app_id,
+                          app_private_key: config.app_private_key,
+                          webhook_secret:  config.webhook_secret, })
     }
 
     pub fn app(&self) -> HubResult<App> {
@@ -305,7 +305,7 @@ mod tests {
 
             if !pp.is_empty() {
                 let cfg = config::GitHubCfg::default();
-                let client = GitHubClient::new(cfg);
+                let client = GitHubClient::new(cfg).unwrap();
                 assert_eq!(client.meta().unwrap(), ());
             }
         }

--- a/components/oauth-client/src/client.rs
+++ b/components/oauth-client/src/client.rs
@@ -36,11 +36,11 @@ pub struct OAuth2Client {
 }
 
 impl OAuth2Client {
-    pub fn new(config: OAuth2Cfg) -> Self {
+    pub fn new(config: OAuth2Cfg) -> Result<Self> {
         let header_values = vec![USER_AGENT_BLDR.clone(),];
         let headers = HeaderMap::from_iter(header_values.into_iter());
 
-        let client = HttpClient::new(&config.token_url, headers);
+        let client = HttpClient::new(&config.token_url, headers)?;
 
         let provider: Box<dyn OAuth2Provider> = match &config.provider[..] {
             "active-directory" => Box::new(ActiveDirectory),
@@ -53,9 +53,9 @@ impl OAuth2Client {
             _ => panic!("Unknown OAuth provider: {}", config.provider),
         };
 
-        OAuth2Client { inner: client,
-                       config,
-                       provider }
+        Ok(OAuth2Client { inner: client,
+                          config,
+                          provider })
     }
 
     pub fn authenticate(&self, code: &str) -> Result<(String, OAuth2User)> {

--- a/components/segment-api-client/src/client.rs
+++ b/components/segment-api-client/src/client.rs
@@ -24,7 +24,8 @@ use builder_core::http_client::{HttpClient,
                                 CONTENT_TYPE_APPLICATION_JSON,
                                 USER_AGENT_BLDR};
 
-use crate::config::SegmentCfg;
+use crate::{config::SegmentCfg,
+            error::SegmentResult};
 
 #[derive(Clone)]
 pub struct SegmentClient {
@@ -35,16 +36,16 @@ pub struct SegmentClient {
 }
 
 impl SegmentClient {
-    pub fn new(config: SegmentCfg) -> Self {
+    pub fn new(config: SegmentCfg) -> SegmentResult<Self> {
         let header_values = vec![USER_AGENT_BLDR.clone(),
                                  ACCEPT_APPLICATION_JSON.clone(),
                                  CONTENT_TYPE_APPLICATION_JSON.clone()];
         let headers = HeaderMap::from_iter(header_values.into_iter());
 
-        SegmentClient { inner:     HttpClient::new(&config.url, headers),
-                        url:       config.url,
-                        write_key: config.write_key,
-                        enabled:   config.enabled, }
+        Ok(SegmentClient { inner:     HttpClient::new(&config.url, headers)?,
+                           url:       config.url,
+                           write_key: config.write_key,
+                           enabled:   config.enabled, })
     }
 
     pub fn identify(&self, user_id: &str) {

--- a/components/segment-api-client/src/error.rs
+++ b/components/segment-api-client/src/error.rs
@@ -16,12 +16,14 @@ use std::{error,
           fmt,
           io};
 
+use builder_core;
 use serde_json;
 
 pub type SegmentResult<T> = Result<T, SegmentError>;
 
 #[derive(Debug)]
 pub enum SegmentError {
+    BuilderCore(builder_core::Error),
     IO(io::Error),
     Serialization(serde_json::Error),
 }
@@ -29,6 +31,7 @@ pub enum SegmentError {
 impl fmt::Display for SegmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
+            SegmentError::BuilderCore(ref e) => format!("{}", e),
             SegmentError::IO(ref e) => format!("{}", e),
             SegmentError::Serialization(ref e) => format!("{}", e),
         };
@@ -39,8 +42,13 @@ impl fmt::Display for SegmentError {
 impl error::Error for SegmentError {
     fn description(&self) -> &str {
         match *self {
+            SegmentError::BuilderCore(ref err) => err.description(),
             SegmentError::IO(ref err) => err.description(),
             SegmentError::Serialization(ref err) => err.description(),
         }
     }
+}
+
+impl From<builder_core::Error> for SegmentError {
+    fn from(err: builder_core::Error) -> Self { SegmentError::BuilderCore(err) }
 }

--- a/components/segment-api-client/src/main.rs
+++ b/components/segment-api-client/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
         }
     }
 
-    let client = SegmentClient::new(config);
+    let client = SegmentClient::new(config).expect("Valid segment client");
     client.identify("abc123");
     client.track("abc123", "tested tracking");
 }


### PR DESCRIPTION
This change enables on-prem Builder services to use cached certificates in "/hab/cache/ssl" as part of the trusted cert chain when communicating with external services such as github or other OAuth providers. This allows for a nicer way to deal with self-signed certs, instead of having to do things like manually modifying the cert.pem file in the core/cacerts installed package.

The one place where we are not using the cached SSL certs is for the S3 Rusoto calls. Those are using the Rusuto http client which has significantly different configuration. This should generally not be an issue for the current on-prem use case which is to use a local Minio instance.

This change also has some minor refactoring done to bubble up Results in a few places instead of unwraps or expects. Also there are a couple of dependent crates that need to be specifically pinned in order to avoid breaking conflicts. Those are commented appropriately.

Resolves https://github.com/habitat-sh/on-prem-builder/issues/173

Signed-off-by: Salim Alam <salam@chef.io>


![](https://media2.giphy.com/media/mD44ZStfDEDngsTL6g/giphy.gif?cid=5a38a5a2b6107be3f9aa605cc5854643c4970b0f92298b12&rid=giphy.gif)
