### PR TITLE
Update cargo.lock after Habitat release

### DIFF
--- a/.expeditor/post_habitat_release.pipeline.yml
+++ b/.expeditor/post_habitat_release.pipeline.yml
@@ -42,7 +42,6 @@ steps:
   # allowing our production workers to then update.
 
   - label: "[:linux: build habitat/builder-worker]"
-    skip: true
     command:
       - .expeditor/scripts/post_habitat_release/build_worker.sh
     expeditor:
@@ -54,7 +53,6 @@ steps:
             - BUILD_PKG_TARGET=x86_64-linux
 
   - label: "[:linux: :two: build habitat/builder-worker]"
-    skip: true
     command:
       - .expeditor/scripts/post_habitat_release/build_worker.sh
     expeditor:
@@ -66,7 +64,6 @@ steps:
             - BUILD_PKG_TARGET=x86_64-linux-kernel2
 
   - label: "[:windows: build habitat/builder-worker]"
-    skip: true
     command:
       - powershell .expeditor/scripts/post_habitat_release/build_worker.ps1
     expeditor:
@@ -81,7 +78,6 @@ steps:
   - wait
 
   - label: "Promote to habitat/builder-worker to acceptance"
-    skip: true
     command:
       - .expeditor/scripts/post_habitat_release/promote_packages_to_channel.sh acceptance
     expeditor:
@@ -100,7 +96,6 @@ steps:
       by our Production builders.
 
   - label: "Promote habitat/builder-worker to stable"
-    skip: true
     command:
       - .expeditor/scripts/post_habitat_release/promote_packages_to_channel.sh stable
     expeditor:
@@ -113,7 +108,6 @@ steps:
   # We do this after building and promoting new workers to ensure the
   # bundle contains those workers.
   - label: ":s3: Create new Bootstrap Bundle"
-    skip: true
     command: ".expeditor/scripts/generate_bootstrap_bundle.sh"
     expeditor:
       executor:

--- a/.expeditor/post_habitat_release.pipeline.yml
+++ b/.expeditor/post_habitat_release.pipeline.yml
@@ -5,6 +5,9 @@ expeditor:
     PIPELINE_HAB_AUTH_TOKEN:
       path: account/static/habitat/chef-ci
       field: auth_token # Production Builder
+    GITHUB_TOKEN:
+      account: github/habitat-sh
+      field: token
   accounts:
     - aws/habitat # for uploading the bootstrap bundle
   defaults:
@@ -13,8 +16,20 @@ expeditor:
       env:
         HAB_ORIGIN: "habitat"
         PIPELINE_HAB_BLDR_URL: "https://bldr.habitat.sh"
+        GITHUB_USER: "habitat-sh" # per https://github.com/github/hub/issues/2264#issuecomment-567241335
 
 steps:
+  - label: ":rust: Cargo update"
+    command:
+      - .expeditor/scripts/post_habitat_release/cargo_update.sh
+    expeditor:
+      account:
+        - github
+      executor:
+        docker:
+          environment:
+            - GITHUB_USER
+    soft_fail: true
 
   # We build new releases of habitat/builder-worker now since they
   # pull in the new Habitat release we just created (specifically, the
@@ -27,6 +42,7 @@ steps:
   # allowing our production workers to then update.
 
   - label: "[:linux: build habitat/builder-worker]"
+    skip: true
     command:
       - .expeditor/scripts/post_habitat_release/build_worker.sh
     expeditor:
@@ -38,6 +54,7 @@ steps:
             - BUILD_PKG_TARGET=x86_64-linux
 
   - label: "[:linux: :two: build habitat/builder-worker]"
+    skip: true
     command:
       - .expeditor/scripts/post_habitat_release/build_worker.sh
     expeditor:
@@ -49,6 +66,7 @@ steps:
             - BUILD_PKG_TARGET=x86_64-linux-kernel2
 
   - label: "[:windows: build habitat/builder-worker]"
+    skip: true
     command:
       - powershell .expeditor/scripts/post_habitat_release/build_worker.ps1
     expeditor:
@@ -63,6 +81,7 @@ steps:
   - wait
 
   - label: "Promote to habitat/builder-worker to acceptance"
+    skip: true
     command:
       - .expeditor/scripts/post_habitat_release/promote_packages_to_channel.sh acceptance
     expeditor:
@@ -81,6 +100,7 @@ steps:
       by our Production builders.
 
   - label: "Promote habitat/builder-worker to stable"
+    skip: true
     command:
       - .expeditor/scripts/post_habitat_release/promote_packages_to_channel.sh stable
     expeditor:
@@ -93,6 +113,7 @@ steps:
   # We do this after building and promoting new workers to ensure the
   # bundle contains those workers.
   - label: ":s3: Create new Bootstrap Bundle"
+    skip: true
     command: ".expeditor/scripts/generate_bootstrap_bundle.sh"
     expeditor:
       executor:

