### PR TITLE
Return 404 if no packages were demoted from the users request

### DIFF
--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -505,7 +505,13 @@ fn demote_package(req: HttpRequest,
                                                              channel: channel.clone() },
                                        &*conn).map_err(Error::DieselError)
     {
-        Ok(_) => {
+        Ok(0) => {
+            debug!("Requested package {} for target {} not present in channel {}",
+                   ident, target, channel);
+            return HttpResponse::new(StatusCode::NOT_FOUND);
+        }
+        Ok(result) => {
+            dbg!(result);
             match PackageChannelAudit::audit(
                 &PackageChannelAudit {
                     package_ident: BuilderPackageIdent(ident.clone()),

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -508,10 +508,9 @@ fn demote_package(req: HttpRequest,
         Ok(0) => {
             debug!("Requested package {} for target {} not present in channel {}",
                    ident, target, channel);
-            return HttpResponse::new(StatusCode::NOT_FOUND);
+            HttpResponse::new(StatusCode::BAD_REQUEST);
         }
         Ok(result) => {
-            dbg!(result);
             match PackageChannelAudit::audit(
                 &PackageChannelAudit {
                     package_ident: BuilderPackageIdent(ident.clone()),

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -508,9 +508,9 @@ fn demote_package(req: HttpRequest,
         Ok(0) => {
             debug!("Requested package {} for target {} not present in channel {}",
                    ident, target, channel);
-            HttpResponse::new(StatusCode::BAD_REQUEST);
+            HttpResponse::new(StatusCode::BAD_REQUEST)
         }
-        Ok(result) => {
+        Ok(_) => {
             match PackageChannelAudit::audit(
                 &PackageChannelAudit {
                     package_ident: BuilderPackageIdent(ident.clone()),


### PR DESCRIPTION
Closes #1188 

This change is based on the assumption that making `target` a required parameter would be a breaking change, as we have older clients that don't set that parameter and we haven't explicitly stated a minimum required `hab` cli version. 

In addition, this change addresses the case where a user passes an invalid combination of `ident`, `target` and `channel`, so this may be a useful addition even if we want to declare `target` as a mandatory parameter.

Without this change, when a user requests a package to demoted, they specify two pieces of information, `ident` and `channel`, with `target` an optional 3rd parameter which, if not specified, is inferred from the current system (in the case of recent `hab` cli versions) or defaulted to `x86_64-linux`.   When the server runs the query, the database returns the result with the [number of rows affected](https://github.com/habitat-sh/builder/blob/master/components/builder-db/src/models/channel.rs#L350).  In the case where `ident` + `target` is not in `channel`, this results in success, 0 rows affected. While this feels like correct behavior to me, it can be very surprising to the user.

What this change does is, if a user passes a combination of `ident`, `target`, and `channel` that results in no action being taken, we return a 404, i.e. "the requested `ident`+`target` was not found in `channel`. "  We could validate that the combination is valid before running the demote, but this would always result in an extra query against the db.  The demote action itself is safe to run in the case where the input triple is not a valid combination, as it will take no action.  

This covers the case of a demote action being taken on an non-existent `ident`, an `ident` with an incorrect `target`, and a valid `ident+target` that isn't in the requested channel to be demoted from.  


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>