### PR TITLE
Allow package versions in versions list to be linkable

### DIFF
--- a/components/builder-web/app/package/package-versions/package-versions.component.html
+++ b/components/builder-web/app/package/package-versions/package-versions.component.html
@@ -9,17 +9,17 @@
     <li class="none" *ngIf="versions.length === 0">
       <span>There are no available versions for this package.</span>
     </li>
-    <div *ngFor="let version of versions" (click)="toggle(version)">
-      <li class="item">
+    <div *ngFor="let version of versions">
+      <li class="item" [routerLink]="itemLinkFor(version.version)">
         <span class="column name">{{ version.version }}</span>
         <span class="column">{{ version.release_count }}</span>
         <span class="column">{{ releaseToDate(version.latest) }}</span>
         <span class="column">
           <hab-platform-icon [platform]="platform" *ngFor="let platform of platformsFor(version)"></hab-platform-icon>
         </span>
-        <hab-icon class="toggle" [symbol]="toggleFor(version)"></hab-icon>
+        <hab-icon class="toggle" [symbol]="toggleFor(version.version)"></hab-icon>
       </li>
-      <div *ngIf="selected === version">
+      <div *ngIf="selected === version.version">
         <ul class="nav-list">
           <li class="item" *ngFor="let pkg of packagesFor(version)" (click)="navigateTo(pkg)">
             <a>

--- a/components/builder-web/cypress/fixtures/package-detail/version-releases.json
+++ b/components/builder-web/cypress/fixtures/package-detail/version-releases.json
@@ -1,0 +1,19 @@
+{
+  "range_start": 0,
+  "range_end": 0,
+  "total_count": 1,
+  "data": [
+    {
+      "origin": "core",
+      "name": "cacerts",
+      "version": "2018.06.20",
+      "release": "20180927173225",
+      "channels": [
+        "unstable"
+      ],
+      "platforms": [
+        "x86_64-linux-kernel2"
+      ]
+    }
+  ]
+}

--- a/components/builder-web/cypress/integration/package-detail.spec.ts
+++ b/components/builder-web/cypress/integration/package-detail.spec.ts
@@ -29,11 +29,13 @@ describe('Package Detail', () => {
     cy.fixture('package-detail/project').as('pkgProject');
     cy.fixture('package-detail/versions-all').as('pkgVersionsAll');
     cy.fixture('package-detail/versions-empty').as('pkgVersionsEmpty');
+    cy.fixture('package-detail/version-releases').as('pkgVersionReleases');
 
     cy.route('GET', '/v1/user/origins', '@userOriginsEmpty');
     cy.route('GET', '/v1/depot/pkgs/core/cacerts/latest?target=x86_64-linux', '@pkgLatestLinux');
     cy.route('GET', '/v1/projects/core/cacerts', '@pkgProject');
     cy.route('GET', '/v1/depot/pkgs/core/cacerts/versions', '@pkgVersionsAll');
+    cy.route('GET', '/v1/depot/pkgs/core/cacerts/2018.06.20?range=0', '@pkgVersionReleases');
 
     cy.setSession();
   });
@@ -170,6 +172,16 @@ describe('Package Detail', () => {
       pkgVersions().should('contain', 'Releases');
       pkgVersions().should('contain', 'Updated');
       pkgVersions().should('contain', 'Platforms');
+    });
+
+    describe('when URL contains a specific version', () => {
+
+      it('displays versions list with that specific version toggled open', () => {
+        cy.visit('/#/pkgs/core/cacerts/2018.06.20');
+
+        const versionRow = pkgVersions().get('.toggle-list > div:nth-child(3)');
+        versionRow.get('.nav-list').should('be.visible');
+      });
     });
   });
 });


### PR DESCRIPTION
As part of https://github.com/habitat-sh/builder/issues/1189, this commit adds the ability to link to a specific version in a package's version list and have it affect the open/close state of the list item.

![](https://user-images.githubusercontent.com/479121/73964588-b0cee280-48cf-11ea-871c-7f7f738c460d.gif)