### PR TITLE
Tweaks package search to use origin membership rather than ownership

### DIFF
--- a/components/builder-db/src/schema/member.rs
+++ b/components/builder-db/src/schema/member.rs
@@ -1,4 +1,5 @@
 table! {
+    use diesel::sql_types::{BigInt, Text, Nullable, Timestamptz};
     origin_members (origin, account_id) {
         account_id -> BigInt,
         origin -> Text,
@@ -9,9 +10,11 @@ table! {
 
 use super::{account::accounts,
             origin::{origins,
-                     origins_with_stats}};
+                     origins_with_stats},
+            package::origin_packages};
 
 joinable!(origin_members -> origins (origin));
 joinable!(origin_members -> origins_with_stats (origin));
 joinable!(origin_members -> accounts (account_id));
 allow_tables_to_appear_in_same_query!(origin_members, origins, origins_with_stats, accounts);
+allow_tables_to_appear_in_same_query!(origin_members, origin_packages);

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -742,6 +742,21 @@ describe('Working with packages', function () {
       request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
         .type('application/json')
         .accept('application/json')
+        .set('Authorization', global.weskerBearer)
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.ident.origin).to.equal('neurosis');
+          expect(res.body.ident.name).to.equal('testapp');
+          expect(res.body.ident.version).to.equal('0.1.3');
+          expect(res.body.ident.release).to.equal(release2);
+          done(err);
+        });
+    });
+
+    it('allows owners of the origin to view private packages when they are authenticated', function (done) {
+      request.get(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
+        .type('application/json')
+        .accept('application/json')
         .set('Authorization', global.boboBearer)
         .expect(200)
         .end(function (err, res) {

--- a/test/builder-api/src/sessions.js
+++ b/test/builder-api/src/sessions.js
@@ -23,5 +23,14 @@ describe('Authenticate API', function() {
           done(err);
         });
     });
+    it('returns wesker', function(done) {
+      request.get('/authenticate/wesker')
+        .expect(200)
+        .end(function(err, res) {
+            expect(res.body.name).to.equal('wesker');
+            global.sessionWesker = res.body;
+            done(err);
+        });
+    });
   });
 });


### PR DESCRIPTION
This is going to need some thorough testing in acceptance. Our functional tests all pass but it's hard to say how search is going to perform without a full dataset.
Signed-off-by: Ian Henry <ihenry@chef.io>