### PR TITLE
Cache config for private packages

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -136,6 +136,7 @@ pub struct ApiCfg {
     pub build_targets:    Vec<PackageTarget>,
     pub features_enabled: String,
     pub build_on_upload:  bool,
+    pub private_max_age:  usize,
 }
 
 impl Default for ApiCfg {
@@ -148,7 +149,8 @@ impl Default for ApiCfg {
                                         target::X86_64_WINDOWS,],
                  build_targets:    vec![target::X86_64_LINUX, target::X86_64_WINDOWS],
                  features_enabled: String::from("jobsrv"),
-                 build_on_upload:  true, }
+                 build_on_upload:  true,
+                 private_max_age:  300, }
     }
 }
 
@@ -347,6 +349,7 @@ mod tests {
         build_targets = ["x86_64-linux"]
         features_enabled = "foo, bar"
         build_on_upload = false
+        private_max_age = 400
 
         [http]
         listen = "0:0:0:0:0:0:0:1"
@@ -419,6 +422,7 @@ mod tests {
 
         assert_eq!(&config.api.features_enabled, "foo, bar");
         assert_eq!(config.api.build_on_upload, false);
+        assert_eq!(config.api.private_max_age, 400);
 
         assert_eq!(&format!("{}", config.http.listen), "::1");
 

--- a/components/builder-api/src/server/framework/headers.rs
+++ b/components/builder-api/src/server/framework/headers.rs
@@ -19,11 +19,23 @@ pub const APPLICATION_JSON: &str = "application/json";
 
 pub const XFILENAME: &str = "x-filename"; // must be lowercase
 
-pub fn cache(cache: bool) -> &'static str {
-    if cache {
-        CACHE
-    } else {
-        NO_CACHE
+pub enum Cache {
+    NoCache,
+    MaxAgeDefault,
+    MaxAge(usize),
+}
+
+impl Default for Cache {
+    fn default() -> Self { Cache::MaxAgeDefault }
+}
+
+impl ToString for Cache {
+    fn to_string(&self) -> String {
+        match self {
+            Cache::NoCache => NO_CACHE.to_string(),
+            Cache::MaxAgeDefault => CACHE.to_string(),
+            Cache::MaxAge(secs) => format!("public, max-age={}", secs),
+        }
     }
 }
 

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -118,7 +118,8 @@ fn get_channels(path: Path<String>,
             let ident_list: Vec<Temp> = list.iter()
                                             .map(|channel| Temp { name: channel.name.clone(), })
                                             .collect();
-            HttpResponse::Ok().header(http::header::CACHE_CONTROL, headers::NO_CACHE)
+            HttpResponse::Ok().header(http::header::CACHE_CONTROL,
+                                      headers::Cache::NoCache.to_string())
                               .json(ident_list)
         }
         Err(Error::NotFound) => HttpResponse::new(StatusCode::NOT_FOUND),
@@ -610,7 +611,8 @@ fn get_latest_package_for_origin_channel_package(req: HttpRequest,
     match do_get_channel_package(&req, &qtarget, &ident, &channel) {
         Ok(json_body) => {
             HttpResponse::Ok().header(http::header::CONTENT_TYPE, headers::APPLICATION_JSON)
-                              .header(http::header::CACHE_CONTROL, headers::cache(false))
+                              .header(http::header::CACHE_CONTROL,
+                                      headers::Cache::NoCache.to_string())
                               .body(json_body)
         }
         Err(Error::NotFound) => HttpResponse::new(StatusCode::NOT_FOUND),
@@ -637,7 +639,8 @@ fn get_latest_package_for_origin_channel_package_version(req: HttpRequest,
     match do_get_channel_package(&req, &qtarget, &ident, &channel) {
         Ok(json_body) => {
             HttpResponse::Ok().header(http::header::CONTENT_TYPE, headers::APPLICATION_JSON)
-                              .header(http::header::CACHE_CONTROL, headers::cache(false))
+                              .header(http::header::CACHE_CONTROL,
+                                      headers::Cache::NoCache.to_string())
                               .body(json_body)
         }
         Err(Error::NotFound) => HttpResponse::new(StatusCode::NOT_FOUND),
@@ -661,7 +664,8 @@ fn get_package_fully_qualified(req: HttpRequest,
     match do_get_channel_package(&req, &qtarget, &ident, &channel) {
         Ok(json_body) => {
             HttpResponse::Ok().header(http::header::CONTENT_TYPE, headers::APPLICATION_JSON)
-                              .header(http::header::CACHE_CONTROL, headers::cache(false))
+                              .header(http::header::CACHE_CONTROL,
+                                      headers::Cache::NoCache.to_string())
                               .body(json_body)
         }
         Err(Error::NotFound) => HttpResponse::new(StatusCode::NOT_FOUND),
@@ -882,6 +886,7 @@ fn postprocess_channel_package_list(_req: &HttpRequest,
     };
 
     response.header(http::header::CONTENT_TYPE, headers::APPLICATION_JSON)
-            .header(http::header::CACHE_CONTROL, headers::NO_CACHE)
+            .header(http::header::CACHE_CONTROL,
+                    headers::Cache::NoCache.to_string())
             .body(body)
 }


### PR DESCRIPTION
This change adds a configurable cache expiration for private packages. This allows better control of private packages at the CDN level, and also lets us tune the cache settings for performance as needed.

Signed-off-by: Salim Alam <salam@chef.io>

![](https://media1.giphy.com/media/leqmpruKOh3gY/giphy.gif?cid=5a38a5a2cb7e1571c9e8e036a1d719ef69f5b09428ed74cf&rid=giphy.gif)
