### PR TITLE
Update deprecated token in query param

### DIFF
--- a/components/builder-web/app/client/github-api.ts
+++ b/components/builder-web/app/client/github-api.ts
@@ -24,13 +24,14 @@ export class GitHubApiClient {
       Accept: [
         'application/vnd.github.v3+json',
         'application/vnd.github.machine-man-preview+json'
-      ]
+      ],
+      Authorization: 'token ' + token
     };
   }
 
   public getUserInstallations(username: string) {
     return new Promise((resolve, reject) => {
-      fetch(`${config['github_api_url']}/user/installations?access_token=${this.token}`, {
+      fetch(`${config['github_api_url']}/user/installations`, {
         method: 'GET',
         headers: this.headers
       })
@@ -110,7 +111,7 @@ export class GitHubApiClient {
 
     private getUserInstallationRepositories(installationId: string, page: number) {
       return new Promise((resolve, reject) => {
-        fetch(`${config['github_api_url']}/user/installations/${installationId}/repositories?access_token=${this.token}&page=${page}&per_page=100`, {
+        fetch(`${config['github_api_url']}/user/installations/${installationId}/repositories?page=${page}&per_page=100`, {
           method: 'GET',
           headers: this.headers
         })


### PR DESCRIPTION
Github is deprecating the use of access token as a query param as a mechanism for authenticating with Github API.  This change replaces the query param with an Authorization header in the web UI calls.

This should resolve https://github.com/habitat-sh/builder/issues/1297

Signed-off-by: Salim Alam <salam@chef.io>

![](https://media1.giphy.com/media/VdW29KR6AgyxKLPCEc/giphy.gif?cid=5a38a5a2782e5504b99d8485e54b716f6bf2355da8c9ca0b&rid=giphy.gif)


