### PR TITLE
Add SSL configuration for depot postgres client

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -315,6 +315,10 @@ mod tests {
         connection_timeout_sec = 4800
         connection_test = true
         pool_size = 1
+        ssl_mode = "verify_ca"
+        ssl_root_cert = "/root_ca.crt"
+        ssl_key = "/ssl.key"
+        ssl_cert = "/ssl.crt"
         "#;
 
         let config = Config::from_raw(&content).unwrap();
@@ -374,6 +378,11 @@ mod tests {
         assert_eq!(config.datastore.connection_timeout_sec, 4800);
         assert_eq!(config.datastore.connection_test, true);
         assert_eq!(config.datastore.pool_size, 1);
+        assert_eq!(config.datastore.ssl_mode, Some("verify_ca".to_string()));
+        assert_eq!(config.datastore.ssl_root_cert,
+                   Some("/root_ca.crt".to_string()));
+        assert_eq!(config.datastore.ssl_key, Some("/ssl.key".to_string()));
+        assert_eq!(config.datastore.ssl_cert, Some("/ssl.crt".to_string()));
     }
 
     #[test]

--- a/components/builder-db/src/config.rs
+++ b/components/builder-db/src/config.rs
@@ -37,6 +37,10 @@ pub struct DataStoreCfg {
     pub connection_test: bool,
     /// Number of database connections to start in pool.
     pub pool_size: u32,
+    pub ssl_mode: Option<String>,
+    pub ssl_cert: Option<String>,
+    pub ssl_key: Option<String>,
+    pub ssl_root_cert: Option<String>,
 }
 
 impl Default for DataStoreCfg {
@@ -49,7 +53,11 @@ impl Default for DataStoreCfg {
                        connection_retry_ms:    300,
                        connection_timeout_sec: 3600,
                        connection_test:        false,
-                       pool_size:              (num_cpus::get() * 2) as u32, }
+                       pool_size:              (num_cpus::get() * 2) as u32,
+                       ssl_mode:               None,
+                       ssl_cert:               None,
+                       ssl_key:                None,
+                       ssl_root_cert:          None, }
     }
 }
 
@@ -65,6 +73,28 @@ impl fmt::Display for DataStoreCfg {
             None => connect,
         };
         connect = format!("{}@{}:{}/{}", connect, self.host, self.port, self.database);
+        let mut opts = Vec::new();
+
+        if let Some(ref m) = self.ssl_mode {
+            opts.push(format!("sslmode={}", m));
+        }
+
+        if let Some(ref m) = self.ssl_cert {
+            opts.push(format!("sslcert={}", m));
+        }
+
+        if let Some(ref m) = self.ssl_key {
+            opts.push(format!("sslkey={}", m));
+        }
+
+        if let Some(ref m) = self.ssl_root_cert {
+            opts.push(format!("sslrootcert={}", m));
+        }
+
+        if !opts.is_empty() {
+            connect = format!("{}?{}", connect, opts.join("&"));
+        }
+
         write!(f, "{}", connect)
     }
 }


### PR DESCRIPTION
This change allows builder to connect to postgres using SSL for
authentication