### PR TITLE
Add dbcall specific histogram metrics to DDog

### DIFF
--- a/components/builder-db/src/metrics.rs
+++ b/components/builder-db/src/metrics.rs
@@ -34,6 +34,10 @@ impl metrics::Metric for Counter {
 
 pub enum Histogram {
     DbCallTime,
+    GetAllLatestCallTime,
+    GetLatestChannelPackageCallTime,
+    GetLatestPackageCallTime,
+    ListAllChannelPackagesCallTime,
 }
 
 impl metrics::HistogramMetric for Histogram {}
@@ -42,6 +46,14 @@ impl metrics::Metric for Histogram {
     fn id(&self) -> Cow<'static, str> {
         match *self {
             Histogram::DbCallTime => "db-call.call-time".into(),
+            Histogram::GetAllLatestCallTime => "db-call.all-latest-call-time".into(),
+            Histogram::GetLatestChannelPackageCallTime => {
+                "db-call.latest-channel-pkg-call-time".into()
+            }
+            Histogram::GetLatestPackageCallTime => "db-call.latest-pkg-call-time".into(),
+            Histogram::ListAllChannelPackagesCallTime => {
+                "db-call.list-all-channel-pkgs-call-time".into()
+            }
         }
     }
 }

--- a/components/builder-db/src/models/channel.rs
+++ b/components/builder-db/src/models/channel.rs
@@ -153,6 +153,8 @@ impl Channel {
         trace!("DBCall channel::get_latest_package time: {} ms",
                start_time.to(end_time).num_milliseconds());
         Histogram::DbCallTime.set(start_time.to(end_time).num_milliseconds() as f64);
+        Histogram::GetLatestChannelPackageCallTime.set(start_time.to(end_time).num_milliseconds()
+                                                       as f64);
 
         result
     }
@@ -200,6 +202,8 @@ impl Channel {
         trace!("DBCall channel::list_all_packages time: {} ms",
                start_time.to(end_time).num_milliseconds());
         Histogram::DbCallTime.set(start_time.to(end_time).num_milliseconds() as f64);
+        Histogram::ListAllChannelPackagesCallTime.set(start_time.to(end_time).num_milliseconds()
+                                                      as f64);
         result
     }
 

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -463,6 +463,7 @@ impl Package {
         trace!("DBCall package::get_latest time: {} ms",
                start_time.to(end_time).num_milliseconds());
         Histogram::DbCallTime.set(start_time.to(end_time).num_milliseconds() as f64);
+        Histogram::GetLatestPackageCallTime.set(start_time.to(end_time).num_milliseconds() as f64);
 
         result
     }
@@ -481,6 +482,7 @@ impl Package {
         trace!("DBCall package::get_all_latest time: {} ms",
                start_time.to(end_time).num_milliseconds());
         Histogram::DbCallTime.set(start_time.to(end_time).num_milliseconds() as f64);
+        Histogram::GetAllLatestCallTime.set(start_time.to(end_time).num_milliseconds() as f64);
         result
     }
 


### PR DESCRIPTION
We want to get some more granular metrics on response times for these specific database calls that we know are already expensive calls. The plan is to get these metrics into datadog so we can see exactly which calls are pegging and how long they're taking to respond.

Signed-off-by: Ian Henry <ihenry@chef.io>