--- a/.expeditor/scripts/post_habitat_release/cargo_update.sh
+++ b/.expeditor/scripts/post_habitat_release/cargo_update.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -euo pipefail 
+
+# shellcheck source=.expeditor/scripts/shared.sh 
+source .expeditor/scripts/post_habitat_release/shared.sh 
+
+branch="expeditor/cargo-update-$(date +"%Y%m%d%H%M%S")"
+git checkout -b "$branch"
+
+toolchain="$(get_toolchain)"
+
+install_rustup
+rustup install "$toolchain"
+
+install_hub
+
+echo "--- :habicat: Installing and configuring build dependencies"
+hab pkg install core/libarchive \
+                core/libsodium \
+                core/openssh \
+                core/openssl \
+                core/pkg-config \
+                core/postgresql-client \
+                core/protobuf \
+                core/zeromq
+
+PKG_CONFIG_PATH="$(< "$(hab pkg path core/libarchive)"/PKG_CONFIG_PATH)"
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(< "$(hab pkg path core/libsodium)"/PKG_CONFIG_PATH)"
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(< "$(hab pkg path core/openssl)"/PKG_CONFIG_PATH)"
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(< "$(hab pkg path core/zeromq)"/PKG_CONFIG_PATH)"
+export PKG_CONFIG_PATH
+
+# The library detection for the zeromq crate needs this additional hint.
+LD_RUN_PATH="$(< "$(hab pkg path core/zeromq)"/LD_RUN_PATH)"
+export LD_RUN_PATH
+
+# 'protoc' needs to be on our path
+PATH="$PATH:$(< "$(hab pkg path core/protobuf)"/RUNTIME_PATH)"
+# The the default container we use in buildkite has pg_config in /usr/bin which 
+# causes the pq-sys crate to be unable to set the correct path to the libraries.
+# This doesn't manifest until later in the build process in the migrations-macros
+# crate which is unable to find libpq. Place postgresql-client on our path first.
+PATH="$(< "$(hab pkg path core/postgresql-client)"/RUNTIME_PATH):$PATH"
+export PATH
+
+echo "--- :rust: Cargo Update"
+cargo clean
+cargo +"$toolchain" update
+
+echo "--- :rust: Cargo Check"
+cargo +"$toolchain" check --all --tests && update_status=$? || update_status=$?
+
+echo "--- :git: Publishing updated Cargo.lock"
+git add Cargo.lock
+
+git commit -s -m "Update Cargo.lock"
+
+pr_labels=""
+pr_message=""
+if [ "$update_status" -ne 0 ]; then 
+  pr_labels="T-DO-NOT-MERGE"
+
+  # read will exit 1 if it can't find a delimeter.
+  # -d '' will always trigger this case as there is no delimeter to find, 
+  # but this is required in order to write the entire message into a single PR 
+  # preserving newlines.
+   read -r -d '' pr_message <<EOM || true
+Unable to update Cargo.lock!
+
+For details on the failure, please visit ${BUILDKITE_BUILD_URL:-No Buildkite url}#${BUILDKITE_JOB_ID:-No Buildkite job id}
+EOM
+fi
+
+# Use shell to push the current branch so we can authenticate without scribbling secrets to disk
+#   or being prompted by git.
+# Hub provides better mechanisms than curl for opening a pr with a message and setting labels,
+# the latter requires multiple curl commands and parsing json responses and error handling at each step.
+push_current_branch
+
+# We have to use --force to open the PR. We're specifying where to push, rather than using a remote, in 
+# the previous command to avoid writing secrets to disk, so hub isn't able to read that information from
+# the git configuration
+hub pull-request --force --no-edit --labels "$pr_labels" --file - <<EOF
+Cargo Update
+
+$pr_message
+EOF
+
+exit "$update_status"

--- a/.expeditor/scripts/post_habitat_release/shared.sh
+++ b/.expeditor/scripts/post_habitat_release/shared.sh
@@ -31,3 +31,52 @@ worker_ident_for_target() {
     target="${1}"
     buildkite-agent meta-data get "${target}-builder-worker"
 }
+
+install_rustup() {
+  if command -v rustup && command -v cargo &>/dev/null; then
+    echo "--- :rust: rustup is currently installed."
+  else
+    echo "--- :rust: Installing rustup."
+    curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y --profile=minimal
+    # shellcheck disable=SC1090
+    source "$HOME"/.cargo/env
+  fi
+}
+
+get_toolchain() {
+    cat "$(git rev-parse --show-toplevel)/rust-toolchain"
+}
+
+latest_release_tag() {
+  local repo="${1?repo argument required}"
+  tag=$(curl --silent "https://api.github.com/repos/${repo}/releases/latest" | jq -r .tag_name)
+  echo "${tag}"
+}
+
+install_hub() {
+  # TODO: Create a Hab core plans pkg for this.
+  # see https://github.com/habitat-sh/habitat/issues/7267
+  local tag
+  tag=$(latest_release_tag github/hub)
+  tag_sans_v="${tag//v/}"
+  url="https://github.com/github/hub/releases/download/${tag}/hub-linux-amd64-${tag_sans_v}.tgz"
+  echo "--- :github: Installing hub version ${tag} to /bin/hub from ${url}"
+  curl -L -O "${url}"
+  tar xfz hub-linux-amd64-*.tgz
+  cp -f hub-linux-amd64-*/bin/hub /bin
+  chmod a+x /bin/hub
+  rm -rf hub-linux-amd64*
+}
+
+# Push the current branch to the project origin
+push_current_branch() {
+  repo=$(git remote get-url origin | sed -rn  's/.+github\.com[\/\:](.*)\.git/\1/p')
+  head=$(git rev-parse --abbrev-ref HEAD)
+
+  if [ "$head" == "master" ]; then
+    echo "Error: Attempting to push to master!"
+    exit 1
+  fi
+
+  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${repo}.git" "$head"
+}


### PR DESCRIPTION
This pulls in the relevant bits for updating the Cargo.lock after a release from the [habitat repository](https://github.com/habitat-sh/habitat).

Closes #1232 