### PR TITLE
Increase root block device size

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -23,6 +23,10 @@ resource "aws_instance" "api" {
     agent       = "${var.connection_agent}"
   }
 
+  root_block_device {
+    volume_size = 20
+  }
+
   ebs_block_device {
     device_name = "/dev/xvdf"
     volume_size = 100
@@ -151,6 +155,10 @@ resource "aws_instance" "jobsrv" {
     agent       = "${var.connection_agent}"
   }
 
+  root_block_device {
+    volume_size = 20
+  }
+
   ebs_block_device {
     device_name = "/dev/xvdf"
     volume_size = 100
@@ -261,6 +269,10 @@ resource "aws_instance" "worker" {
     user        = "ubuntu"
     private_key = "${file("${var.connection_private_key}")}"
     agent       = "${var.connection_agent}"
+  }
+
+  root_block_device {
+    volume_size = 20
   }
 
   ebs_block_device {
@@ -380,6 +392,10 @@ resource "aws_instance" "linux2-worker" {
     user        = "ubuntu"
     private_key = "${file("${var.connection_private_key}")}"
     agent       = "${var.connection_agent}"
+  }
+
+  root_block_device {
+    volume_size = 20
   }
 
   ebs_block_device {


### PR DESCRIPTION
Terraform change to increase root block device size to 20GB

Signed-off-by: Salim Alam <salam@chef.io>

![](https://media1.giphy.com/media/4EaYD0UzipYcM/giphy.gif?cid=5a38a5a283fb39338c2e20f8a4050cb9111a279512ab4b5c&rid=giphy.gif)
