### PR TITLE
Include target for evaluating uniqueness in get_all_latest

### DIFF
--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -472,9 +472,9 @@ impl Package {
         Counter::DBCall.increment();
         let start_time = PreciseTime::now();
         let result = origin_packages_with_version_array::table
-            .distinct_on((origin_packages_with_version_array::origin, origin_packages_with_version_array::name))
+            .distinct_on((origin_packages_with_version_array::origin, origin_packages_with_version_array::name, origin_packages_with_version_array::target))
             .order(sql::<PackageWithVersionArray>(
-                "origin, name, string_to_array(version_array[1],'.')::\
+                "origin, name, target, string_to_array(version_array[1],'.')::\
                 numeric[] desc, ident_array[4] desc",
             ))
             .get_results(conn);


### PR DESCRIPTION
Closes #1302 

This change was validated using the same set of packages used to reproduce the error.  On starting jobsrv, it now reports the correct numbers of packages in the build graph. 

```
builder-jobsrv.default(O): [2020-02-12T16:03:44Z INFO  habitat_builder_jobsrv::server] Graph build stats (PT0.002793900S sec):
builder-jobsrv.default(O): [2020-02-12T16:03:44Z INFO  habitat_builder_jobsrv::server] Target x86_64-linux: 1 nodes, 0 edges
builder-jobsrv.default(O): [2020-02-12T16:03:44Z INFO  habitat_builder_jobsrv::server] Target x86_64-linux-kernel2: 1 nodes, 0 edges
builder-jobsrv.default(O): [2020-02-12T16:03:44Z INFO  habitat_builder_jobsrv::server] Target x86_64-windows: 0 nodes, 0 edges
```

Once this change is in acceptance, we should examine the `rdeps` api to confirm it fixes the issue reported with `core/curl` missing `core/git` as an rdep. We can also check `core/openssl` to verify that `core/python` is a reverse dependency. 

![stay on target](https://media1.tenor.com/images/df0c278a939fad47298c1c62196be510/tenor.gif?itemid=5204982)

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>