### PR TITLE
Support TLS for memcached

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memcache 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memcache 0.13.1 (git+https://github.com/stevendanna/rust-memcache.git?branch=tls-support)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth-client 0.0.0",
  "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1760,10 +1760,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "memcache"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/stevendanna/rust-memcache.git?branch=tls-support#e0618256ce0426351a7850ddbdf8a4562b710ecd"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_dispatch 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3784,7 +3785,7 @@ dependencies = [
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
-"checksum memcache 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "85a0882d404337b0a0fdca08a8bd74bdd9e9d7ac88d4339dfee099c832b79811"
+"checksum memcache 0.13.1 (git+https://github.com/stevendanna/rust-memcache.git?branch=tls-support)" = "<none>"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,9 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-openssl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-resolver 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -44,12 +46,14 @@ dependencies = [
  "actix-utils 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "copyless 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -60,6 +64,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -115,8 +120,10 @@ dependencies = [
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-openssl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -130,6 +137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-openssl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -202,6 +210,7 @@ dependencies = [
  "actix-threadpool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-utils 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web-codegen 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "awc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -210,6 +219,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -293,6 +303,29 @@ dependencies = [
 name = "autocfg"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "awc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-service 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "backtrace"
@@ -386,6 +419,24 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "brotli-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "brotli2"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -993,6 +1044,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1778,6 +1830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miniz-sys"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3066,6 +3127,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-openssl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-process"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,6 +3647,7 @@ dependencies = [
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+"checksum awc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "364537de6ac9f996780f9dd097d6c4ca7c91dd5735153e9fb545037479becd10"
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
@@ -3587,6 +3659,8 @@ dependencies = [
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
+"checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
+"checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
@@ -3719,6 +3793,7 @@ dependencies = [
 "checksum migrations_macros 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "719ef0bc7f531428764c9b70661c14abd50a7f3d21f355752d9985aa21251c9e"
 "checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
+"checksum miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
 "checksum miniz_oxide 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "304f66c19be2afa56530fa7c39796192eef38618da8d19df725ad7c6d6b2aaae"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
@@ -3854,6 +3929,7 @@ dependencies = [
 "checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
+"checksum tokio-openssl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "771d6246b170ae108d67d9963c23f31a579016c016d73bd4bd7d6ef0252afda7"
 "checksum tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afbd6ef1b8cc2bd2c2b580d882774d443ebb1c6ceefe35ba9ea4ab586c89dbe8"
 "checksum tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c56391be9805bc80163151c0b9e5164ee64f4b0200962c346fea12773158f22d"
 "checksum tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -52,6 +52,7 @@ uuid = { version = "*", features = ["v4"] }
 [dependencies.actix-web]
 version = "*"
 default-features = false
+features = [ "ssl" ]
 
 [dependencies.clap]
 version = "*"

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -28,7 +28,6 @@ hex = "*"
 reqwest = "=0.9.17"
 lazy_static = "*"
 log = "*"
-memcache = "*"
 num_cpus = "*"
 openssl = "=0.10.22"
 percent-encoding = "*"
@@ -48,6 +47,11 @@ tempfile = "*"
 time = "*"
 url = "*"
 uuid = { version = "*", features = ["v4"] }
+
+[dependencies.memcache]
+version = "*"
+git = "https://github.com/stevendanna/rust-memcache.git"
+branch = "tls-support"
 
 [dependencies.actix-web]
 version = "*"

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -166,7 +166,7 @@ impl GatewayCfg for Config {
 pub struct HttpCfg {
     pub listen:        IpAddr,
     pub port:          u16,
-    pub tls:           Option<TLSCfg>,
+    pub tls:           Option<TLSServerCfg>,
     pub handler_count: usize,
     pub keep_alive:    usize,
 }
@@ -174,10 +174,36 @@ pub struct HttpCfg {
 /// Optional TLS configuration
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
-pub struct TLSCfg {
+pub struct TLSServerCfg {
     pub cert_path:    PathBuf,
     pub key_path:     PathBuf,
     pub ca_cert_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct TLSClientCfg {
+    pub cert_path:    Option<PathBuf>,
+    pub key_path:     Option<PathBuf>,
+    pub ca_cert_path: Option<PathBuf>,
+    pub verify:       bool,
+}
+
+impl Default for TLSServerCfg {
+    fn default() -> Self {
+        TLSServerCfg { cert_path:    PathBuf::from("/hab/svc/builder-api/files/service.crt"),
+                       key_path:     PathBuf::from("/hab/svc/builder-api/files/service.key"),
+                       ca_cert_path: None, }
+    }
+}
+
+impl Default for TLSClientCfg {
+    fn default() -> Self {
+        TLSClientCfg { cert_path:    None,
+                       key_path:     None,
+                       ca_cert_path: None,
+                       verify:       true, }
+    }
 }
 
 impl Default for HttpCfg {
@@ -187,14 +213,6 @@ impl Default for HttpCfg {
                   tls:           None,
                   handler_count: Config::default_handler_count(),
                   keep_alive:    60, }
-    }
-}
-
-impl Default for TLSCfg {
-    fn default() -> Self {
-        TLSCfg { cert_path:    PathBuf::from("/hab/svc/builder-api/files/service.crt"),
-                 key_path:     PathBuf::from("/hab/svc/builder-api/files/service.key"),
-                 ca_cert_path: None, }
     }
 }
 
@@ -221,6 +239,7 @@ pub struct UiCfg {
 pub struct MemcacheCfgHosts {
     pub host: String,
     pub port: u16,
+    pub tls:  Option<TLSClientCfg>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -233,7 +252,8 @@ pub struct MemcacheCfg {
 impl Default for MemcacheCfgHosts {
     fn default() -> Self {
         MemcacheCfgHosts { host: String::from("localhost"),
-                           port: 11211, }
+                           port: 11211,
+                           tls:  None, }
     }
 }
 
@@ -244,9 +264,50 @@ impl Default for MemcacheCfg {
     }
 }
 
+impl MemcacheCfg {
+    pub fn memcache_hosts(&self) -> Vec<String> {
+        self.hosts
+            .iter()
+            .map(|h| h.to_string_with_params())
+            .collect()
+    }
+}
+
+impl MemcacheCfgHosts {
+    pub fn to_string_with_params(&self) -> String {
+        let mut url = format!("{}?tcp_nodelay=true", self); // tcp_nodelay is a significant perf gain
+        if let Some(tls_config) = &self.tls {
+            if tls_config.ca_cert_path.is_some() {
+                url.push_str(&format!("&ca_path={}",
+                                      tls_config.ca_cert_path.as_ref().unwrap().to_string_lossy()))
+            }
+
+            if tls_config.key_path.is_some() {
+                url.push_str(&format!("&key_path={}",
+                                      tls_config.key_path.as_ref().unwrap().to_string_lossy()))
+            }
+
+            if tls_config.cert_path.is_some() {
+                url.push_str(&format!("&cert_path={}",
+                                      tls_config.cert_path.as_ref().unwrap().to_string_lossy()))
+            }
+
+            if tls_config.verify {
+                url.push_str("&verify_mode=peer");
+            } else {
+                url.push_str("&verify_mode=none");
+            }
+        }
+        url
+    }
+}
+
 impl fmt::Display for MemcacheCfgHosts {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "memcache://{}:{}", self.host, self.port)
+        match &self.tls {
+            Some(_) => write!(f, "memcache+tls://{}:{}", self.host, self.port),
+            None => write!(f, "memcache://{}:{}", self.host, self.port),
+        }
     }
 }
 

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -192,8 +192,8 @@ impl Default for HttpCfg {
 
 impl Default for TLSCfg {
     fn default() -> Self {
-        TLSCfg { cert_path:    PathBuf::from("/hab/svc/builder-api/config/service.crt"),
-                 key_path:     PathBuf::from("/hab/svc/builder-api/config/service.key"),
+        TLSCfg { cert_path:    PathBuf::from("/hab/svc/builder-api/files/service.crt"),
+                 key_path:     PathBuf::from("/hab/svc/builder-api/files/service.key"),
                  ca_cert_path: None, }
     }
 }

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -166,16 +166,35 @@ impl GatewayCfg for Config {
 pub struct HttpCfg {
     pub listen:        IpAddr,
     pub port:          u16,
+    pub tls:           Option<TLSCfg>,
     pub handler_count: usize,
     pub keep_alive:    usize,
+}
+
+/// Optional TLS configuration
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct TLSCfg {
+    pub cert_path:    PathBuf,
+    pub key_path:     PathBuf,
+    pub ca_cert_path: Option<PathBuf>,
 }
 
 impl Default for HttpCfg {
     fn default() -> Self {
         HttpCfg { listen:        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
                   port:          9636,
+                  tls:           None,
                   handler_count: Config::default_handler_count(),
                   keep_alive:    60, }
+    }
+}
+
+impl Default for TLSCfg {
+    fn default() -> Self {
+        TLSCfg { cert_path:    PathBuf::from("/hab/svc/builder-api/config/service.crt"),
+                 key_path:     PathBuf::from("/hab/svc/builder-api/config/service.key"),
+                 ca_cert_path: None, }
     }
 }
 

--- a/components/builder-api/src/server/error.rs
+++ b/components/builder-api/src/server/error.rs
@@ -66,6 +66,7 @@ pub enum Error {
     Protobuf(protobuf::ProtobufError),
     SerdeJson(serde_json::Error),
     System,
+    TLSError(openssl::error::ErrorStack),
     Unprocessable,
     Utf8(string::FromUtf8Error),
 }
@@ -102,6 +103,7 @@ impl fmt::Display for Error {
             Error::Protobuf(ref e) => format!("{}", e),
             Error::SerdeJson(ref e) => format!("{}", e),
             Error::System => "Internal error".to_string(),
+            Error::TLSError(ref e) => format!("{}", e),
             Error::Unprocessable => "Unprocessable entity".to_string(),
             Error::Utf8(ref e) => format!("{}", e),
         };
@@ -139,6 +141,7 @@ impl error::Error for Error {
             Error::Protobuf(ref err) => err.description(),
             Error::SerdeJson(ref err) => err.description(),
             Error::System => "Internal error",
+            Error::TLSError(ref err) => err.description(),
             Error::Unprocessable => "Unprocessable entity",
             Error::Utf8(ref err) => err.description(),
         }
@@ -261,6 +264,10 @@ impl From<db::error::Error> for Error {
 
 impl From<serde_json::Error> for Error {
     fn from(err: serde_json::Error) -> Error { Error::SerdeJson(err) }
+}
+
+impl From<openssl::error::ErrorStack> for Error {
+    fn from(err: openssl::error::ErrorStack) -> Error { Error::TLSError(err) }
 }
 
 impl From<string::FromUtf8Error> for Error {

--- a/components/builder-api/src/server/services/memcache.rs
+++ b/components/builder-api/src/server/services/memcache.rs
@@ -37,11 +37,7 @@ pub struct MemcacheClient {
 impl MemcacheClient {
     pub fn new(config: &MemcacheCfg) -> Self {
         trace!("Creating memcache client, hosts: {:?}", config.hosts);
-        let memcache_host_strings: Vec<String> = config
-            .hosts
-            .iter()
-            .map(|h| format!("{}?tcp_nodelay=true", h)) // tcp_nodelay is a significant perf gain
-            .collect();
+        let memcache_host_strings = config.memcache_hosts();
         let memcache_hosts: Vec<&str> = memcache_host_strings.iter().map(AsRef::as_ref).collect();
         MemcacheClient { cli: memcache::Client::connect(memcache_hosts).unwrap(),
                          ttl: config.ttl, }


### PR DESCRIPTION
This adds optional support for TLS-enabled memcached servers. It
builds on #1218.

Signed-off-by: Steven Danna <steve@chef.io>