### PR TITLE
Change route to pull from origin_package_settings, create settigs on upload

### DIFF
--- a/components/builder-api/src/server/resources/origins.rs
+++ b/components/builder-api/src/server/resources/origins.rs
@@ -820,7 +820,9 @@ fn list_unique_packages(req: HttpRequest,
                              limit:      per_page as i64, };
 
     match Package::distinct_for_origin(lpr, &*conn) {
-        Ok((packages, count)) => postprocess_package_list(&req, &packages, count, &pagination),
+        Ok((packages, count)) => {
+            postprocess_package_list(&req, packages.as_slice(), count, &pagination)
+        }
         Err(err) => {
             debug!("{}", err);
             Error::DieselError(err).into()

--- a/components/builder-db/src/migrations/2020-02-11-810532_settings_refresh/up.sql
+++ b/components/builder-db/src/migrations/2020-02-11-810532_settings_refresh/up.sql
@@ -1,0 +1,1 @@
+INSERT into origin_package_settings (origin, name, visibility, owner_id) SELECT DISTINCT ON (origin, name, visibility, owner_id) origin, name ,visibility, owner_id FROM origin_packages ON CONFLICT DO NOTHING;

--- a/components/builder-db/src/models/settings.rs
+++ b/components/builder-db/src/models/settings.rs
@@ -20,6 +20,8 @@ use crate::{bldr_core::metrics::CounterMetric,
          QueryableByName,
          Queryable,
          Clone,
+         AsExpression,
+         PartialEq,
          Identifiable)]
 #[table_name = "origin_package_settings"]
 pub struct OriginPackageSettings {

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -149,6 +149,19 @@ describe('Working with packages', function () {
         });
     });
 
+    it('uploads does not allow duplicate upload', function (done) {
+      request.post(`/depot/pkgs/neurosis/testapp/0.1.3/${release2}`)
+        .set('Authorization', global.boboBearer)
+        .set('Content-Length', file2.length)
+        .query({ checksum: 'd8943c86636eb0a24cb63a80b3d9375ce342f2fa192375f3a0b83eab44de21eb' })
+        .send(file2)
+        .expect(409)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty
+          done(err);
+        });
+    });
+
     it('uploads a third package', function (done) {
       request.post(`/depot/pkgs/neurosis/testapp/0.1.4/${release3}`)
         .set('Authorization', global.boboBearer)


### PR DESCRIPTION
Should be pretty straightforward, this is in service of the ui changes. It should add another migration to refresh the data that exists in the `origin_package_settings` table, alter package upload to create an entry in origin_package_settings in the case that it doesn't yet exist, and alters the origin packages route to look in the new table rather than the previous table. 

Whether we bundle it into this migration or not - I think it probably makes sense to change the 'origin_packages' table to a different name. Perhaps `origin_package_artifacts` or the like.
Signed-off-by: Ian Henry <ihenry@chef.io>