### PR TITLE
Remove the example commands from the sidebar

### DIFF
--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
@@ -41,14 +41,4 @@
       <a [routerLink]="['./']">View available versions</a>.
     </p>
   </section>
-  <ng-container *ngIf="isAService">
-    <section>
-      <h3>Run Command</h3>
-      <hab-copyable style="input" [text]="runCommand"></hab-copyable>
-    </section>
-    <section>
-      <h3>Export Command</h3>
-      <hab-copyable style="input" [text]="exportCommand"></hab-copyable>
-    </section>
-  </ng-container>
 </div>


### PR DESCRIPTION
Closes https://github.com/habitat-sh/builder/issues/293

Signed-off-by: Josh Black <raskchanky@gmail.com>