### PR TITLE
Update www bucket policy to add version

### DIFF
--- a/terraform/www.tf
+++ b/terraform/www.tf
@@ -51,6 +51,7 @@ resource "aws_s3_bucket" "www" {
 
   policy = <<EOF
 {
+  "Version": "2008-10-17",
   "Statement": [
     {
       "Effect": "Allow",


### PR DESCRIPTION
This change stops Terraform from repeatedly trying to update the www bucket on every run.

Signed-off-by: Salim Alam <salam@chef.io>

![](https://media2.giphy.com/media/1hBWHsBYoqYOfsmAsL/giphy.gif?cid=5a38a5a27b613178276fc9ec195c3812a55696683da284f1&rid=giphy.gif)
