### PR TITLE
call set_session_id_context

### DIFF
--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -61,6 +61,9 @@ use self::resources::{authenticate::Authenticate,
                       settings::Settings,
                       user::User};
 
+use rand::{self,
+           Rng};
+
 use crate::config::{Config,
                     GatewayCfg};
 
@@ -194,6 +197,8 @@ pub fn run(config: Config) -> error::Result<()> {
             builder.set_private_key_file(&tls_cfg.key_path, SslFiletype::PEM)?;
             builder.set_certificate_chain_file(&tls_cfg.cert_path)?;
             builder.set_cipher_list(TLS_CIPHERS)?;
+            let random_bytes = rand::thread_rng().gen::<[u8; 16]>();
+            builder.set_session_id_context(&random_bytes)?;
 
             match &tls_cfg.ca_cert_path {
                 None => {


### PR DESCRIPTION
The rust openssl docs say:

> This value should be set when using client certificates, or each
> request will fail its handshake and need to be restarted.

(https://docs.rs/openssl/0.10.16/openssl/ssl/struct.SslAcceptorBuilder.html#method.set_session_id_context)

Similarly, the SSL documentation says:

> If the session id context is not set on an SSL/TLS server and client
> certificates are used, stored sessions will not be reused but a
> fatal error will be flagged and the handshake will fail.

(https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_session_id_context.html)

I've opted to always set it since it doesn't appear _invalid_ to set
it even when client-certificates are not in use.

I've made our context id a random string. Other popular applications
such as nginx use facts about the TLS certificates in use and the host
to generate the string they use. I've opted for a random string
because we were unsure on the exact security properties required of
the session_id_context.

Signed-off-by: Steven Danna <steve@chef.io>