### PR TITLE
adds owner_account to the OriginWithSecretKey response

### DIFF
--- a/components/builder-db/src/migrations/2020-01-28-174159_origins_add_owner_account/up.sql
+++ b/components/builder-db/src/migrations/2020-01-28-174159_origins_add_owner_account/up.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW origins_with_secret_key AS
+  SELECT origins.name,
+     origins.owner_id,
+     origin_secret_keys.full_name AS private_key_name,
+     origins.default_package_visibility,
+     accounts.name AS owner_account
+    FROM (origins
+     LEFT JOIN origin_secret_keys ON ((origins.name = origin_secret_keys.origin))
+     LEFT JOIN accounts ON ((origins.owner_id = accounts.id)))
+   ORDER BY origins.name, origin_secret_keys.full_name DESC;

--- a/components/builder-db/src/models/origin.rs
+++ b/components/builder-db/src/models/origin.rs
@@ -47,6 +47,7 @@ pub struct OriginWithSecretKey {
     pub name: String,
     pub private_key_name: Option<String>,
     pub default_package_visibility: PackageVisibility,
+    pub owner_account: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Queryable)]

--- a/components/builder-db/src/schema/origin.rs
+++ b/components/builder-db/src/schema/origin.rs
@@ -18,6 +18,7 @@ table! {
         name -> Text,
         private_key_name -> Nullable<Text>,
         default_package_visibility -> PackageVisibilityMapping,
+        owner_account -> Text,
     }
 }
 

--- a/test/builder-api/src/helpers.js
+++ b/test/builder-api/src/helpers.js
@@ -3,3 +3,5 @@ global.boboBearer = 'Bearer bobo';
 global.mystiqueBearer = 'Bearer mystique';
 global.hankBearer = 'Bearer hank';
 global.weskerBearer = 'Bearer wesker';
+// accounts.name of boboBearer
+global.boboAccountName = 'bobo';

--- a/test/builder-api/src/origins.js
+++ b/test/builder-api/src/origins.js
@@ -48,6 +48,7 @@ describe('Origin API', function () {
           expect(res.body.id).to.equal(global.originNeurosis.id);
           expect(res.body.owner_id).to.equal(global.originNeurosis.owner_id);
           expect(res.body.default_package_visibility).to.equal(global.originNeurosis.default_package_visibility);
+          expect(res.body.owner_account).to.equal(global.boboAccountName);
           done(err);
         });
     });


### PR DESCRIPTION
Closes https://github.com/habitat-sh/builder/issues/1272

This change updates the `OriginWithSecretKey` struct and underlying db view by adding an `owner_account` field to it, such that a HTTP [GET](https://github.com/habitat-sh/builder/blob/eb9f96bee229b1f9b1e0b26686f1befdd0c8f901/components/builder-api/src/server/resources/origins.rs#L169) of `/depot/origins/{origin}` returns the new [OriginWithSecretKey](https://github.com/habitat-sh/builder/blob/141967f3a5c5eaa2cb03a752dc34d0dd51e04499/components/builder-db/src/models/origin.rs#L80-L86).

Previous view:
```
builder=# \d+ origins_with_secret_key
                            View "public.origins_with_secret_key"
           Column           |           Type            | Modifiers | Storage  | Description
----------------------------+---------------------------+-----------+----------+-------------
 name                       | text                      |           | extended |
 owner_id                   | bigint                    |           | plain    |
 private_key_name           | text                      |           | extended |
 default_package_visibility | origin_package_visibility |           | plain    |
View definition:
 SELECT origins.name,
    origins.owner_id,
    origin_secret_keys.full_name AS private_key_name,
    origins.default_package_visibility
   FROM origins
     LEFT JOIN origin_secret_keys ON origins.name = origin_secret_keys.origin
  ORDER BY origins.name, origin_secret_keys.full_name DESC;

builder=# 
```

Updated view:
```
builder=# \d+ origins_with_secret_key
                            View "public.origins_with_secret_key"
           Column           |           Type            | Modifiers | Storage  | Description
----------------------------+---------------------------+-----------+----------+-------------
 name                       | text                      |           | extended |
 owner_id                   | bigint                    |           | plain    |
 private_key_name           | text                      |           | extended |
 default_package_visibility | origin_package_visibility |           | plain    |
 owner_account              | text                      |           | extended |
View definition:
 SELECT origins.name,
    origins.owner_id,
    origin_secret_keys.full_name AS private_key_name,
    origins.default_package_visibility,
    accounts.name AS owner_account
   FROM origins
     LEFT JOIN origin_secret_keys ON origins.name = origin_secret_keys.origin
     LEFT JOIN accounts ON origins.owner_id = accounts.id
  ORDER BY origins.name, origin_secret_keys.full_name DESC;

builder=#
```
Signed-off-by: Jeremy J. Miller <jm@chef.io>