### PR TITLE
Add builder-memcached to boostrap seed

### DIFF
--- a/.expeditor/builder_seed.txt
+++ b/.expeditor/builder_seed.txt
@@ -8,6 +8,7 @@ habitat/builder-api
 habitat/builder-api-proxy
 habitat/builder-jobsrv
 habitat/builder-worker
+habitat/builder-memcached
 
 # Utilities
 core/sumologic


### PR DESCRIPTION
This adds `habitat/builder-memcached` to the bootstrap bundle creation. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>