### PR TITLE
Add infra for key encryption

### DIFF
--- a/components/builder-core/src/access_token.rs
+++ b/components/builder-core/src/access_token.rs
@@ -69,7 +69,7 @@ pub fn generate_access_token(key_dir: &PathBuf,
     token.set_expires(expires);
 
     let bytes = message::encode(&token).map_err(Error::Protocol)?;
-    let ciphertext = encrypt(key_dir, &bytes)?;
+    let (ciphertext, _) = encrypt(key_dir, &bytes)?;
 
     Ok(format!("{}{}", ACCESS_TOKEN_PREFIX, ciphertext))
 }

--- a/components/builder-core/src/integrations.rs
+++ b/components/builder-core/src/integrations.rs
@@ -27,7 +27,7 @@ use crate::{error::{Error,
 
 // TBD - these functions should take keys directly instead of key directory.
 
-pub fn encrypt<A>(key_dir: A, bytes: &[u8]) -> Result<String>
+pub fn encrypt<A>(key_dir: A, bytes: &[u8]) -> Result<(String, String)>
     where A: AsRef<Path>
 {
     let display_path = key_dir.as_ref().display();
@@ -55,7 +55,7 @@ pub fn encrypt<A>(key_dir: A, bytes: &[u8]) -> Result<String>
     // is consistently base64 and does not have random text interspersed with readable text.
     // This makes it easier to pass around, eg, for access tokens, and is by design.
     // The downside is that there is double base64 happening.
-    Ok(base64::encode(wsb.as_bytes()))
+    Ok((base64::encode(wsb.as_bytes()), kp.rev))
 }
 
 // This function takes in a double base64 encoded string

--- a/components/builder-db/src/migrations/2019-11-05-011907_private_keys/up.sql
+++ b/components/builder-db/src/migrations/2019-11-05-011907_private_keys/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE origin_secret_keys
+  ADD COLUMN encryption_key_rev text;

--- a/components/builder-db/src/models/keys.rs
+++ b/components/builder-db/src/models/keys.rs
@@ -57,6 +57,7 @@ pub struct OriginPrivateSigningKey {
     pub created_at: Option<NaiveDateTime>,
     pub updated_at: Option<NaiveDateTime>,
     pub origin: String,
+    pub encryption_key_rev: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
@@ -100,12 +101,13 @@ pub struct NewOriginPrivateEncryptionKey<'a> {
 #[derive(Insertable)]
 #[table_name = "origin_secret_keys"]
 pub struct NewOriginPrivateSigningKey<'a> {
-    pub owner_id:  i64,
-    pub name:      &'a str,
-    pub full_name: &'a str,
-    pub revision:  &'a str,
-    pub body:      &'a [u8],
-    pub origin:    &'a str,
+    pub owner_id:           i64,
+    pub name:               &'a str,
+    pub full_name:          &'a str,
+    pub revision:           &'a str,
+    pub body:               &'a [u8],
+    pub origin:             &'a str,
+    pub encryption_key_rev: &'a str,
 }
 
 #[derive(Insertable)]

--- a/components/builder-db/src/schema/key.rs
+++ b/components/builder-db/src/schema/key.rs
@@ -23,6 +23,7 @@ table! {
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
         origin -> Text,
+        encryption_key_rev -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
This change adds some infra for keeping origin secret (signing) keys encrypted at rest. New secret keys are encrypted when they are stored in the DB. Pre-existing secret keys are able to be retrieved even if they are not (yet) encrypted. This allows us to be backward compatible, and migration of un-encrypted keys to happen asynchronously.