### PR TITLE
[CI] Remove extra AWS account

### DIFF
--- a/.expeditor/post_habitat_release.pipeline.yml
+++ b/.expeditor/post_habitat_release.pipeline.yml
@@ -2,7 +2,6 @@
 
 expeditor:
   accounts:
-    - aws/chef-cd # for downloading GPG keys to validate manifests
     - aws/habitat # for uploading the bootstrap bundle
 
 steps:


### PR DESCRIPTION
We don't need two accounts... this was leftover from an incomplete
refactoring.

Signed-off-by: Christopher Maier <cmaier@chef.io>