### PR TITLE
Plumbs new project reqs through jobsrv, preserves backcompat

### DIFF
--- a/components/builder-api/src/server/helpers.rs
+++ b/components/builder-api/src/server/helpers.rs
@@ -67,6 +67,26 @@ pub fn extract_pagination_in_pages(pagination: &Query<Pagination>) -> (isize, is
     (pagination.range / PAGINATION_RANGE_MAX + 1, PAGINATION_RANGE_MAX)
 }
 
+pub fn extract_target(qtarget: &Query<Target>) -> PackageTarget {
+    match qtarget.target {
+        Some(ref t) => {
+            trace!("Query requested target = {}", t);
+            match PackageTarget::from_str(t) {
+                Ok(t) => t,
+                Err(err) => {
+                    debug!("Invalid target requested: {}, err = {:?}", t, err);
+                    debug!("USING DEFAULT = x86_64-linux");
+                    PackageTarget::from_str("x86_64-linux").unwrap()
+                }
+            }
+        }
+        None => {
+            debug!("NO TARGET PASSED. USING DEFAULT = x86_64-linux");
+            PackageTarget::from_str("x86_64-linux").unwrap()
+        }
+    }
+}
+
 // TODO: Deprecate getting target from User Agent header
 pub fn target_from_headers(req: &HttpRequest) -> PackageTarget {
     let user_agent_header = match req.headers().get(header::USER_AGENT) {

--- a/components/builder-api/src/server/resources/jobs.rs
+++ b/components/builder-api/src/server/resources/jobs.rs
@@ -490,7 +490,7 @@ fn do_get_job_log(req: &HttpRequest, job_id: u64, start: u64) -> Result<jobsrv::
             // database.
             // TODO (SA): Update the project information in the job to match the DB
             let conn = req_state(req).db.get_conn().map_err(Error::DbError)?;
-            let project = Project::get(job.get_project().get_name(), &*conn)?;
+            let project = Project::get(job.get_project().get_name(), job.get_target(), &*conn)?;
             let settings =
                 OriginPackageSettings::get(&GetOriginPackageSettings { origin:
                                                                            job.get_project()

--- a/components/builder-api/src/server/services/github.rs
+++ b/components/builder-api/src/server/services/github.rs
@@ -222,7 +222,7 @@ fn build_plans(req: &HttpRequest,
 
     for plan in plans.iter() {
         let project_name = format!("{}/{}", &plan.0.origin, &plan.0.name);
-        match Project::get(&project_name, &*conn) {
+        match Project::get(&project_name, &plan.1, &*conn) {
             Ok(project) => {
                 if repo_url != project.vcs_data {
                     warn!("Repo URL ({}) doesn't match project vcs data ({}). Aborting.",

--- a/components/builder-db/src/models/projects.rs
+++ b/components/builder-db/src/models/projects.rs
@@ -66,15 +66,16 @@ pub struct UpdateProject<'a> {
 }
 
 impl Project {
-    pub fn get(name: &str, conn: &PgConnection) -> QueryResult<Project> {
+    pub fn get(name: &str, target: &str, conn: &PgConnection) -> QueryResult<Project> {
         Counter::DBCall.increment();
         origin_projects::table.filter(origin_projects::name.eq(name))
+                              .filter(origin_projects::target.eq(target))
                               .get_result(conn)
     }
 
-    pub fn delete(name: &str, conn: &PgConnection) -> QueryResult<usize> {
+    pub fn delete(name: &str, target: &str, conn: &PgConnection) -> QueryResult<usize> {
         Counter::DBCall.increment();
-        diesel::delete(origin_projects::table.filter(origin_projects::name.eq(name))).execute(conn)
+        diesel::delete(origin_projects::table.filter(origin_projects::name.eq(name)).filter(origin_projects::target.eq(target))).execute(conn)
     }
 
     pub fn create(project: &NewProject, conn: &PgConnection) -> QueryResult<Project> {

--- a/components/builder-jobsrv/src/server/scheduler.rs
+++ b/components/builder-jobsrv/src/server/scheduler.rs
@@ -536,7 +536,7 @@ impl ScheduleMgr {
                     -> Result<Option<jobsrv::Job>> {
         let conn = self.db.get_conn().map_err(Error::Db)?;
 
-        let project = match Project::get(&project_name, &*conn) {
+        let project = match Project::get(&project_name, &target, &*conn) {
             Ok(project) => project,
             Err(diesel::result::Error::NotFound) => {
                 // It's valid to not have a project connected

--- a/test/builder-api/src/origins.js
+++ b/test/builder-api/src/origins.js
@@ -216,7 +216,7 @@ describe('Origin API', function () {
         });
     });
 
-    it('succeeds in deleting the associated project', function (done) {
+    it('succeeds in deleting associated project', function (done) {
       request.delete('/projects/umbrella/testapp')
         .type('application/json')
         .accept('application/json')

--- a/test/builder-api/src/projects.js
+++ b/test/builder-api/src/projects.js
@@ -8,7 +8,6 @@ const repoId = 114932712;
 const projectCreatePayload = {
   origin: 'neurosis',
   plan_path: 'plan.sh',
-  target: 'x86_64-linux',
   installation_id: installationId,
   repo_id: repoId,
   auto_build: true
@@ -208,6 +207,7 @@ describe('Projects API', function () {
         .send({
           plan_path: 'awesome/plan.sh',
           installation_id: installationId,
+          target: 'x86_64-linux',
           repo_id: repoId
         })
         .expect(204)


### PR DESCRIPTION
This PR does a couple of things.

a. It plumbs the new project target requirements through to the jobsrv
b. It provides a mechanism for users to delete ALL projects for a given package by passing a '*' to the query value.
c. Finally, as a goal, it mostly preserves backwards compatibility. By providing the previous behavior of the api through default values.

Signed-off-by: Ian Henry <ihenry@chef.io>