### PR TITLE
Update ssh_helpers for new access policies

### DIFF
--- a/tools/ssh_helpers/update-habitat-ssh
+++ b/tools/ssh_helpers/update-habitat-ssh
@@ -32,6 +32,7 @@ do
     echo "  User ubuntu" >> ~/.ssh/config
     echo "  IdentitiesOnly yes" >> ~/.ssh/config
     echo "  IdentityFile ~/.ssh/habitat-srv-admin" >> ~/.ssh/config
+    echo "  ProxyJump jump.chef.co" >> ~/.ssh/config
     echo "" >> ~/.ssh/config
 done
 


### PR DESCRIPTION
Hey folks, please follow the directions below before approving this PR, as I am using that as a signal everyone is able to access acceptance so we can proceed with the changes to live.  Please reach out to me on slack if you run into any issues. 

Below are the updated steps outlined in our on-call documentation to access our builder environments. Once you have completed `Access to the VPN and Chef jump host` and IT has granted you access, please checkout this branch (so you have access to the updated scripts) and follow the directions in `SSH access to prod/acceptance nodes` and `RDP access to prod/acceptance windows-workers` 


## Access to the VPN and Chef jump host

In order to ssh or rdp into the production or acceptance Builder environments, you will need access to the Chef jump host and the VPN.   You will need to be logged in to the VPN in order to connect to any Builder instance. 

### VPN
Details on accessing the VPN can be found in the [Chef Wiki](https://chefio.atlassian.net/wiki/spaces/OPS/pages/63143963/Remote+access+VPN+-+Openvpn+-+User+version). If you run into issues, please reach out to the team or the IT folks for help.

###  Jump host

Access to the jump host is provided by the [helpdesk](https://helpdesk.chef.io).  Details on requesting access to the jump host can be found in the [Chef Wiki](https://chefio.atlassian.net/wiki/spaces/ENG/pages/783548461/SOP-002+Providing+access+to+instances+in+chef-engineering#SOP-002Providingaccesstoinstancesinchef-engineering-Step2:Gainaccesstojump.chef.co). If you run into issues, please reach out to the team or the IT folks for help.


## SSH access to prod/acceptance nodes

You will need access to the 1Password shared vault (if you do not have this, ask a core team member) and to the Habitat AWS account (should be through an icon in Okta; if you don't have this, ask the Chef internal help desk).

Copy the "habitat-srv-admin" key from the shared vault.  I always put mine in my ~/.aws directory on my workstation. You will also need to ensure you `chmod 600 habitat-srv-admin` in order for ssh to be able to load the key.

There are a set of scripts in the [`ssh_helpers` directory in the habitat repo](https://github.com/habitat-sh/builder/tree/master/tools/ssh_helpers). You can use these to automatically populate all the production (and acceptance) nodes in your ssh config, and can then simply refer to the node by its friendly name, e.g.: `ssh live-builder-api-0`.  

It is **strongly recommended** you use these scripts to manage your ssh configuration, as they will automatically set up the jump host connection for you.  Please read the documentation on the scripts to understand how to use them

**NOTE** If your local workstation username is different then your `@chef.io` username, you will also need the following config in your `~/.ssh/config`.   This config is unique per-user.

```
Host jump.chef.co
  User your_chef_username
```

## RDP access to prod/acceptance windows-workers

In order to access the windows worker nodes, you will need to create an ssh tunnel to point your RDP client of choice at.  

On Linux, MacOS, and WSL, you can run:
```
ssh -L 33389:<windows worker dns>:3389 jump.chef.co
```
And then point your RDP client at `localhost:33389`

You will need to leave the ssh session that is created open while you are connected to the Windows host. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>