### PR TITLE
Include `target` param w/ build job create request

### DIFF
--- a/components/builder-web/app/actions/jobs.ts
+++ b/components/builder-web/app/actions/jobs.ts
@@ -47,9 +47,9 @@ export function clearJobs() {
   };
 }
 
-export function submitJob(origin: string, name: string, token: string) {
+export function submitJob(origin: string, name: string, target: string, token: string) {
   return dispatch => {
-    return depotApi.submitJob(origin, name, token)
+    return depotApi.submitJob(origin, name, target, token)
       .then(response => {
         dispatch(addNotification({
           title: 'Job submitted',

--- a/components/builder-web/app/client/depot-api.ts
+++ b/components/builder-web/app/client/depot-api.ts
@@ -260,8 +260,8 @@ export function promotePackage(origin: string, name: string, version: string, re
   });
 }
 
-export function submitJob(origin: string, pkg: string, token: string) {
-  const url = `${urlPrefix}/depot/pkgs/schedule/${origin}/${pkg}`;
+export function submitJob(origin: string, pkg: string, target: string, token: string) {
+  const url = `${urlPrefix}/depot/pkgs/schedule/${origin}/${pkg}?target=${target}`;
 
   return new Promise((resolve, reject) => {
     fetch(url, {

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
@@ -32,7 +32,7 @@ export class PackageSidebarComponent {
 
   build() {
     let token = this.store.getState().session.token;
-    this.store.dispatch(submitJob(this.origin, this.name, token));
+    this.store.dispatch(submitJob(this.origin, this.name, this.target, token));
   }
 
   get buildButtonLabel() {

--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -50,6 +50,7 @@
     <hab-package-sidebar
       [origin]="origin"
       [name]="name"
+      [target]="target"
       [isOriginMember]="isOriginMember"
       [hasPlan]="hasPlan"
       [building]="building">

--- a/components/builder-web/app/package/package/package.component.spec.ts
+++ b/components/builder-web/app/package/package/package.component.spec.ts
@@ -110,7 +110,7 @@ describe('PackageComponent', () => {
       declarations: [
         PackageComponent,
         MockComponent({ selector: 'hab-package-breadcrumbs', inputs: ['ident'] }),
-        MockComponent({ selector: 'hab-package-sidebar', inputs: ['origin', 'name', 'building', 'isOriginMember', 'hasPlan'] }),
+        MockComponent({ selector: 'hab-package-sidebar', inputs: ['origin', 'name', 'target', 'building', 'isOriginMember', 'hasPlan'] }),
         MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] }),
         MockComponent({ selector: 'hab-job-notice', inputs: ['job'] }),
         MockComponent({ selector: 'hab-visibility-icon', inputs: ['visibility', 'prefix'] })


### PR DESCRIPTION
This commit ensures the selected target platform is included w/ the request to build a new package.

Fixes https://github.com/habitat-sh/builder/issues/1157

![](https://user-images.githubusercontent.com/479121/64281213-de25f780-cf0f-11e9-84ae-d4ac79bc37bb.gif)
