### PR TITLE
Update memcache library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "enum_dispatch"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1275,7 +1275,7 @@ dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memcache 0.13.1 (git+https://github.com/stevendanna/rust-memcache.git?branch=tls-support)",
+ "memcache 0.14.0 (git+https://github.com/stevendanna/rust-memcache.git?branch=ssd/avoid-short-writes)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth-client 0.0.0",
  "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1815,14 +1815,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memcache"
-version = "0.13.1"
-source = "git+https://github.com/stevendanna/rust-memcache.git?branch=tls-support#e0618256ce0426351a7850ddbdf8a4562b710ecd"
+version = "0.14.0"
+source = "git+https://github.com/stevendanna/rust-memcache.git?branch=ssd/avoid-short-writes#eb27628ae02d6508f26f7c6618d99bdd7c791251"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "enum_dispatch 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enum_dispatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3821,7 +3821,7 @@ dependencies = [
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
 "checksum enum-as-inner 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3d58266c97445680766be408285e798d3401c6d4c378ec5552e78737e681e37d"
-"checksum enum_dispatch 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "06849e4a4ac700647e2af09430bd254855282adaf5387901ea142452c4d6655f"
+"checksum enum_dispatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d187ded8d68dfce7d5fe26be489494e1d43edf15896d1df094790d77caf07b27"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum env_proxy 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "700798562fcbc0a4c89546df5dfa8586e82345026e3992242646d527dec948e4"
 "checksum env_proxy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8731da06ff3731a69115a2910345ae5ee8d1fe09c846a9eca101b444a30ad454"
@@ -3896,7 +3896,7 @@ dependencies = [
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 "checksum md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-"checksum memcache 0.13.1 (git+https://github.com/stevendanna/rust-memcache.git?branch=tls-support)" = "<none>"
+"checksum memcache 0.14.0 (git+https://github.com/stevendanna/rust-memcache.git?branch=ssd/avoid-short-writes)" = "<none>"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -51,7 +51,7 @@ uuid = { version = "*", features = ["v4"] }
 [dependencies.memcache]
 version = "*"
 git = "https://github.com/stevendanna/rust-memcache.git"
-branch = "tls-support"
+branch = "ssd/avoid-short-writes"
 
 [dependencies.actix-web]
 version = "*"


### PR DESCRIPTION
The updated library fixes a bug where memcache request would fail
because of a short write while writing the payload