### PR TITLE
Remove windows-worker specific security group

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -470,6 +470,7 @@ resource "aws_instance" "windows-worker" {
     var.aws_admin_sg,
     var.hab_sup_sg,
     aws_security_group.jobsrv_client.id,
+    aws_security_group.worker.id,
   ]
 
   connection {

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -470,7 +470,6 @@ resource "aws_instance" "windows-worker" {
     var.aws_admin_sg,
     var.hab_sup_sg,
     aws_security_group.jobsrv_client.id,
-    aws_security_group.windows-worker.id,
   ]
 
   connection {

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -199,41 +199,6 @@ resource "aws_security_group" "worker" {
   }
 }
 
-resource "aws_security_group" "windows-worker" {
-  name   = "builder-windows-worker-${var.env}"
-  vpc_id = var.aws_vpc_id
-
-  # RDP access
-  ingress {
-    from_port   = 3389
-    to_port     = 3389
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # WinRM access
-  ingress {
-    from_port   = 5985
-    to_port     = 5986
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
-    X-Environment = var.env
-    X-Application = "builder"
-    X-ManagedBy   = "Terraform"
-  }
-}
-
 resource "aws_security_group" "worker_studio" {
   name   = "builder-worker-studio-${var.env}"
   vpc_id = var.aws_vpc_id

--- a/terraform/templates/windows_worker_user_data
+++ b/terraform/templates/windows_worker_user_data
@@ -27,7 +27,7 @@
 
   # Install habitat
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-  iwr https://api.bintray.com/content/habitat/stable/windows/x86_64/hab-%24latest-x86_64-windows.zip?bt_package=hab-x86_64-windows -Outfile c:\habitat.zip
+  iwr https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-windows.zip -Outfile c:\habitat.zip
   Expand-Archive c:/habitat.zip c:/
   mv c:/hab-* c:/habitat
   $env:Path = $env:Path,"C:\habitat" -join ";"
@@ -42,7 +42,7 @@
   # Add config to HabService.dll.config
   $svcPath = Join-Path $env:SystemDrive "hab\svc\windows-service"
   [xml]$configXml = Get-Content (Join-Path $svcPath HabService.dll.config)
-  $configXml.configuration.appSettings.add[2].value = "${flags}"
+  $configXml.configuration.appSettings.add[1].value = "${flags}"
   $configXml.Save((Join-Path $svcPath HabService.dll.config))
 
   # Start service


### PR DESCRIPTION
This removes the open security group for rdp access to Windows. Access controls have been moved to Builder environment specific Terraform configuration. 

In addition, we change the source of the hab cli from Bintray to packages.chef.io in this PR.
We also update the array index for our launcher args, as a recent change in the WindowsService move from elements in the array to only 2. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>