### PR TITLE
Package settings tab revamp

### DIFF
--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -56,7 +56,7 @@ export function fetchGitHubRepositories(installationID: number) {
   };
 }
 
-function clearGitHubInstallations() {
+export function clearGitHubInstallations() {
   return {
     type: CLEAR_GITHUB_INSTALLATIONS
   };
@@ -69,7 +69,7 @@ function populateGitHubInstallations(payload) {
   };
 }
 
-function clearGitHubRepositories() {
+export function clearGitHubRepositories() {
   return {
     type: CLEAR_GITHUB_REPOSITORIES
   };

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -142,12 +142,14 @@ export {
   fetchLatestPackage,
   fetchPackage,
   fetchPackageChannels,
+  fetchPackageSettings,
   fetchPackageVersions,
   filterPackagesBy,
   getUniquePackages,
   POPULATE_DASHBOARD_RECENT,
   promotePackage,
   SET_CURRENT_PACKAGE_CHANNELS,
+  SET_CURRENT_PACKAGE_SETTINGS,
   SET_CURRENT_PACKAGE_VERSIONS,
   SET_CURRENT_PACKAGE,
   SET_CURRENT_PACKAGE_TARGET,
@@ -163,7 +165,8 @@ export {
   setCurrentPackageTarget,
   setCurrentPackageTargets,
   setPackagesSearchQuery,
-  setVisiblePackages
+  setVisiblePackages,
+  setCurrentPackageVisibility
 } from './packages';
 
 export {

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -51,6 +51,8 @@ export {
   CLEAR_GITHUB_REPOSITORIES,
   fetchGitHubInstallations,
   fetchGitHubRepositories,
+  clearGitHubInstallations,
+  clearGitHubRepositories,
   POPULATE_GITHUB_INSTALLATIONS,
   POPULATE_GITHUB_REPOSITORIES
 } from './gitHub';

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -175,8 +175,10 @@ export {
   fetchProjects,
   SET_CURRENT_PROJECT_INTEGRATION,
   SET_CURRENT_PROJECT,
+  SET_CURRENT_PROJECTS,
   SET_PROJECTS,
   setCurrentProject,
+  setCurrentProjects,
   setProjectIntegrationSettings,
   setProjectVisibility,
   updateProject

--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -365,3 +365,24 @@ export function setVisiblePackages(params, error = undefined) {
     error: error,
   };
 }
+
+export function setPackageReleaseVisibility(origin: string, name: string, version: string, release: string, setting: string, token: string) {
+  return dispatch => {
+    new BuilderApiClient(token).setPackageReleaseVisibility(origin, name, version, release, setting)
+      .then(response => {
+        const ident = { origin, name, version, release };
+        dispatch(fetchPackage({ ident }));
+        dispatch(addNotification({
+          title: 'Privacy settings saved',
+          type: SUCCESS
+        }));
+      })
+      .catch(error => {
+        dispatch(addNotification({
+          title: 'Failed to save privacy settings',
+          body: error.message,
+          type: DANGER
+        }));
+      });
+  };
+}

--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -30,6 +30,7 @@ export const SET_CURRENT_PACKAGE_TARGETS = 'SET_CURRENT_PACKAGE_TARGETS';
 export const SET_LATEST_IN_CHANNEL = 'SET_LATEST_IN_CHANNEL';
 export const SET_LATEST_PACKAGE = 'SET_LATEST_PACKAGE';
 export const SET_CURRENT_PACKAGE_CHANNELS = 'SET_CURRENT_PACKAGE_CHANNELS';
+export const SET_CURRENT_PACKAGE_SETTINGS = 'SET_CURRENT_PACKAGE_SETTINGS';
 export const SET_CURRENT_PACKAGE_VERSIONS = 'SET_CURRENT_PACKAGE_VERSIONS';
 export const SET_PACKAGES_NEXT_RANGE = 'SET_PACKAGES_NEXT_RANGE';
 export const SET_PACKAGES_SEARCH_QUERY = 'SET_PACKAGES_SEARCH_QUERY';
@@ -184,6 +185,14 @@ export function fetchLatestInChannel(origin: string, name: string, channel: stri
   };
 }
 
+export function fetchPackageSettings(origin: string, name: string, token: string) {
+  return dispatch => {
+    new BuilderApiClient(token).getPackageSettings(origin, name)
+      .then(settings => dispatch(setCurrentPackageSettings(settings)))
+      .catch(error => dispatch(setCurrentPackageSettings({}, error)));
+  };
+}
+
 export function fetchPackageVersions(origin: string, name: string) {
   return dispatch => {
     dispatch(clearPackages());
@@ -326,6 +335,34 @@ export function setCurrentPackageChannels(channels) {
   return {
     type: SET_CURRENT_PACKAGE_CHANNELS,
     payload: channels
+  };
+}
+
+export function setCurrentPackageSettings(settings, error = undefined) {
+  return {
+    type: SET_CURRENT_PACKAGE_SETTINGS,
+    payload: settings,
+    error: error,
+  };
+}
+
+export function setCurrentPackageVisibility(origin: string, name: string, setting: string, token: string) {
+  return dispatch => {
+    new BuilderApiClient(token).setPackageVisibility(origin, name, setting)
+      .then(settings => {
+        dispatch(setCurrentPackageSettings(settings));
+        dispatch(addNotification({
+          title: 'Privacy settings saved',
+          type: SUCCESS
+        }));
+      })
+      .catch(error => {
+        dispatch(addNotification({
+          title: 'Failed to save privacy settings',
+          body: error.message,
+          type: DANGER
+        }));
+      });
   };
 }
 

--- a/components/builder-web/app/actions/projects.ts
+++ b/components/builder-web/app/actions/projects.ts
@@ -68,11 +68,11 @@ export function setProjectIntegrationSettings(origin: string, name: string, inte
   };
 }
 
-export function setProjectVisibility(origin: string, name: string, setting: string, token: string) {
+export function setProjectVisibility(origin: string, name: string, target: string, setting: string, token: string) {
   return dispatch => {
     new BuilderApiClient(token).setProjectVisibility(origin, name, setting)
       .then(response => {
-        dispatch(fetchProject(origin, name, token, false));
+        dispatch(fetchProject(origin, name, target, token, false));
         dispatch(addNotification({
           title: 'Privacy settings saved',
           type: SUCCESS
@@ -88,11 +88,11 @@ export function setProjectVisibility(origin: string, name: string, setting: stri
   };
 }
 
-export function fetchProject(origin: string, name: string, token: string, alert: boolean) {
+export function fetchProject(origin: string, name: string, target: string, token: string, alert: boolean) {
   return dispatch => {
     dispatch(clearCurrentProject());
 
-    new BuilderApiClient(token).getProject(origin, name)
+    new BuilderApiClient(token).getProject(origin, name, target)
       .then(response => {
         dispatch(setCurrentProject(response, null));
       })

--- a/components/builder-web/app/actions/projects.ts
+++ b/components/builder-web/app/actions/projects.ts
@@ -128,9 +128,9 @@ export function fetchProjectIntegration(origin: string, name: string, integratio
   };
 }
 
-export function deleteProject(id: string, token: string) {
+export function deleteProject(name: string, target: string, token: string) {
   return dispatch => {
-    new BuilderApiClient(token).deleteProject(id).then(response => {
+    new BuilderApiClient(token).deleteProject(name, target).then(response => {
       dispatch(clearCurrentProject());
       dispatch(addNotification({
         title: 'Plan connection deleted',

--- a/components/builder-web/app/actions/projects.ts
+++ b/components/builder-web/app/actions/projects.ts
@@ -68,11 +68,10 @@ export function setProjectIntegrationSettings(origin: string, name: string, inte
   };
 }
 
-export function setProjectVisibility(origin: string, name: string, target: string, setting: string, token: string) {
+export function setProjectVisibility(origin: string, name: string, setting: string, token: string) {
   return dispatch => {
     new BuilderApiClient(token).setProjectVisibility(origin, name, setting)
       .then(response => {
-        dispatch(fetchProject(origin, name, target, token, false));
         dispatch(addNotification({
           title: 'Privacy settings saved',
           type: SUCCESS

--- a/components/builder-web/app/actions/projects.ts
+++ b/components/builder-web/app/actions/projects.ts
@@ -21,6 +21,7 @@ export const CLEAR_CURRENT_PROJECT = 'CLEAR_CURRENT_PROJECT';
 export const CLEAR_CURRENT_PROJECT_INTEGRATION = 'CLEAR_CURRENT_PROJECT_SETTINGS';
 export const DELETE_PROJECT = 'DELETE_PROJECT';
 export const SET_CURRENT_PROJECT = 'SET_CURRENT_PROJECT';
+export const SET_CURRENT_PROJECTS = 'SET_CURRENT_PROJECTS';
 export const SET_CURRENT_PROJECT_INTEGRATION = 'SET_CURRENT_PROJECT_INTEGRATION';
 export const SET_PROJECTS = 'SET_PROJECTS';
 
@@ -192,6 +193,14 @@ export function setCurrentProject(project, error = undefined) {
   return {
     type: SET_CURRENT_PROJECT,
     payload: project,
+    error: error
+  };
+}
+
+export function setCurrentProjects(projects, error = undefined) {
+  return {
+    type: SET_CURRENT_PROJECTS,
+    payload: projects,
     error: error
   };
 }

--- a/components/builder-web/app/actions/projects.ts
+++ b/components/builder-web/app/actions/projects.ts
@@ -132,8 +132,15 @@ export function fetchProjectIntegration(origin: string, name: string, integratio
 
 export function fetchCurrentProjects(origin: string, name: string, token: string) {
   return dispatch => {
-    const fetchAll = targets.map(target => new BuilderApiClient(token).getProject(origin, name, target.id));
-    Promise.all(fetchAll).then(projects => dispatch(setCurrentProjects(projects)));
+    const fetchAll = targets.map(target => {
+      return new BuilderApiClient(token)
+        .getProject(origin, name, target.id)
+        .catch(error => null);
+    });
+
+    Promise.all(fetchAll)
+      .then(projects => dispatch(setCurrentProjects(projects)))
+      .catch(error => dispatch(setCurrentProjects([])));
   };
 }
 

--- a/components/builder-web/app/async-validator.ts
+++ b/components/builder-web/app/async-validator.ts
@@ -12,66 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Observable } from 'rxjs';
-import { Observer } from 'rxjs';
-import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
-import { FormControl } from '@angular/forms';
+import { AsyncValidatorFn, FormControl, ValidationErrors } from '@angular/forms';
+import { from, Observable, timer } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
-// Wraps an async validator with a static `debounce` method, so you can debounce
-// async validation.
-//
-// Where you would normally put:
-//
-//     myAsyncValidator
-//
-// Use:
-//
-//     AsyncValidator.debounce(control => myAsyncValidator(control))
-//
-// Taken from http://stackoverflow.com/a/36076946.
 export class AsyncValidator {
-  private validate: Function;
 
-  constructor(validator: (control: FormControl) => any, time = 300) {
-
-    let source: Observable<FormControl> = new Observable((observer: Observer<FormControl>) => {
-      this.validate = (control) => observer.next(control);
-    });
-
-    source
-      .pipe(
-        debounceTime(time),
-        distinctUntilChanged(null, (x: any) => x.control.value),
-        map((x: any) => {
-          return {
-            promise: validator(x.control),
-            resolver: x.promiseResolver
-          };
-        })
-      )
-      .subscribe(
-        (x) => x.promise.then(
-          resultValue => x.resolver(resultValue),
-          e => console.log('async validator error: %s', e)
-        )
-      );
-  }
-
-  private getValidator() {
-    return (control) => {
-      let promiseResolver;
-
-      let p = new Promise((resolve) => {
-        promiseResolver = resolve;
-      });
-
-      this.validate({ control: control, promiseResolver: promiseResolver });
-      return p;
+  // Returns a new async validator that wraps provided async validator in a debounced observable.
+  //
+  // Where you would normally put:
+  //
+  //     myAsyncValidator
+  //
+  // Use:
+  //
+  //     AsyncValidator.debounce(myAsyncValidator);
+  //     AsyncValidator.debounce(myAsyncValidator, 2000);
+  static debounce(validatorFn: AsyncValidatorFn, debounceTime = 400): AsyncValidatorFn {
+    return function debouncedAsyncValidator(control: FormControl): Observable<ValidationErrors> {
+      return timer(debounceTime).pipe(switchMap(() => from(validatorFn(control))));
     };
-  }
-
-  static debounce(validator: (control: FormControl) => any, debounceTime = 400) {
-    const asyncValidator = new this(validator, debounceTime);
-    return asyncValidator.getValidator();
   }
 }

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -419,9 +419,9 @@ export class BuilderApiClient {
     });
   }
 
-  public getProject(origin: string, name: string) {
+  public getProject(origin: string, name: string, target: string) {
     return new Promise((resolve, reject) => {
-      fetch(`${this.urlPrefix}/projects/${origin}/${name}`, {
+      fetch(`${this.urlPrefix}/projects/${origin}/${name}?target=${target}`, {
         method: 'GET',
         headers: this.headers
       })

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -222,9 +222,9 @@ export class BuilderApiClient {
     });
   }
 
-  public deleteProject(projectId) {
+  public deleteProject(name: string, target: string) {
     return new Promise((resolve, reject) => {
-      fetch(`${this.urlPrefix}/projects/${projectId}`, {
+      fetch(`${this.urlPrefix}/projects/${name}?target=${target}`, {
         method: 'DELETE',
         headers: this.headers
       })

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -675,6 +675,42 @@ export class BuilderApiClient {
     });
   }
 
+  public getPackageSettings(origin: string, name: string) {
+    return new Promise((resolve, reject) => {
+      fetch(`${this.urlPrefix}/settings/${origin}/${name}`, {
+        headers: this.headers,
+      })
+        .then(response => this.handleUnauthorized(response, reject))
+        .then(response => {
+          if (response.ok) {
+            resolve(response.json());
+          } else {
+            reject(new Error(response.statusText));
+          }
+        })
+        .catch(error => this.handleError(error, reject));
+    });
+  }
+
+  public setPackageVisibility(origin: string, name: string, setting: string) {
+    return new Promise((resolve, reject) => {
+      fetch(`${this.urlPrefix}/settings/${origin}/${name}`, {
+        headers: this.jsonHeaders,
+        method: 'PUT',
+        body: JSON.stringify({ visibility: setting })
+      })
+        .then(response => this.handleUnauthorized(response, reject))
+        .then(response => {
+          if (response.ok) {
+            resolve(response.json());
+          } else {
+            reject(new Error(response.statusText));
+          }
+        })
+        .catch(error => this.handleError(error, reject));
+    });
+  }
+
   public getIntegration(origin: string, type: string, name: string) {
     return new Promise((resolve, reject) => {
       fetch(`${this.urlPrefix}/depot/origins/${origin}/integrations/${type}/${name}`, {

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -222,9 +222,9 @@ export class BuilderApiClient {
     });
   }
 
-  public deleteProject(name: string, target: string) {
+  public deleteProject(origin: string, name: string, target: string) {
     return new Promise((resolve, reject) => {
-      fetch(`${this.urlPrefix}/projects/${name}?target=${target}`, {
+      fetch(`${this.urlPrefix}/projects/${origin}/${name}?target=${target}`, {
         method: 'DELETE',
         headers: this.headers
       })
@@ -394,7 +394,7 @@ export class BuilderApiClient {
           if (response.ok) {
             resolve(response.json());
           } else {
-            reject(new Error(response.statusText));
+            resolve(null);
           }
         })
         .catch(error => this.handleError(error, reject));

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -804,6 +804,25 @@ export class BuilderApiClient {
     });
   }
 
+  public setPackageReleaseVisibility(origin: string, name: string, version: string, release: string, setting: string) {
+    return new Promise((resolve, reject) => {
+      fetch(`${this.urlPrefix}/depot/pkgs/${origin}/${name}/${version}/${release}/${setting}`, {
+        headers: this.headers,
+        method: 'PATCH'
+      })
+        .then(response => this.handleUnauthorized(response, reject))
+        .then(response => {
+          if (response.ok) {
+            resolve();
+          }
+          else {
+            reject(new Error(response.statusText));
+          }
+        })
+        .catch(error => this.handleError(error, reject));
+    });
+  }
+
   public deleteIntegration(origin: string, name: string, type: string) {
     return new Promise((resolve, reject) => {
       fetch(`${this.urlPrefix}/depot/origins/${origin}/integrations/${type}/${name}`, {

--- a/components/builder-web/app/initial-state.ts
+++ b/components/builder-web/app/initial-state.ts
@@ -153,6 +153,7 @@ export default Record({
   packages: Record({
     current: Package(),
     currentChannels: [],
+    currentSettings: undefined,
     dashboard: Record({
       origin: undefined,
       recent: List()

--- a/components/builder-web/app/initial-state.ts
+++ b/components/builder-web/app/initial-state.ts
@@ -208,6 +208,7 @@ export default Record({
   })(),
   projects: Record({
     current: Project(),
+    currentProjects: [],
     visible: List(),
     ui: Record({
       current: Record({

--- a/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
@@ -12,12 +12,6 @@
         Create Package
       </button>
 
-      <hab-project-settings
-        [origin]="origin"
-        [integrations]="integrations"
-        (toggled)="toggled($event)"
-        (saved)="saved($event)">
-      </hab-project-settings>
     </section>
 
     <section *ngIf="!selectingPlan">

--- a/components/builder-web/app/package/package-release-settings/package-release-settings.component.html
+++ b/components/builder-web/app/package/package-release-settings/package-release-settings.component.html
@@ -1,0 +1,7 @@
+<h3>Visibility</h3>
+<p>Set the visibility of the build artifact (.hart file).</p>
+<hab-visibility-selector
+  [setting]="visibility"
+  [plural]="false"
+  (changed)="handleSettingChange($event)">
+</hab-visibility-selector>

--- a/components/builder-web/app/package/package-release-settings/package-release-settings.component.ts
+++ b/components/builder-web/app/package/package-release-settings/package-release-settings.component.ts
@@ -1,0 +1,70 @@
+import { Component, OnDestroy } from '@angular/core';
+import { MatDialog } from '@angular/material';
+import { PackageReleaseVisibilityDialog } from '../package-release-visibility-dialog/package-release-visibility.dialog';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { AppStore } from '../../app.store';
+import { setPackageReleaseVisibility } from '../../actions/packages';
+
+@Component({
+  template: require('./package-release-settings.component.html')
+})
+export class PackageReleaseSettingsComponent implements OnDestroy {
+  visibility: string;
+
+  prevVisibility: string;
+
+  private isDestroyed$: Subject<boolean> = new Subject();
+
+  constructor(private store: AppStore, private confirmDialog: MatDialog) {
+    this.store.observe('packages.current.visibility')
+      .pipe(takeUntil(this.isDestroyed$))
+      .subscribe(visibility => this.visibility = visibility);
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed$.next(true);
+    this.isDestroyed$.complete();
+  }
+
+  get token() {
+    return this.store.getState().session.token;
+  }
+
+  get package() {
+    return this.store.getState().packages.current;
+  }
+
+  handleSettingChange(setting: string) {
+    this.prevVisibility = this.visibility;
+    this.visibility = setting;
+
+    if (setting === 'private') {
+      this.confirmSettingChange();
+    } else {
+      this.saveSettingChange();
+    }
+  }
+
+  confirmSettingChange() {
+    this.confirmDialog
+      .open(PackageReleaseVisibilityDialog, { width: '480px', data: { visibility: this.visibility, package: this.package } })
+      .beforeClose()
+      .subscribe(confirmed => {
+        if (confirmed) {
+          this.saveSettingChange();
+        } else {
+          this.cancelSettingChange();
+        }
+      });
+  }
+
+  cancelSettingChange() {
+    this.visibility = this.prevVisibility;
+  }
+
+  saveSettingChange() {
+    const { origin, name, version, release } = this.package.ident;
+    this.store.dispatch(setPackageReleaseVisibility(origin, name, version, release, this.visibility, this.token));
+  }
+}

--- a/components/builder-web/app/package/package-release-visibility-dialog/package-release-visibility.dialog.html
+++ b/components/builder-web/app/package/package-release-visibility-dialog/package-release-visibility.dialog.html
@@ -1,0 +1,14 @@
+<div class="dialog">
+  <section class="heading">
+    <h1>Change artifact to {{ data.visibility }}?</h1>
+  </section>
+  <section class="body">
+    <p>Changing <strong>{{ artifactName }}</strong> to {{ data.visibility }} may break all the existing dependent or transitive dependent packages in their future rebuilds.</p>
+  </section>
+  <section class="controls">
+    <button mat-raised-button color="primary" class="button" (click)="confirm()">
+      Change to {{ data.visibility }}
+    </button>
+    <a (click)="cancel()">Cancel</a>
+  </section>
+</div>

--- a/components/builder-web/app/package/package-release-visibility-dialog/package-release-visibility.dialog.spec.ts
+++ b/components/builder-web/app/package/package-release-visibility-dialog/package-release-visibility.dialog.spec.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DebugElement } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { PackageReleaseVisibilityDialog } from './package-release-visibility.dialog';
+
+describe('PackageReleaseVisibilityDialog', () => {
+  let fixture: ComponentFixture<PackageReleaseVisibilityDialog>;
+  let component: PackageReleaseVisibilityDialog;
+  let element: DebugElement;
+  let dialogRef = {
+    open() {},
+    close() {}
+  };
+  let dialogData = {
+    visibility: 'private',
+    package: {
+      ident: {
+        origin: 'testorigin',
+        name: 'testname',
+        version: '1.0',
+        release: '100'
+      }
+    }
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        MatDialogModule
+      ],
+      declarations: [
+        PackageReleaseVisibilityDialog
+      ],
+      providers: [
+        { provide: MatDialogRef, useFactory: () => dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: dialogData }
+      ]
+    });
+
+    fixture = TestBed.createComponent(PackageReleaseVisibilityDialog);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+    fixture.detectChanges();
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('artifactName', () => {
+    it('is correct', () => {
+      expect(component.artifactName).toEqual('testorigin/testname/1.0/100');
+    });
+  });
+
+  describe('confirm()', () => {
+    it('closes dialog ref with true value', () => {
+      spyOn(dialogRef, 'close');
+
+      component.confirm();
+
+      expect(dialogRef.close).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('cancel()', () => {
+    it('closes dialog ref with false value', () => {
+      spyOn(dialogRef, 'close');
+
+      component.cancel();
+
+      expect(dialogRef.close).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/components/builder-web/app/package/package-release-visibility-dialog/package-release-visibility.dialog.ts
+++ b/components/builder-web/app/package/package-release-visibility-dialog/package-release-visibility.dialog.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+
+@Component({
+  template: require('./package-release-visibility.dialog.html')
+})
+export class PackageReleaseVisibilityDialog {
+  constructor(
+    private ref: MatDialogRef<PackageReleaseVisibilityDialog>,
+    @Inject(MAT_DIALOG_DATA) private data: any
+  ) {}
+
+  get artifactName() {
+    const { origin, name, version, release } = this.data.package.ident;
+    return [origin, name, version, release].join('/');
+  }
+
+  cancel() {
+    this.ref.close(false);
+  }
+
+  confirm() {
+    this.ref.close(true);
+  }
+}

--- a/components/builder-web/app/package/package-release/package-release.component.spec.ts
+++ b/components/builder-web/app/package/package-release/package-release.component.spec.ts
@@ -14,10 +14,10 @@
 
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component, DebugElement } from '@angular/core';
-import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
+import { get } from 'lodash';
 import { MockComponent } from 'ng2-mock-component';
 import { AppStore } from '../../app.store';
 import { Package } from '../../records/Package';
@@ -33,11 +33,23 @@ class MockAppStore {
       },
       app: {
         name: 'Habitat'
+      },
+      router: {
+        route: {
+          params: {
+            origin: 'core',
+            name: 'nginx'
+          }
+        }
       }
     };
   }
 
   dispatch() { }
+
+  observe(path) {
+    return of(get(this.getState(), path));
+  }
 }
 
 class MockRoute {
@@ -83,20 +95,5 @@ describe('PackageReleaseComponent', () => {
     fixture = TestBed.createComponent(PackageReleaseComponent);
     component = fixture.componentInstance;
     element = fixture.debugElement;
-  });
-
-  describe('given origin, name, version and release', () => {
-
-    it('fetches the specified package', () => {
-      expect(store.dispatch).toHaveBeenCalled();
-      expect(actions.fetchPackage).toHaveBeenCalledWith({
-        ident: {
-          origin: 'core',
-          name: 'nginx',
-          version: '1.11.10',
-          release: '20170829004822'
-        }
-      });
-    });
   });
 });

--- a/components/builder-web/app/package/package-routing.module.ts
+++ b/components/builder-web/app/package/package-routing.module.ts
@@ -73,7 +73,8 @@ const routes: Routes = [
       },
       {
         path: ':version/:release/settings',
-        component: PackageReleaseSettingsComponent
+        component: PackageReleaseSettingsComponent,
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
       }
     ]
   }

--- a/components/builder-web/app/package/package-routing.module.ts
+++ b/components/builder-web/app/package/package-routing.module.ts
@@ -20,6 +20,7 @@ import { PackageJobsComponent } from './package-jobs/package-jobs.component';
 import { PackageLatestComponent } from './package-latest/package-latest.component';
 import { PackageSettingsComponent } from './package-settings/package-settings.component';
 import { PackageReleaseComponent } from './package-release/package-release.component';
+import { PackageReleaseSettingsComponent } from './package-release-settings/package-release-settings.component';
 import { PackageVersionsComponent } from './package-versions/package-versions.component';
 import { BuilderEnabledGuard } from '../shared/guards/builder-enabled.guard';
 import { OriginMemberGuard } from '../shared/guards/origin-member.guard';
@@ -69,6 +70,10 @@ const routes: Routes = [
       {
         path: ':version/:release',
         component: PackageReleaseComponent
+      },
+      {
+        path: ':version/:release/settings',
+        component: PackageReleaseSettingsComponent
       }
     ]
   }

--- a/components/builder-web/app/package/package-routing.module.ts
+++ b/components/builder-web/app/package/package-routing.module.ts
@@ -58,6 +58,11 @@ const routes: Routes = [
         canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
       },
       {
+        path: 'settings/:target',
+        component: PackageSettingsComponent,
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
+      },
+      {
         path: ':version',
         component: PackageVersionsComponent
       },

--- a/components/builder-web/app/package/package-settings/package-settings.component.html
+++ b/components/builder-web/app/package/package-settings/package-settings.component.html
@@ -1,3 +1,11 @@
 <div class="hab-package-settings">
-  <hab-project-settings [origin]="origin" [name]="name" [project]="project" [integrations]="integrations" (saved)="saved($event)"></hab-project-settings>
+  <hab-project-settings
+    [origin]="origin"
+    [name]="name"
+    [project]="project"
+    [projects]="projects"
+    [integrations]="integrations"
+    [target]="target"
+    (saved)="saved($event)">
+  </hab-project-settings>
 </div>

--- a/components/builder-web/app/package/package-settings/package-settings.component.ts
+++ b/components/builder-web/app/package/package-settings/package-settings.component.ts
@@ -68,6 +68,10 @@ export class PackageSettingsComponent implements OnDestroy {
     }
   }
 
+  get projects() {
+    return this.store.getState().projects.currentProjects;
+  }
+
   get integrations() {
     return this.store.getState().origins.currentIntegrations.integrations || [];
   }

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
@@ -9,7 +9,7 @@
     </button>
     <p *ngIf="!isBuildable" class="disabled-build-msg">{{ buildButtonDisabledMessage }}</p>
   </section>
-  <section *ngIf="isOriginMember && hasPlan">
+  <section *ngIf="isOriginMember && projectExists && hasPlan">
     <h3>Settings</h3>
     <ul>
       <li>

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.spec.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.spec.ts
@@ -91,6 +91,11 @@ describe('PackageSidebarComponent', () => {
         }
       },
       projects: {
+        ui: {
+          current: {
+            exists: true
+          }
+        },
         current: {
           visibility: 'private',
           vcs_data: 'https://github.com/cnunciato/testapp.git',

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
@@ -77,6 +77,10 @@ export class PackageSidebarComponent {
     return this.store.getState().projects.current;
   }
 
+  get projectExists() {
+    return this.store.getState().projects.ui.current.exists;
+  }
+
   get runCommand() {
     return `hab start ${this.origin}/${this.name}`;
   }

--- a/components/builder-web/app/package/package-versions/package-versions.component.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.ts
@@ -42,7 +42,12 @@ export class PackageVersionsComponent implements OnDestroy {
         this.origin = params.origin;
         this.name = params.name;
         this.title.setTitle(`Packages › ${this.origin}/${this.name} › Versions | ${store.getState().app.name}`);
-        this.toggle(params.version);
+      });
+
+    this.store.observe('router.route.params.version')
+      .pipe(takeUntil(this.isDestroyed$))
+      .subscribe(version => {
+        this.toggle(version);
       });
   }
 

--- a/components/builder-web/app/package/package.module.ts
+++ b/components/builder-web/app/package/package.module.ts
@@ -27,6 +27,7 @@ import { PackageLatestComponent } from './package-latest/package-latest.componen
 import { PackagePromoteComponent } from './package-promote/package-promote.component';
 import { PackageSettingsComponent } from './package-settings/package-settings.component';
 import { PackageReleaseComponent } from './package-release/package-release.component';
+import { PackageReleaseSettingsComponent } from './package-release-settings/package-release-settings.component';
 import { PackageReleaseVisibilityDialog } from './package-release-visibility-dialog/package-release-visibility.dialog';
 import { PackageSidebarComponent } from './package-sidebar/package-sidebar.component';
 import { PackageVersionsComponent } from './package-versions/package-versions.component';
@@ -59,6 +60,7 @@ import { PackageRoutingModule } from './package-routing.module';
     PackageDetailComponent,
     PackagePromoteComponent,
     PackageReleaseComponent,
+    PackageReleaseSettingsComponent,
     PackageReleaseVisibilityDialog,
     PackageSidebarComponent,
     PackageSettingsComponent,

--- a/components/builder-web/app/package/package.module.ts
+++ b/components/builder-web/app/package/package.module.ts
@@ -27,6 +27,7 @@ import { PackageLatestComponent } from './package-latest/package-latest.componen
 import { PackagePromoteComponent } from './package-promote/package-promote.component';
 import { PackageSettingsComponent } from './package-settings/package-settings.component';
 import { PackageReleaseComponent } from './package-release/package-release.component';
+import { PackageReleaseVisibilityDialog } from './package-release-visibility-dialog/package-release-visibility.dialog';
 import { PackageSidebarComponent } from './package-sidebar/package-sidebar.component';
 import { PackageVersionsComponent } from './package-versions/package-versions.component';
 import { PackageCreateDialog } from './package-create-dialog/package-create.dialog';
@@ -58,12 +59,14 @@ import { PackageRoutingModule } from './package-routing.module';
     PackageDetailComponent,
     PackagePromoteComponent,
     PackageReleaseComponent,
+    PackageReleaseVisibilityDialog,
     PackageSidebarComponent,
     PackageSettingsComponent,
     PackageVersionsComponent
   ],
   entryComponents: [
-    PackageCreateDialog
+    PackageCreateDialog,
+    PackageReleaseVisibilityDialog
   ],
   exports: []
 })

--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -1,7 +1,7 @@
 <header>
   <h1>
     <hab-package-breadcrumbs [ident]="ident"></hab-package-breadcrumbs>
-    <hab-visibility-icon *ngIf="isOriginMember && !activeRelease" [visibility]="activeSettings?.visibility || defaultVisibility" prefix="Default Package Visibility:"></hab-visibility-icon>
+    <hab-visibility-icon *ngIf="isOriginMember && !version && !activeRelease" [visibility]="activeSettings?.visibility || defaultVisibility" prefix="Default Package Visibility:"></hab-visibility-icon>
     <hab-visibility-icon *ngIf="isOriginMember && activeRelease" [visibility]="activePackage?.visibility"  prefix="Artifact Visibility:"></hab-visibility-icon>
   </h1>
   <h2>package</h2>

--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -1,45 +1,69 @@
 <header>
   <h1>
     <hab-package-breadcrumbs [ident]="ident"></hab-package-breadcrumbs>
-    <hab-visibility-icon [visibility]="visibility" *ngIf="isOriginMember" prefix="Default Package Visibility:"></hab-visibility-icon>
+    <hab-visibility-icon *ngIf="isOriginMember && !activeRelease" [visibility]="visibility" prefix="Default Package Visibility:"></hab-visibility-icon>
+    <hab-visibility-icon *ngIf="isOriginMember && activeRelease" [visibility]="activePackage.visibility"  prefix="Artifact Visibility:"></hab-visibility-icon>
   </h1>
   <h2>package</h2>
 </header>
 <nav class="tabs" mat-tab-nav-bar>
-  <a
-    mat-tab-link
-    routerLink="latest"
-    routerLinkActive
-    #latest="routerLinkActive"
-    [active]="latest.isActive">
-    Latest
-  </a>
-  <a mat-tab-link
-    routerLink="./"
-    [routerLinkActiveOptions]="{exact: true}"
-    routerLinkActive
-    #versions="routerLinkActive"
-    [active]="versions.isActive">
-    Versions
-  </a>
-  <a
-    mat-tab-link
-    *ngIf="builderEnabled && isOriginMember"
-    routerLink="jobs"
-    routerLinkActive
-    #jobs="routerLinkActive"
-    [active]="jobs.isActive">
-    Build Jobs
-  </a>
-  <a
-    mat-tab-link
-    *ngIf="builderEnabled && isOriginMember"
-    routerLink="settings"
-    routerLinkActive
-    #settings="routerLinkActive"
-    [active]="settings.isActive">
-    Settings
-  </a>
+  <ng-container *ngIf="!activeRelease">
+    <a
+      mat-tab-link
+      routerLink="latest"
+      routerLinkActive
+      #latest="routerLinkActive"
+      [active]="latest.isActive">
+      Latest
+    </a>
+    <a
+      mat-tab-link
+      routerLink="./"
+      [routerLinkActiveOptions]="{exact: true}"
+      routerLinkActive
+      #versions="routerLinkActive"
+      [active]="versions.isActive">
+      Versions
+    </a>
+    <a
+      mat-tab-link
+      *ngIf="builderEnabled && isOriginMember"
+      routerLink="jobs"
+      routerLinkActive
+      #jobs="routerLinkActive"
+      [active]="jobs.isActive">
+      Build Jobs
+    </a>
+    <a
+      mat-tab-link
+      *ngIf="builderEnabled && isOriginMember"
+      routerLink="settings"
+      routerLinkActive
+      #settings="routerLinkActive"
+      [active]="settings.isActive">
+      Settings
+    </a>
+  </ng-container>
+  <ng-container *ngIf="activeRelease">
+    <a
+      mat-tab-link
+      [routerLink]="['./', version, release]"
+      [routerLinkActiveOptions]="{exact: true}"
+      routerLinkActive
+      #releaseManifest="routerLinkActive"
+      [active]="releaseManifest.isActive">
+      Manifest
+    </a>
+    <a
+      *ngIf="builderEnabled && isOriginMember"
+      mat-tab-link
+      [routerLink]="['./', version, release, 'settings']"
+      routerLinkActive
+      #releaseSettings="routerLinkActive"
+      [active]="releaseSettings.isActive">
+      Settings
+    </a>
+  </ng-container>
 </nav>
 <div class="body">
   <div class="content" [class.full]="useFullWidth">
@@ -56,5 +80,14 @@
       [hasPlan]="hasPlan"
       [building]="building">
     </hab-package-sidebar>
+  </aside>
+  <aside *ngIf="showReleaseSidebar">
+    <h3>Settings</h3>
+    <ul>
+      <li>
+        <hab-visibility-icon [visibility]="activePackage.visibility" prefix="Artifact visibility:"></hab-visibility-icon>
+        {{ activePackage.visibility | titlecase }} artifact
+      </li>
+    </ul>
   </aside>
 </div>

--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -4,7 +4,7 @@
     <hab-visibility-icon *ngIf="isOriginMember && !version && !activeRelease" [visibility]="activeSettings?.visibility || defaultVisibility" prefix="Default Package Visibility:"></hab-visibility-icon>
     <hab-visibility-icon *ngIf="isOriginMember && activeRelease" [visibility]="activePackage?.visibility"  prefix="Artifact Visibility:"></hab-visibility-icon>
   </h1>
-  <h2>package</h2>
+  <h2>{{ subheading }}</h2>
 </header>
 <nav class="tabs" mat-tab-nav-bar>
   <ng-container *ngIf="!activeRelease">

--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -1,8 +1,8 @@
 <header>
   <h1>
     <hab-package-breadcrumbs [ident]="ident"></hab-package-breadcrumbs>
-    <hab-visibility-icon *ngIf="isOriginMember && !activeRelease" [visibility]="visibility" prefix="Default Package Visibility:"></hab-visibility-icon>
-    <hab-visibility-icon *ngIf="isOriginMember && activeRelease" [visibility]="activePackage.visibility"  prefix="Artifact Visibility:"></hab-visibility-icon>
+    <hab-visibility-icon *ngIf="isOriginMember && !activeRelease" [visibility]="activeSettings?.visibility || defaultVisibility" prefix="Default Package Visibility:"></hab-visibility-icon>
+    <hab-visibility-icon *ngIf="isOriginMember && activeRelease" [visibility]="activePackage?.visibility"  prefix="Artifact Visibility:"></hab-visibility-icon>
   </h1>
   <h2>package</h2>
 </header>

--- a/components/builder-web/app/package/package/package.component.spec.ts
+++ b/components/builder-web/app/package/package/package.component.spec.ts
@@ -62,7 +62,10 @@ describe('PackageComponent', () => {
         builder: false
       },
       origins: {
-        mine: []
+        mine: [],
+        current: {
+          default_package_visibility: 'public'
+        }
       },
       packages: {
         currentPlatforms: [

--- a/components/builder-web/app/package/package/package.component.spec.ts
+++ b/components/builder-web/app/package/package/package.component.spec.ts
@@ -84,7 +84,8 @@ describe('PackageComponent', () => {
           visibility: 'private',
           vcs_data: 'https://github.com/cnunciato/testapp.git',
           auto_rebuild: false
-        }
+        },
+        currentProjects: []
       },
       session: {
         token: 'some-token'

--- a/components/builder-web/app/package/package/package.component.ts
+++ b/components/builder-web/app/package/package/package.component.ts
@@ -24,7 +24,7 @@ import { PackageVersionsComponent } from '../package-versions/package-versions.c
 import { AppStore } from '../../app.store';
 import {
   fetchJobs, fetchIntegrations, fetchLatestPackage, fetchLatestInChannel, fetchOrigin, fetchProject,
-  fetchPackageVersions, setCurrentPackageTarget, clearPackageVersions, fetchPackage, fetchPackageChannels
+  fetchPackageSettings, fetchPackageVersions, setCurrentPackageTarget, clearPackageVersions, fetchPackage, fetchPackageChannels
 } from '../../actions/index';
 import { targetFrom, targets as allPlatforms } from '../../util';
 
@@ -72,7 +72,10 @@ export class PackageComponent implements OnInit, OnDestroy {
 
     combineLatest(origin$, name$)
       .pipe(takeUntil(this.isDestroyed$))
-      .subscribe(() => this.fetchPackageVersions());
+      .subscribe(() => {
+        this.fetchPackageSettings();
+        this.fetchPackageVersions();
+      });
 
     combineLatest(origin$, name$, version$, release$)
       .pipe(takeUntil(this.isDestroyed$))
@@ -157,6 +160,10 @@ export class PackageComponent implements OnInit, OnDestroy {
     return this.store.getState().packages.current;
   }
 
+  get activeSettings() {
+    return this.store.getState().packages.currentSettings;
+  }
+
   get activeRelease() {
     return this.version && this.release ? this.activePackage : null;
   }
@@ -186,6 +193,10 @@ export class PackageComponent implements OnInit, OnDestroy {
     return this.store.getState().projects.current.visibility;
   }
 
+  get defaultVisibility() {
+    return this.store.getState().origins.current.default_package_visibility;
+  }
+
   onRouteActivate(routedComponent) {
     this.showSidebar = false;
     this.showReleaseSidebar = false;
@@ -194,7 +205,6 @@ export class PackageComponent implements OnInit, OnDestroy {
     [
       PackageJobsComponent,
       PackageLatestComponent,
-      PackageReleaseComponent,
       PackageVersionsComponent
     ].forEach((c) => {
       if (routedComponent instanceof c) {
@@ -222,6 +232,10 @@ export class PackageComponent implements OnInit, OnDestroy {
 
   private fetchLatestStable() {
     this.store.dispatch(fetchLatestInChannel(this.origin, this.name, 'stable', this.target));
+  }
+
+  private fetchPackageSettings() {
+    this.store.dispatch(fetchPackageSettings(this.origin, this.name, this.token));
   }
 
   private fetchPackageVersions() {

--- a/components/builder-web/app/package/package/package.component.ts
+++ b/components/builder-web/app/package/package/package.component.ts
@@ -129,6 +129,10 @@ export class PackageComponent implements OnInit, OnDestroy {
     this.isDestroyed$.complete();
   }
 
+  get subheading() {
+    return this.activeRelease ? 'artifact' : 'package';
+  }
+
   get ident() {
     return {
       origin: this.origin,

--- a/components/builder-web/app/package/package/package.component.ts
+++ b/components/builder-web/app/package/package/package.component.ts
@@ -185,8 +185,8 @@ export class PackageComponent implements OnInit, OnDestroy {
   }
 
   private fetchProject() {
-    if (this.token && this.origin && this.name && this.isOriginMember) {
-      this.store.dispatch(fetchProject(this.origin, this.name, this.token, false));
+    if (this.token && this.origin && this.name && this.target && this.isOriginMember) {
+      this.store.dispatch(fetchProject(this.origin, this.name, this.target, this.token, false));
       this.store.dispatch(fetchIntegrations(this.origin, this.token));
     }
   }

--- a/components/builder-web/app/package/package/package.component.ts
+++ b/components/builder-web/app/package/package/package.component.ts
@@ -115,7 +115,7 @@ export class PackageComponent implements OnInit, OnDestroy {
   }
 
   get hasPlan() {
-    return this.store.getState().projects.ui.current.exists;
+    return this.store.getState().projects.currentProjects.length > 0;
   }
 
   get builderEnabled() {

--- a/components/builder-web/app/records/Package.ts
+++ b/components/builder-web/app/records/Package.ts
@@ -29,5 +29,6 @@ export const Package = Record({
   config: undefined,
   channels: [],
   target: undefined,
-  is_a_service: undefined
+  is_a_service: undefined,
+  visibility: ''
 });

--- a/components/builder-web/app/records/Project.ts
+++ b/components/builder-web/app/records/Project.ts
@@ -19,6 +19,7 @@ export const Project = Record({
   auto_build: undefined,
   name: undefined,
   origin: undefined,
+  target: undefined,
   owner_id: undefined,
   package_name: undefined,
   plan_path: undefined,

--- a/components/builder-web/app/reducers/packages.ts
+++ b/components/builder-web/app/reducers/packages.ts
@@ -92,6 +92,13 @@ export default function packages(state = initialState['packages'], action) {
           setIn(['ui', 'versions', 'loading'], false);
       }
 
+    case actionTypes.SET_CURRENT_PACKAGE_SETTINGS:
+      if (action.error) {
+        return state.set('currentSettings', undefined);
+      } else {
+        return state.set('currentSettings', action.payload);
+      }
+
     case actionTypes.SET_LATEST_IN_CHANNEL:
       if (action.error) {
         return state.setIn(['latestInChannel', action.payload.channel], undefined).

--- a/components/builder-web/app/reducers/packages.ts
+++ b/components/builder-web/app/reducers/packages.ts
@@ -51,7 +51,10 @@ export default function packages(state = initialState['packages'], action) {
 
     case actionTypes.CLEAR_PACKAGE_VERSIONS:
       return state.set('versions', undefined)
-        .set('currentPlatforms', []);
+        .set('currentPlatforms', [])
+        .setIn(['ui', 'versions', 'errorMessage'], undefined)
+        .setIn(['ui', 'versions', 'loading'], true)
+        .setIn(['ui', 'versions', 'exists'], false);
 
     case actionTypes.SET_CURRENT_PACKAGE:
       if (action.error) {

--- a/components/builder-web/app/reducers/projects.ts
+++ b/components/builder-web/app/reducers/projects.ts
@@ -47,6 +47,9 @@ export default function projects(state = initialState['projects'], action) {
           setIn(['ui', 'current', 'loading'], false);
       }
 
+    case actionTypes.SET_CURRENT_PROJECTS:
+      return state.setIn(['currentProjects'], action.payload.filter(p => p).map(p => Project(p)));
+
     case actionTypes.SET_CURRENT_PROJECT_INTEGRATION:
       return state.setIn(['current', 'settings', action.payload.name], action.payload.settings);
 

--- a/components/builder-web/app/shared/breadcrumbs/breadcrumbs.component.html
+++ b/components/builder-web/app/shared/breadcrumbs/breadcrumbs.component.html
@@ -13,3 +13,9 @@
     {{ident.version}}
   </a>
 </ng-container>
+<ng-container *ngIf="ident.release">
+  <span>/</span>
+  <a [routerLink]="['/pkgs', ident.origin, ident.name, ident.version, ident.release]">
+    {{ident.release}}
+  </a>
+</ng-container>

--- a/components/builder-web/app/shared/checking-input/checking-input.component.html
+++ b/components/builder-web/app/shared/checking-input/checking-input.component.html
@@ -14,7 +14,7 @@
       autofocus="{{autofocus}}"
       placeholder="{{placeholder}}">
   </div>
-  <div class="validation-message" *ngIf="control.dirty && !control.pending ">
+  <div class="validation-message" *ngIf="!control.pending">
     <span *ngIf="control.invalid" class="invalid">
       <span *ngIf="control.errors.invalidFormat">
         {{displayName}} {{unmatchedMessage}}

--- a/components/builder-web/app/shared/checking-input/checking-input.component.html
+++ b/components/builder-web/app/shared/checking-input/checking-input.component.html
@@ -15,7 +15,7 @@
       placeholder="{{placeholder}}">
   </div>
   <div class="validation-message" *ngIf="control.dirty && !control.pending ">
-    <span *ngIf="!control.valid" class="invalid">
+    <span *ngIf="control.invalid" class="invalid">
       <span *ngIf="control.errors.invalidFormat">
         {{displayName}} {{unmatchedMessage}}
       </span>

--- a/components/builder-web/app/shared/checking-input/checking-input.component.spec.ts
+++ b/components/builder-web/app/shared/checking-input/checking-input.component.spec.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { DebugElement, SimpleChange } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { MockComponent } from 'ng2-mock-component';
+import { ReactiveFormsModule, FormGroup } from '@angular/forms';
+import { CheckingInputComponent } from './checking-input.component';
+
+describe('CheckingInputComponent', () => {
+  let fixture: ComponentFixture<CheckingInputComponent>;
+  let component: CheckingInputComponent;
+  let element: DebugElement;
+
+  const inputEl = () => fixture.nativeElement.querySelector('input');
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule
+      ],
+      declarations: [
+        CheckingInputComponent,
+        MockComponent({ selector: 'hab-icon', inputs: ['symbol'] })
+      ]
+    });
+
+    fixture = TestBed.createComponent(CheckingInputComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+
+    component.form = new FormGroup({});
+  });
+
+  it('can be disabled via `disabled` input property', () => {
+    component.disabled = false;
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(inputEl().hasAttribute('disabled')).toBe(false);
+
+    component.disabled = true;
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(inputEl().hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/components/builder-web/app/shared/checking-input/checking-input.component.ts
+++ b/components/builder-web/app/shared/checking-input/checking-input.component.ts
@@ -47,6 +47,10 @@ export class CheckingInputComponent implements OnInit, OnChanges {
       this.patternValidator.bind(this),
     ];
 
+    const asyncValidators = [
+      AsyncValidator.debounce(this.takenValidator.bind(this))
+    ];
+
     // If explicitly passed false, don't validate for max length. If one
     // wasn't passed, use the default.
     if (this.maxLength !== false) {
@@ -67,7 +71,7 @@ export class CheckingInputComponent implements OnInit, OnChanges {
     this.control = new FormControl(
       this.value,
       Validators.compose(validators),
-      AsyncValidator.debounce(control => this.takenValidator(control))
+      Validators.composeAsync(asyncValidators)
     );
 
     this.setDisabledState(this.control);

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -90,6 +90,56 @@
     }
   }
 
+  .connect-btn {
+    .connect-btn-text {
+      padding-right: 10px;
+      border-right: 1px solid $white;
+      margin-right: 5px;
+    }
+
+    .connect-btn-icon {
+      margin: 3px -10px 0 0;
+      padding: 0;
+    }
+
+    &[disabled] .connect-btn-text {
+      border-right-color: $disabled;
+    }
+  }
+
+  .connect-plan-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 9999;
+    background: $white;
+    overflow: scroll;
+
+    .overlay-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0 10%;
+      overflow: hidden;
+      background: $very-light-gray;
+
+      hab-platform-icon {
+        margin-left: $default-margin;
+      }
+
+      .overlay-close {
+        font-size: 30px;
+        height: 30px;
+      }
+    }
+
+    .overlay-body {
+      padding: 1em 10%;
+    }
+  }
+
   .connected-plans {
 
     li {
@@ -204,4 +254,8 @@
       }
     }
   }
+}
+
+.mat-menu-panel.connect-menu {
+  max-width: none;
 }

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -149,44 +149,11 @@
       }
 
       .plan-path {
-
-        hab-icon {
-          margin-right: $default-margin;
-        }
+        margin-right: $small-margin;
       }
 
-      .plan-actions {
-
-        hab-icon {
-          width: 16px;
-          color: $hab-blue;
-          margin-right: 22px;
-          cursor: pointer;
-          @include transition(color);
-
-          &:hover {
-            color: darken($hab-blue, 10%);
-          }
-
-          &:active {
-            color: $hab-links;
-          }
-        }
-      }
-
-      .plan-status {
-
-        hab-icon {
-          width: 18px;
-
-          &.success {
-            color: $success;
-          }
-        }
-
-        span {
-          color: $medium-gray;
-        }
+      .invalid-path-icon {
+        color: map-get($icon-colors, alert);
       }
     }
   }

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -258,4 +258,22 @@
 
 .mat-menu-panel.connect-menu {
   max-width: none;
+
+  .mat-menu-content:not(:empty) {
+    padding: 0;
+    border: $hab-borders;
+  }
+
+  .mat-menu-item {
+    color: $hab-links;
+    border-bottom: $hab-borders;
+  }
+
+  .mat-menu-item[disabled] {
+    color: $disabled;
+  }
+
+  .mat-menu-item:last-child {
+    border-bottom: none;
+  }
 }

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -28,46 +28,41 @@
     background-color: $very-light-gray;
     border-radius: $default-radius;
     color: $dark-blue;
+    display: flex;
+    flex-direction: column;
 
-    hab-icon {
-      width: 24px;
-      height: 24px;
-    }
+    .note-icon {
+      display: none;
 
-    .icon, .info {
-      margin-right: $default-margin;
-      margin-bottom: $default-margin;
-    }
-
-    .icon {
-      float: left;
-    }
-
-    .cta {
-      margin-right: $default-margin;
-
-      .button {
-        @include cta;
+      hab-icon {
+        width: 24px;
+        height: 24px;
       }
+    }
+
+    .note-text {
+      padding: 0 0 $default-padding 0;
+
+      p {
+        margin: 0;
+      }
+    }
+
+    .note-icon,
+    .note-text,
+    .note-cta {
+      min-width: auto;
     }
 
     @include tablet-up {
-      display: flex;
+      flex-direction: row;
 
-      .icon {
-        flex: 0 0 24px;
+      .note-icon {
+        display: block;
       }
 
-      .info {
-        flex: 1;
-      }
-
-      .cta {
-        flex: 0 0 140px;
-
-        .button {
-          @include cta;
-        }
+      .note-text {
+        padding: 0 $default-padding;
       }
     }
   }

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -56,7 +56,13 @@
       <li class="item" *ngFor="let project of projects">
         <span class="column name">
           <hab-platform-icon [platform]="project.target"></hab-platform-icon>
-          <span>{{ project.plan_path }}</span>
+          <span class="plan-path">{{ project.plan_path }}</span>
+          <hab-icon 
+            *ngIf="hasInvalidPlanPath(project)"
+            class="invalid-path-icon"
+            symbol="alert"
+            title="Invalid plan file path">
+          </hab-icon>
         </span>
         <span class="column actions">
           <hab-icon symbol="settings" (click)="openConnectEdit(project)" title="Edit this connection"></hab-icon>

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -3,6 +3,20 @@
   <p>Set the default visibility of build artificats (.hart files) for the package. Applies to future build artifacts only. To change the visibility of the existing artifacts, see settings for each artifact in <a [routerLink]="['/pkgs', origin, name]">versions</a>.</p>
   <hab-visibility-selector [setting]="visibility" (changed)="settingChanged($event)"></hab-visibility-selector>
 
+  <div class="note" *ngIf="!loadingInstallations && !gitHubAppInstalled">
+    <div class="note-icon">
+      <hab-icon symbol="github"></hab-icon>
+    </div>
+    <div class="note-text">
+      <p>Install the Builder Github app and allow access to the plan repository before connecting a new plan or building from the existing plans. After it's installed, <a (click)="refresh()">refresh</a> this page.</p>
+    </div>
+    <div class="note-cta">
+      <a href="{{ config['github_app_url'] }}" mat-raised-button color="primary" target="_blank">
+        Install GitHub App <hab-icon symbol="open-in-new"></hab-icon>
+      </a>
+    </div>
+  </div>
+
   <div class="connect" *ngIf="!project && !connecting">
     <button mat-raised-button color="primary" class="button" (click)="connect()" [disabled]="!hasPrivateKey">
       Connect a plan file
@@ -50,19 +64,6 @@
   </div>
   <div class="connecting" *ngIf="connecting">
     <form [formGroup]="form" #formValues="ngForm">
-      <div class="note" *ngIf="!loadingInstallations">
-        <div class="icon">
-          <hab-icon symbol="github"></hab-icon>
-        </div>
-        <div class="info">
-          {{ gitHubAppNote }}
-        </div>
-        <div class="cta">
-          <a href="{{ config['github_app_url'] }}" mat-raised-button color="accent" class="button" target="_blank">
-            {{ gitHubAppLabel }} GitHub App
-          </a>
-        </div>
-      </div>
       <ol>
         <li [class.active]="!selectedInstallation" (click)="clearConnection()">Select a GitHub repo</li>
         <li [class.active]="selectedInstallation">Set path to Habitat plan file</li>
@@ -72,12 +73,6 @@
           <hab-icon symbol="loading" class="spinning"></hab-icon>
         </div>
         <div *ngIf="!loadingInstallations">
-          <p *ngIf="installations.size === 0">
-            It looks like you haven't yet installed the Habitat Builder app.
-            <a href="{{ config['github_app_url'] }}" target="_blank">Install it on GitHub</a>, then come back here and
-            <a class="try-again" (click)="connect()">
-              <hab-icon symbol="loading"></hab-icon>try again</a>. (It may take a few minutes for the changes to be recognized.)
-          </p>
           <div *ngIf="installations.size > 0">
             <p>
               Choose the GitHub organization and repository that

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -101,10 +101,10 @@
                 </div>
                 <div>
                   <h3>Repository</h3>
-                  <div *ngIf="!activeInstallation && !loadingRepositories">
+                  <div *ngIf="!activeInstallation">
                     Choose an organization.
                   </div>
-                  <div *ngIf="loadingRepositories">
+                  <div *ngIf="activeInstallation && loadingRepositories">
                     <hab-icon symbol="loading" class="spinning"></hab-icon>
                   </div>
                   <ul class="select-list repositories" *ngIf="activeInstallation && !loadingRepositories">

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -1,4 +1,8 @@
 <div class="project-settings-component">
+  <h3>Default Visibility</h3>
+  <p>Set the default visibility of build artificats (.hart files) for the package. Applies to future build artifacts only. To change the visibility of the existing artifacts, see settings for each artifact in <a [routerLink]="['/pkgs', origin, name]">versions</a>.</p>
+  <hab-visibility-selector [setting]="visibility" (changed)="settingChanged($event)"></hab-visibility-selector>
+
   <div class="connect" *ngIf="!project && !connecting">
     <button mat-raised-button color="primary" class="button" (click)="connect()" [disabled]="!hasPrivateKey">
       Connect a plan file
@@ -126,8 +130,6 @@
             [maxLength]="false" [isAvailable]="doesFileExist" [value]="selectedPath">
           </hab-checking-input>
         </div>
-        <hr>
-        <hab-visibility-selector [setting]="visibility" (changed)="settingChanged($event)"></hab-visibility-selector>
         <hr>
         <hab-docker-export-settings #docker *ngIf="selectedInstallation" [origin]="origin" [package]="name" [integrations]="integrations"
           [current]="dockerSettings" [enabled]="dockerEnabled">

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -135,7 +135,7 @@
             </hab-checking-input>
           </div>
           <hr>
-          <hab-docker-export-settings #docker *ngIf="selectedInstallation" [origin]="origin" [package]="name" [integrations]="integrations"
+          <hab-docker-export-settings #docker [origin]="origin" [package]="name" [integrations]="integrations"
             [current]="dockerSettings" [enabled]="dockerEnabled">
           </hab-docker-export-settings>
           <hr>

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -39,7 +39,7 @@
         </span>
         <span class="column actions">
           <hab-icon symbol="settings" (click)="editConnection()" title="Edit this connection"></hab-icon>
-          <hab-icon symbol="cancel" (click)="disconnect()" title="Remove this connection"></hab-icon>
+          <hab-icon symbol="cancel" (click)="disconnect(project)" title="Remove this connection"></hab-icon>
         </span>
       </li>
     </ul>

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -17,14 +17,22 @@
     </div>
   </div>
 
-  <div class="connect" *ngIf="!project && !connecting">
-    <button mat-raised-button color="primary" class="button" (click)="connect()" [disabled]="!hasPrivateKey">
-      Connect a plan file
-    </button>
-    <span class="no-keys" *ngIf="!hasPrivateKey">
-      <hab-icon symbol="add-circle"></hab-icon>
-      <a [routerLink]="['/origins', origin, 'keys']">Add required origin keys</a>
-    </span>
+  <h3>Connected Plans</h3>
+  <button mat-button mat-raised-button color="primary" class="button connect-btn" [matMenuTriggerFor]="menu" [disabled]="!hasPrivateKey || !gitHubAppInstalled">
+    <span class="connect-btn-text">Connect a plan file</span>
+    <hab-icon class="connect-btn-icon" symbol="drop-down"></hab-icon>
+  </button>
+  <mat-menu #menu="matMenu" [overlapTrigger]="false" class="connect-menu">
+    <button mat-menu-item (click)="openConnect('linux')">for Linux (kernel version 3.2 or later)</button>
+    <button mat-menu-item (click)="openConnect('linux2')">for Linux 2 (kernel version 2.6.32 or later)</button>
+    <button mat-menu-item (click)="openConnect('windows')">for Windows</button>
+  </mat-menu>
+  <span class="no-keys" *ngIf="!hasPrivateKey">
+    <hab-icon symbol="add-circle"></hab-icon>
+    <a [routerLink]="['/origins', origin, 'keys']">Add required origin keys</a>
+  </span>
+
+  <div class="connect" *ngIf="!projects.length > 0 && !connecting">
     <div *ngIf="name">
       <p>
         <strong>There are currently no Habitat plan files connected.</strong>
@@ -39,109 +47,102 @@
       </p>
     </div>
   </div>
-  <div class="connected-plans" *ngIf="project && !connecting">
+  <div class="connected-plans" *ngIf="projects.length > 0 && !connecting">
     <ul class="action-list">
       <li class="heading">
         <h4>Plan</h4>
-        <h4>Status</h4>
         <h4>Actions</h4>
       </li>
-      <li class="item">
+      <li class="item" *ngFor="let project of projects">
         <span class="column name">
-          <hab-icon [symbol]="iconFor(project.plan_path)"></hab-icon>
+          <hab-platform-icon [platform]="project.target"></hab-platform-icon>
           <span>{{ project.plan_path }}</span>
         </span>
-        <span class="column plan-status">
-          <hab-icon symbol="check" class="success"></hab-icon>
-          <span>connected</span>
-        </span>
         <span class="column actions">
-          <hab-icon symbol="settings" (click)="editConnection()" title="Edit this connection"></hab-icon>
+          <hab-icon symbol="settings" (click)="openConnectEdit(project)" title="Edit this connection"></hab-icon>
           <hab-icon symbol="cancel" (click)="disconnect(project)" title="Remove this connection"></hab-icon>
         </span>
       </li>
     </ul>
   </div>
-  <div class="connecting" *ngIf="connecting">
-    <form [formGroup]="form" #formValues="ngForm">
-      <ol>
-        <li [class.active]="!selectedInstallation" (click)="clearConnection()">Select a GitHub repo</li>
-        <li [class.active]="selectedInstallation">Set path to Habitat plan file</li>
-      </ol>
-      <div class="installation" *ngIf="!selectedInstallation">
-        <div *ngIf="loadingInstallations">
-          <hab-icon symbol="loading" class="spinning"></hab-icon>
-        </div>
-        <div *ngIf="!loadingInstallations">
-          <div *ngIf="installations.size > 0">
-            <p>
-              Choose the GitHub organization and repository that
-              <strong>contain your Habitat plan file</strong>.
-            </p>
-            <div class="installation-selector">
-              <div>
-                <h3>Organization</h3>
-                <ul class="select-list installations">
-                  <li class="item" *ngFor="let install of installations"
-                    [class.active]="activeInstallation === install"
-                    (click)="pickInstallation(install)">
-                    {{ install.get('account').get('login') }}
-                  </li>
-                </ul>
-              </div>
-              <div>
-                <h3>Repository</h3>
-                <div *ngIf="!activeInstallation && !loadingRepositories">
-                  Choose an organization.
+  <div class="connecting connect-plan-overlay" *ngIf="connecting">
+    <div class="overlay-header">
+      <h1 class="overlay-title">
+        Connect a {{ planTargetName }} plan file to {{ origin }}
+        <hab-platform-icon [platform]="target"></hab-platform-icon>
+      </h1>
+      <a class="overlay-close" (click)="clearConnection()">&times;</a>
+    </div>
+    <div class="overlay-body">
+      <form [formGroup]="form" #formValues="ngForm">
+        <div class="installation">
+          <div *ngIf="loadingInstallations">
+            <hab-icon symbol="loading" class="spinning"></hab-icon>
+          </div>
+          <div *ngIf="!loadingInstallations">
+            <div *ngIf="installations.size > 0">
+              <p>Choose the GitHub organization and repository that contain your Habitat plan file.</p>
+              <div class="installation-selector">
+                <div>
+                  <h3>Organization</h3>
+                  <ul class="select-list installations">
+                    <li class="item" *ngFor="let install of installations"
+                      [class.active]="activeInstallation === install"
+                      (click)="pickInstallation(install)">
+                      {{ install.get('account').get('login') }}
+                    </li>
+                  </ul>
                 </div>
-                <div *ngIf="loadingRepositories">
-                  <hab-icon symbol="loading" class="spinning"></hab-icon>
+                <div>
+                  <h3>Repository</h3>
+                  <div *ngIf="!activeInstallation && !loadingRepositories">
+                    Choose an organization.
+                  </div>
+                  <div *ngIf="loadingRepositories">
+                    <hab-icon symbol="loading" class="spinning"></hab-icon>
+                  </div>
+                  <ul class="select-list repositories" *ngIf="activeInstallation && !loadingRepositories">
+                    <li class="item" *ngFor="let repo of repositories"
+                      [class.active]="activeRepo === repo"
+                      (click)="pickRepo(repo)">
+                      {{ repo.get('name') }}
+                    </li>
+                  </ul>
                 </div>
-                <ul class="select-list repositories" *ngIf="activeInstallation && !loadingRepositories">
-                  <li class="item" *ngFor="let repo of repositories"
-                    [class.active]="activeRepo === repo"
-                    (click)="pickRepo(repo)">
-                    {{ repo.get('name') }}
-                  </li>
-                </ul>
               </div>
+            </div>
+            <div class="github-note">
+              <p>* Don't see the organization or repository? Grant builder access in <a href="{{ config['github_app_url'] }}" target="_blank">Builder GitHub App <hab-icon symbol="open-in-new"></hab-icon></a> and <a>Refresh</a> the page.</p>
             </div>
           </div>
         </div>
-      </div>
-      <div *ngIf="selectedInstallation">
-        <a class="repo-link" href="{{ repoUrl }}" target="_blank">
-          <hab-icon symbol="open-in-new"></hab-icon>
-          Go to your repo
-        </a>
-        <h3>Path to Plan File</h3>
-        <p>
-          Enter the path to your plan file from the root of your repo. By default, we check for
-          <code>habitat/plan.sh</code>.
-        </p>
-        <div class="files">
-          <hab-checking-input id="plan_path" name="plan_path" availableMessage="found." notAvailableMessage="does not exist in the repository."
-            unmatchedMessage="must be named either plan.sh or plan.ps1." displayName="Plan file" [form]="form" [pattern]="false"
-            [maxLength]="false" [isAvailable]="doesFileExist" [value]="selectedPath">
-          </hab-checking-input>
+        <div>
+          <h3>Path to Plan File</h3>
+          <p>
+            Enter the path to your plan file from the root of your repo. By default, we check for
+            <code>{{ defaultPath }}</code>.
+          </p>
+          <div class="files">
+            <hab-checking-input id="plan_path" name="plan_path" availableMessage="found." notAvailableMessage="does not exist in the repository."
+              [unmatchedMessage]="unmatchedMessage" displayName="Plan file" [form]="form" [pattern]="unmatchedPattern"
+              [maxLength]="false" [isAvailable]="doesFileExist" [value]="selectedPath" [disabled]="!selectedInstallation">
+            </hab-checking-input>
+          </div>
+          <hr>
+          <hab-docker-export-settings #docker *ngIf="selectedInstallation" [origin]="origin" [package]="name" [integrations]="integrations"
+            [current]="dockerSettings" [enabled]="dockerEnabled">
+          </hab-docker-export-settings>
+          <hr>
+          <hab-auto-build-settings [enabled]="autoBuild" (toggled)="autoBuildToggled($event)"></hab-auto-build-settings>
+          <hr>
         </div>
-        <hr>
-        <hab-docker-export-settings #docker *ngIf="selectedInstallation" [origin]="origin" [package]="name" [integrations]="integrations"
-          [current]="dockerSettings" [enabled]="dockerEnabled">
-        </hab-docker-export-settings>
-        <hr>
-        <hab-auto-build-settings [enabled]="autoBuild" (toggled)="autoBuildToggled($event)"></hab-auto-build-settings>
-        <hr>
-      </div>
-      <div class="controls">
-        <button *ngIf="!selectedInstallation" mat-raised-button color="primary" class="button" (click)="next()" [disabled]="!repoSelected">
-          Next &raquo;
-        </button>
-        <button *ngIf="selectedInstallation" mat-raised-button color="primary" class="button" (click)="saveConnection()" [disabled]="!validProject">
-          {{ connectButtonLabel }} Connection
-        </button>
-        <a (click)="clearConnection()">Cancel</a>
-      </div>
-    </form>
+        <div class="controls">
+          <button mat-raised-button color="primary" class="button" (click)="saveConnection()" [disabled]="!validProject">
+            {{ connectButtonLabel }} Connection
+          </button>
+          <a (click)="clearConnection()">Cancel</a>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -23,9 +23,9 @@
     <hab-icon class="connect-btn-icon" symbol="drop-down"></hab-icon>
   </button>
   <mat-menu #menu="matMenu" [overlapTrigger]="false" class="connect-menu">
-    <button mat-menu-item (click)="openConnect('linux')">for Linux (kernel version 3.2 or later)</button>
-    <button mat-menu-item (click)="openConnect('linux2')">for Linux 2 (kernel version 2.6.32 or later)</button>
-    <button mat-menu-item (click)="openConnect('windows')">for Windows</button>
+    <button mat-menu-item [disabled]="hasPlanFor('linux')" (click)="openConnect('linux')">for Linux (kernel version 3.2 or later)</button>
+    <button mat-menu-item [disabled]="hasPlanFor('linux2')" (click)="openConnect('linux2')">for Linux 2 (kernel version 2.6.32 or later)</button>
+    <button mat-menu-item [disabled]="hasPlanFor('windows')" (click)="openConnect('windows')">for Windows</button>
   </mat-menu>
   <span class="no-keys" *ngIf="!hasPrivateKey">
     <hab-icon symbol="add-circle"></hab-icon>

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -382,6 +382,7 @@ export class ProjectSettingsComponent implements OnChanges, AfterViewChecked {
 
   settingChanged(setting) {
     this.visibility = setting;
+    this.store.dispatch(setProjectVisibility(this.origin, this.name, this.visibility, this.token));
   }
 
   private doAfterViewChecked(f) {
@@ -390,7 +391,6 @@ export class ProjectSettingsComponent implements OnChanges, AfterViewChecked {
 
   private handleSaved(successful, origin, name, target) {
     if (successful) {
-      this.saveVisibility(origin, name, target);
       this.saveIntegration(origin, name);
       this.store.dispatch(fetchProject(origin, name, target, this.token, false));
       this.saved.emit({ origin: origin, name: name });
@@ -416,9 +416,5 @@ export class ProjectSettingsComponent implements OnChanges, AfterViewChecked {
         this.store.dispatch(deleteProjectIntegration(this.origin, this.name, k, this.token));
       });
     }
-  }
-
-  private saveVisibility(origin, name, target) {
-    this.store.dispatch(setProjectVisibility(origin, name, target, this.visibility, this.token));
   }
 }

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -307,6 +307,12 @@ export class ProjectSettingsComponent implements OnChanges, OnDestroy, AfterView
     return !!path.match(/\.ps1$/);
   }
 
+  hasPlanFor(target: string): boolean {
+    return this.projects.filter(project => {
+      return project.target === targetFrom('param', target).id;
+    }).length === 1;
+  }
+
   clearConnection() {
     this.clearSelection();
     this.router.navigate(['/pkgs', this.origin, this.name, 'settings']);

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -28,8 +28,8 @@ import { BuilderApiClient } from '../../client/builder-api';
 import { AppStore } from '../../app.store';
 import {
   addProject, clearGitHubInstallations, clearGitHubRepositories, updateProject, setProjectIntegrationSettings, deleteProject,
-  fetchGitHubInstallations, fetchGitHubRepositories, fetchProject, setProjectVisibility,
-  deleteProjectIntegration
+  fetchGitHubInstallations, fetchGitHubRepositories, fetchProject, setCurrentPackageVisibility,
+  deleteProjectIntegration, createEmptyPackage
 } from '../../actions/index';
 import config from '../../config';
 import { targetFrom, targets } from '../../util';
@@ -270,7 +270,10 @@ export class ProjectSettingsComponent implements OnChanges, OnDestroy, AfterView
   }
 
   get visibility() {
-    return this._visibility || this.store.getState().origins.current.default_package_visibility || 'public';
+    const { currentSettings } = this.store.getState().packages;
+    const { default_package_visibility } = this.store.getState().origins.current;
+    const visibility = currentSettings ? currentSettings.visibility : default_package_visibility;
+    return this._visibility || visibility || 'public';
   }
 
   set visibility(v: string) {
@@ -452,7 +455,7 @@ export class ProjectSettingsComponent implements OnChanges, OnDestroy, AfterView
 
   settingChanged(setting) {
     this.visibility = setting;
-    this.store.dispatch(setProjectVisibility(this.origin, this.name, this.visibility, this.token));
+    this.store.dispatch(setCurrentPackageVisibility(this.origin, this.name, this.visibility, this.token));
   }
 
   refresh() {

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -350,12 +350,14 @@ export class ProjectSettingsComponent implements OnChanges, AfterViewChecked {
   saveConnection() {
     if (this.project) {
       this.store.dispatch(updateProject(this.project.name, this.planTemplate, this.token, (result) => {
-        this.handleSaved(result.success, this.project.origin, this.project.package_name);
+        const { origin, package_name, target } = this.project;
+        this.handleSaved(result.success, origin, package_name, target);
       }));
     }
     else {
       this.store.dispatch(addProject(this.planTemplate, this.token, (result) => {
-        this.handleSaved(result.success, result.response.origin, result.response.package_name);
+        const { origin, package_name, target } = result.response;
+        this.handleSaved(result.success, origin, package_name, target);
       }));
     }
   }
@@ -386,11 +388,11 @@ export class ProjectSettingsComponent implements OnChanges, AfterViewChecked {
     this._doAfterViewChecked.push(f);
   }
 
-  private handleSaved(successful, origin, name) {
+  private handleSaved(successful, origin, name, target) {
     if (successful) {
-      this.saveVisibility(origin, name);
+      this.saveVisibility(origin, name, target);
       this.saveIntegration(origin, name);
-      this.store.dispatch(fetchProject(origin, name, this.token, false));
+      this.store.dispatch(fetchProject(origin, name, target, this.token, false));
       this.saved.emit({ origin: origin, name: name });
       this.clearConnection();
     }
@@ -416,7 +418,7 @@ export class ProjectSettingsComponent implements OnChanges, AfterViewChecked {
     }
   }
 
-  private saveVisibility(origin, name) {
-    this.store.dispatch(setProjectVisibility(origin, name, this.visibility, this.token));
+  private saveVisibility(origin, name, target) {
+    this.store.dispatch(setProjectVisibility(origin, name, target, this.visibility, this.token));
   }
 }

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -247,14 +247,14 @@ export class ProjectSettingsComponent implements OnChanges, AfterViewChecked {
     this.toggled.emit(this.connecting);
   }
 
-  disconnect() {
+  disconnect(project) {
     const ref = this.disconnectDialog.open(DisconnectConfirmDialog, {
       width: '460px'
     });
 
     ref.afterClosed().subscribe((confirmed) => {
       if (confirmed) {
-        this.store.dispatch(deleteProject(this.project.name, this.token));
+        this.store.dispatch(deleteProject(project.name, project.target, this.token));
       }
     });
   }

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -307,6 +307,11 @@ export class ProjectSettingsComponent implements OnChanges, OnDestroy, AfterView
     return !!path.match(/\.ps1$/);
   }
 
+  hasInvalidPlanPath(project): boolean {
+    this.target = project.target;
+    return !(new RegExp(this.unmatchedPattern).test(project.plan_path));
+  }
+
   hasPlanFor(target: string): boolean {
     return this.projects.filter(project => {
       return project.target === targetFrom('param', target).id;

--- a/components/builder-web/app/shared/shared.module.ts
+++ b/components/builder-web/app/shared/shared.module.ts
@@ -18,7 +18,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import {
-  MatCheckbox, MatCheckboxModule, MatIconModule, MatIconRegistry, MatRadioModule,
+  MatCheckbox, MatCheckboxModule, MatIconModule, MatIconRegistry, MatMenuModule, MatRadioModule,
   MatRadioGroup, MatRadioButton, MatSlideToggleModule, MatSlideToggle, MatTooltipModule, MatTabsModule,
   MatButtonModule
 } from '@angular/material';
@@ -55,6 +55,7 @@ import { JobNoticeComponent } from './job-notice/job-notice.component';
     FormsModule,
     MatCheckboxModule,
     MatIconModule,
+    MatMenuModule,
     MatTabsModule,
     MatRadioModule,
     MatSlideToggleModule,

--- a/components/builder-web/app/shared/visibility-selector/visibility-selector.component.html
+++ b/components/builder-web/app/shared/visibility-selector/visibility-selector.component.html
@@ -2,20 +2,20 @@
   <mat-radio-group class="wrapper" [(ngModel)]="setting" (change)="change($event)">
     <mat-radio-button class="selector" [class.active]="setting === 'public'" value="public">
       <h5>
-        Public packages
+        Public {{ settingLabel }}
         <hab-icon symbol="public"></hab-icon>
       </h5>
       <span>
-        Package builds will appear in public search results and can be utilized by any user.
+        {{ publicDescription }}
       </span>
     </mat-radio-button>
     <mat-radio-button class="selector" [class.active]="setting === 'private'" value="private">
       <h5>
-        Private packages
+        Private {{ settingLabel }}
         <hab-icon symbol="lock"></hab-icon>
       </h5>
       <span>
-        Package builds will NOT appear in public search results and can ONLY be utilized by members of this origin.
+        {{ privateDescription }}
       </span>
     </mat-radio-button>
   </mat-radio-group>

--- a/components/builder-web/app/shared/visibility-selector/visibility-selector.component.ts
+++ b/components/builder-web/app/shared/visibility-selector/visibility-selector.component.ts
@@ -19,9 +19,23 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   template: require('./visibility-selector.component.html')
 })
 export class VisibilitySelectorComponent {
-
   @Input() setting: string = 'public';
+
+  @Input() plural: boolean = true;
+
   @Output() changed: EventEmitter<string> = new EventEmitter<string>();
+
+  get settingLabel() {
+    return `artifact${this.plural ? 's' : ''}`;
+  }
+
+  get publicDescription() {
+    return `The ${this.settingLabel} appear${this.plural ? '' : 's'} in public search results and can be utilized by any user.`;
+  }
+
+  get privateDescription() {
+    return `The ${this.settingLabel} do${this.plural ? '' : 'es'} NOT appear in public search results and can ONLY be utilized by members of this origin.`;
+  }
 
   change() {
     this.changed.emit(this.setting);

--- a/components/builder-web/cypress/fixtures/package-detail/project.json
+++ b/components/builder-web/cypress/fixtures/package-detail/project.json
@@ -5,6 +5,7 @@
   "package_name": "cacerts",
   "name": "core/cacerts",
   "plan_path": "cacerts/plan.sh",
+  "target": "x86_64-linux",
   "visibility": "public",
   "vcs_type": "git",
   "vcs_data": "https://github.com/sauron/core-plans.git",

--- a/components/builder-web/cypress/integration/package-detail.spec.ts
+++ b/components/builder-web/cypress/integration/package-detail.spec.ts
@@ -33,7 +33,7 @@ describe('Package Detail', () => {
 
     cy.route('GET', '/v1/user/origins', '@userOriginsEmpty');
     cy.route('GET', '/v1/depot/pkgs/core/cacerts/latest?target=x86_64-linux', '@pkgLatestLinux');
-    cy.route('GET', '/v1/projects/core/cacerts', '@pkgProject');
+    cy.route('GET', '/v1/projects/core/cacerts?target=x86_64-linux', '@pkgProject');
     cy.route('GET', '/v1/depot/pkgs/core/cacerts/versions', '@pkgVersionsAll');
     cy.route('GET', '/v1/depot/pkgs/core/cacerts/2018.06.20?range=0', '@pkgVersionReleases');
 

--- a/components/builder-web/stylesheets/base/_theme.scss
+++ b/components/builder-web/stylesheets/base/_theme.scss
@@ -4,6 +4,8 @@
 @import "@angular/material/theming";
 @import "theme_palette";
 
+$mat-elevation-color: $medium-gray;
+
 $custom-typography: mat-typography-config(
   $button: mat-typography-level($base-font-size, $base-line-height, normal),
   $font-family: "#{$base-font-family}"


### PR DESCRIPTION
Various updates to package settings tab that couldn't be easily untangled from one another:

- Allows default package visibility setting to be modified directly from settings tab
- Allows multiple plan files for different OS targets to be added, edited, removed
- Plan add/edit form simplified to a single-step form within a page overlay
- Fix bug where debounced AsyncValidators do not complete their observable stream

![](https://user-images.githubusercontent.com/479121/73208872-6d70b900-4104-11ea-9a10-83c6cf489911.gif)

https://github.com/habitat-sh/builder/issues/1180
https://github.com/habitat-sh/builder/issues/1181
https://github.com/habitat-sh/builder/issues/1240