### PR TITLE
Jamie/1292 member depart origin

### DIFF
--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -89,6 +89,7 @@ export {
   deleteOriginInvitation,
   deleteOriginMember,
   deleteOriginSecret,
+  departOrigin,
   fetchIntegration,
   fetchIntegrations,
   fetchMyOriginInvitations,

--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -121,6 +121,26 @@ export function deleteOriginMember(origin: string, member: string, token: string
   };
 }
 
+export function departOrigin(origin: string, member: string, token: string) {
+  console.log(member);
+  return dispatch => {
+    new BuilderApiClient(token).deleteOriginMember(origin, member).   // swap out internals for
+      then(response => {                                              // a departing memeber
+        dispatch(addNotification({                                    // in current state this will fail
+          title: `Departed from ${origin}.`,
+          type: SUCCESS,
+        }));
+        dispatch(fetchOriginMembers(origin, token));
+      }).catch(error => {
+        dispatch(addNotification({
+          title: 'Failed to depart from Origin',
+          body: error.message,
+          type: DANGER,
+        }));
+      });
+  };
+}
+
 export function createOrigin(body: object, token: string, isFirstOrigin = false, callback: Function = (origin) => { }) {
   return dispatch => {
     dispatch(setCurrentOriginCreatingFlag(true));

--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -121,12 +121,11 @@ export function deleteOriginMember(origin: string, member: string, token: string
   };
 }
 
-export function departOrigin(origin: string, member: string, token: string) {
-  console.log(member);
+export function departOrigin(origin: string, token: string) {
   return dispatch => {
-    new BuilderApiClient(token).deleteOriginMember(origin, member).   // swap out internals for
-      then(response => {                                              // a departing memeber
-        dispatch(addNotification({                                    // in current state this will fail
+    new BuilderApiClient(token).departFromOrigin(origin)
+      .then(response => {
+        dispatch(addNotification({
           title: `Departed from ${origin}.`,
           type: SUCCESS,
         }));

--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -121,17 +121,16 @@ export function deleteOriginMember(origin: string, member: string, token: string
   };
 }
 
-export function departOrigin(origin: string, token: string, callback: Function = (origin) => { }) {
+export function departOrigin(originName: string, token: string, callback: Function = (originName) => { }) {
   return dispatch => {
-    new BuilderApiClient(token).departFromOrigin(origin)
+    new BuilderApiClient(token).departFromOrigin(originName)
       .then(response => {
         dispatch(addNotification({
-          title: `Departed from ${origin}.`,
+          title: `Departed from ${originName}.`,
           type: SUCCESS,
         }));
 
-        dispatch(fetchOriginMembers(origin, token));
-        callback(origin);
+        callback(originName);
 
       }).catch(error => {
         dispatch(addNotification({

--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -121,7 +121,7 @@ export function deleteOriginMember(origin: string, member: string, token: string
   };
 }
 
-export function departOrigin(origin: string, token: string) {
+export function departOrigin(origin: string, token: string, callback: Function = (origin) => { }) {
   return dispatch => {
     new BuilderApiClient(token).departFromOrigin(origin)
       .then(response => {
@@ -129,7 +129,10 @@ export function departOrigin(origin: string, token: string) {
           title: `Departed from ${origin}.`,
           type: SUCCESS,
         }));
+
         dispatch(fetchOriginMembers(origin, token));
+        callback(origin);
+
       }).catch(error => {
         dispatch(addNotification({
           title: 'Failed to depart from Origin',

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -89,6 +89,26 @@ export class BuilderApiClient {
     });
   }
 
+  ////
+  public departFromOrigin(origin: string) {
+    return new Promise((resolve, reject) => {
+      fetch(`${this.urlPrefix}/depot/origins/${origin}/depart`, {
+        headers: this.headers,
+        method: 'POST',
+      })
+        .then(response => this.handleUnauthorized(response, reject))
+        .then(response => {
+          if (response.ok) {
+            resolve(true);
+          } else {
+            reject(new Error(response.statusText));
+          }
+        })
+        .catch(error => this.handleError(error, reject));
+    });
+  }
+  ///
+
   public ignoreOriginInvitation(invitationId: string, originName: string) {
     return new Promise((resolve, reject) => {
       fetch(`${this.urlPrefix}/depot/origins/${originName}/invitations/${invitationId}/ignore`, {

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -89,7 +89,6 @@ export class BuilderApiClient {
     });
   }
 
-  ////
   public departFromOrigin(origin: string) {
     return new Promise((resolve, reject) => {
       fetch(`${this.urlPrefix}/depot/origins/${origin}/depart`, {
@@ -107,7 +106,6 @@ export class BuilderApiClient {
         .catch(error => this.handleError(error, reject));
     });
   }
-  ///
 
   public ignoreOriginInvitation(invitationId: string, originName: string) {
     return new Promise((resolve, reject) => {

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
@@ -1,6 +1,15 @@
 .origin-members-tab-component {
+  background: red;
   
   .action-list {
     font-size: $base-font-size; 
+  }
+
+  #dfo-section {
+
+    button {
+      display: inline-block;
+      margin-left: auto;
+    }
   }
 }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
@@ -5,10 +5,12 @@
   }
 
   #dfo-section {
+    text-align: right;
 
     button {
-      display: block;
-      margin-left: auto;
+      color: $hab-red;
+      border: 1px solid $hab-red;
+      box-shadow: none;
     }
   }
 }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
@@ -1,5 +1,4 @@
 .origin-members-tab-component {
-  background: red;
   
   .action-list {
     font-size: $base-font-size; 
@@ -8,7 +7,7 @@
   #dfo-section {
 
     button {
-      display: inline-block;
+      display: block;
       margin-left: auto;
     }
   }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
@@ -8,9 +8,9 @@
     text-align: right;
 
     button {
+      margin: 1px;
       color: $hab-red;
       border: 1px solid $hab-red;
-      box-shadow: none;
     }
   }
 }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/_depart-origin.dialog.scss
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/_depart-origin.dialog.scss
@@ -2,5 +2,6 @@
 
   h1 {
     color: $hab-red;
+    font-weight: normal;
   }
 }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/_depart-origin.dialog.scss
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/_depart-origin.dialog.scss
@@ -1,0 +1,6 @@
+.depart-origin {
+
+  .heading h1 {
+    color: $chef-red;
+  }
+}

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/_depart-origin.dialog.scss
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/_depart-origin.dialog.scss
@@ -1,6 +1,6 @@
 .depart-origin {
 
-  .heading h1 {
-    color: $chef-red;
+  h1 {
+    color: $hab-red;
   }
 }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/depart-origin.dialog.html
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/depart-origin.dialog.html
@@ -1,0 +1,16 @@
+<div class="dialog depart-origin">
+  <section class="heading">
+    <h1>Depart from Origin?</h1>
+  </section>
+  <section class="body">
+    <p>
+      Departing from <strong>{{ originName }}</strong> will revoke your access to create packages and utilize private artifacts in this origin.
+    </p>
+  </section>
+  <section class="controls">
+    <button mat-raised-button color="primary" class="button" (click)="ok()">
+      Depart from Origin
+    </button>
+    <a (click)="cancel()">Cancel</a>
+  </section>
+</div>

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/depart-origin.dialog.html
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/depart-origin.dialog.html
@@ -1,6 +1,6 @@
 <div class="dialog depart-origin">
   <section class="heading">
-    <h1>Depart from Origin?</h1>
+    <h1>Depart from origin?</h1>
   </section>
   <section class="body">
     <p>

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/depart-origin.dialog.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/dialog/depart-origin.dialog.ts
@@ -12,11 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import "origin-page/origin-integrations-tab/origin-integrations-tab.component";
-@import "origin-page/origin-page.component";
-@import "origin-page/origin-members-tab/origin-members-tab.component";
-@import "origin-page/origin-members-tab/dialog/depart-origin.dialog";
-@import "origin-page/origin-keys-tab/origin-keys-tab.component";
-@import "origin-page/origin-jobs-tab/jobs-list/jobs-list.component";
-@import "origin-page/origin-job-detail/origin-job-detail.component";
-@import "origins-page/origins-page.component";
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+
+@Component({
+  template: require('./depart-origin.dialog.html')
+})
+export class DepartOriginDialog {
+
+  constructor(
+    private ref: MatDialogRef<DepartOriginDialog>,
+    @Inject(MAT_DIALOG_DATA) private data: any
+  ) { }
+
+  get originName() {
+    return this.data.originName || 'this origin';
+  }
+
+  ok() {
+    this.ref.close(true);
+  }
+
+  cancel() {
+    this.ref.close(false);
+  }
+}

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
@@ -51,6 +51,13 @@
         </li>
       </ul>
     </section>
+
+    <section id="dfo-section">
+      <button mat-stroked-button color="warn">
+        <span>Depart from Origin</span>
+      </button>
+    </section>
+
   </div>
   <aside>
     <h3>About Members</h3>

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
@@ -53,7 +53,7 @@
     </section>
 
     <section id="dfo-section">
-      <button mat-stroked-button color="warn" *ngIf="!isOriginOwner">
+      <button mat-raised-button color="basic" *ngIf="!isOriginOwner">
         Depart from Origin
       </button>
     </section>

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
@@ -53,7 +53,7 @@
     </section>
 
     <section id="dfo-section">
-      <button mat-raised-button color="basic" *ngIf="!isOriginOwner">
+      <button mat-raised-button color="basic" *ngIf="!isOriginOwner" (click)="departFromOrigin()">
         Depart from Origin
       </button>
     </section>

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
@@ -53,8 +53,8 @@
     </section>
 
     <section id="dfo-section">
-      <button mat-stroked-button color="warn">
-        <span>Depart from Origin</span>
+      <button mat-stroked-button color="warn" *ngIf="!isOriginOwner">
+        Depart from Origin
       </button>
     </section>
 

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -97,8 +97,8 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
     return this.store.getState().session.token;
   }
 
-  private get self() {
-    return this.store.getState().users.current.profile.name;
+  private get isPrivate() {
+    return this.store.getState().origins.current.default_package_visibility === 'private' ? true : false;
   }
 
   canDelete(member) {
@@ -143,7 +143,11 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
         if (confirmed) {
           this.store.dispatch(departOrigin(this.origin.name, this.token, (originName) => {
             this.router.navigateByUrl('/', { skipLocationChange: true }).then(() => {
-              this.router.navigate(['/origins', originName]);
+              if (this.isPrivate) {
+                this.router.navigate(['/origins']);
+              } else {
+                this.router.navigate(['/origins', originName]);
+              }
             });
           }));
         }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -73,6 +73,10 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
     return this.store.getState().origins.currentPendingInvitations;
   }
 
+  get isOriginOwner() {
+    return this.store.getState().users.current.profile.id === this.store.getState().origins.current.owner_id;
+  }
+
   get members(): List<Object> {
     return this.store.getState().origins.currentMembers;
   }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -139,7 +139,7 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
       .afterClosed()
       .subscribe((confirmed) => {
         if (confirmed) {
-          this.store.dispatch(departOrigin(this.origin.name, this.self, this.token));
+          this.store.dispatch(departOrigin(this.origin.name, this.token));
         }
       });
   }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -131,7 +131,7 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
     });
   }
 
-  departFromOrigin() {
+  departFromOrigin(): void {
     const data = {
       originName: this.origin.name
     };
@@ -155,7 +155,7 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
     field.markAsPristine();
   }
 
-  private departureRouting(isPrivate, originName) {
+  private departureRouting(isPrivate: boolean, originName: string): void {
     // Check to see if the origin has default package visibility of private and route accordingly
     if (isPrivate) {
       this.router.navigateByUrl('/origins');

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -141,8 +141,10 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
       .afterClosed()
       .subscribe((confirmed) => {
         if (confirmed) {
-          this.store.dispatch(departOrigin(this.origin.name, this.token, (origin) => {
-            this.router.navigate(['/origins', origin]);
+          this.store.dispatch(departOrigin(this.origin.name, this.token, (originName) => {
+            this.router.navigateByUrl('/', { skipLocationChange: true }).then(() => {
+              this.router.navigate(['/origins', originName]);
+            });
           }));
         }
       });

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -14,6 +14,7 @@
 
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormControl, FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
@@ -39,6 +40,7 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
   constructor(
     formBuilder: FormBuilder,
     private route: ActivatedRoute,
+    private router: Router,
     private store: AppStore,
     private confirmDialog: MatDialog,
     private departOriginDialog: MatDialog,
@@ -139,7 +141,9 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
       .afterClosed()
       .subscribe((confirmed) => {
         if (confirmed) {
-          this.store.dispatch(departOrigin(this.origin.name, this.token));
+          this.store.dispatch(departOrigin(this.origin.name, this.token, (origin) => {
+            this.router.navigate(['/origins', origin]);
+          }));
         }
       });
   }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -24,7 +24,7 @@ import { DepartOriginDialog } from './dialog/depart-origin.dialog';
 import { AppStore } from '../../../app.store';
 import { deleteOriginInvitation, inviteUserToOrigin } from '../../../actions/index';
 import { Origin } from '../../../records/Origin';
-import { deleteOriginMember, fetchOriginMembers, fetchOriginInvitations } from '../../../actions/index';
+import { deleteOriginMember, departOrigin, fetchOriginMembers, fetchOriginInvitations } from '../../../actions/index';
 import config from '../../../config';
 
 @Component({
@@ -95,6 +95,10 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
     return this.store.getState().session.token;
   }
 
+  private get self() {
+    return this.store.getState().users.current.profile.name;
+  }
+
   canDelete(member) {
     return this.store.getState().users.current.profile.name !== member;
   }
@@ -135,7 +139,7 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
       .afterClosed()
       .subscribe((confirmed) => {
         if (confirmed) {
-          console.log('you are being removed from the origin');
+          this.store.dispatch(departOrigin(this.origin.name, this.self, this.token));
         }
       });
   }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -123,6 +123,18 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
     });
   }
 
+  departFromOrigin() {
+    const data = {
+      heading: 'Depart from origin?',
+      body: `Departing from ${this.origin.name} will revoke your access to create packages and utilize private artifacts in this origin.`,
+      action: 'Depart from Origin'
+    };
+
+    this.confirm(data, () => {
+      console.log('depart from origin confirm clicked');
+    });
+  }
+
   submit(username: string) {
     this.store.dispatch(inviteUserToOrigin(username, this.origin.name, this.token));
     const field = this.form.get('username');

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -20,6 +20,7 @@ import { Subscription } from 'rxjs';
 import { List } from 'immutable';
 import { MatDialog } from '@angular/material';
 import { SimpleConfirmDialog } from '../../../shared/dialog/simple-confirm/simple-confirm.dialog';
+import { DepartOriginDialog } from './dialog/depart-origin.dialog';
 import { AppStore } from '../../../app.store';
 import { deleteOriginInvitation, inviteUserToOrigin } from '../../../actions/index';
 import { Origin } from '../../../records/Origin';
@@ -40,6 +41,7 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private store: AppStore,
     private confirmDialog: MatDialog,
+    private departOriginDialog: MatDialog,
     private title: Title
   ) {
     this.form = formBuilder.group({});
@@ -125,14 +127,17 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
 
   departFromOrigin() {
     const data = {
-      heading: 'Depart from origin?',
-      body: `Departing from ${this.origin.name} will revoke your access to create packages and utilize private artifacts in this origin.`,
-      action: 'Depart from Origin'
+      originName: this.origin.name
     };
 
-    this.confirm(data, () => {
-      console.log('depart from origin confirm clicked');
-    });
+    this.departOriginDialog
+      .open(DepartOriginDialog, { width: '480px', data: data })
+      .afterClosed()
+      .subscribe((confirmed) => {
+        if (confirmed) {
+          console.log('you are being removed from the origin');
+        }
+      });
   }
 
   submit(username: string) {

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.ts
@@ -142,13 +142,7 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
       .subscribe((confirmed) => {
         if (confirmed) {
           this.store.dispatch(departOrigin(this.origin.name, this.token, (originName) => {
-            this.router.navigateByUrl('/', { skipLocationChange: true }).then(() => {
-              if (this.isPrivate) {
-                this.router.navigate(['/origins']);
-              } else {
-                this.router.navigate(['/origins', originName]);
-              }
-            });
+            this.departureRouting(this.isPrivate, originName);
           }));
         }
       });
@@ -159,6 +153,17 @@ export class OriginMembersTabComponent implements OnInit, OnDestroy {
     const field = this.form.get('username');
     field.setValue('');
     field.markAsPristine();
+  }
+
+  private departureRouting(isPrivate, originName) {
+    // Check to see if the origin has default package visibility of private and route accordingly
+    if (isPrivate) {
+      this.router.navigateByUrl('/origins');
+    } else {
+      this.router.navigateByUrl('/', { skipLocationChange: true }).then(() => {
+        this.router.navigate(['/origins', originName]);
+      });
+    }
   }
 
   private confirm(data, then) {

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.spec.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.spec.ts
@@ -27,6 +27,7 @@ import { Origin } from '../../../records/Origin';
 import { OriginMembersTabComponent } from './origin-members-tab.component';
 import * as actions from '../../../actions';
 
+
 class MockAppStore {
   getState() {
     return {
@@ -61,7 +62,7 @@ class MockAppStore {
 
 class MockDialog { }
 
-describe('OriginMembersTabComponent', () => {
+fdescribe('OriginMembersTabComponent', () => {
   let fixture: ComponentFixture<OriginMembersTabComponent>;
   let component: OriginMembersTabComponent;
   let element: DebugElement;
@@ -87,7 +88,7 @@ describe('OriginMembersTabComponent', () => {
         { provide: AppStore, useValue: store },
         { provide: MatDialog, useClass: MockDialog }
       ]
-    });
+    }).compileComponents();
 
     fixture = TestBed.createComponent(OriginMembersTabComponent);
     component = fixture.componentInstance;
@@ -103,11 +104,29 @@ describe('OriginMembersTabComponent', () => {
 
   describe('departing an origin', () => {
 
-    it('removes the user from the origin', () => {
-      // component.departFromOrigin();
-      // fixture.detectChanges();
+    it('shows a depart origin button when user is not the owner', () => {
+      // console.log('*************');
+      // console.log(component.isOriginOwner);
+      fixture.detectChanges();
+      let departButton = fixture.debugElement.query(By.css('#dfo-section button'));
+      expect(departButton).toBeTruthy();
+    });
 
-      // expect(store.dispatch).toHaveBeenCalled();
+    it('opens up a modal when depart button is clicked', () => {
+      element.query(By.css('#dfo-section button')).nativeElement.click();
+      fixture.detectChanges();
+      const modalWindow = element.query(By.css('.dialog.depart-origin'));
+
+      expect(modalWindow).toBeTruthy();
+    });
+
+    it('removes the user from the origin when the button is clicked', () => {
+
+      // expect() // user to be gone
+    });
+
+    it('reloads the page after departure', () => {
+      // expect page reload
     });
   });
 

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.spec.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.spec.ts
@@ -14,13 +14,10 @@
 
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component, DebugElement } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { By } from '@angular/platform-browser';
 import { MatDialog } from '@angular/material';
 import { List } from 'immutable';
-import { ActivatedRoute, Router } from '@angular/router';
-import { Observable } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
 import { AppStore } from '../../../app.store';
 import { Origin } from '../../../records/Origin';
@@ -62,17 +59,16 @@ class MockAppStore {
 
 class MockDialog { }
 
-fdescribe('OriginMembersTabComponent', () => {
+describe('OriginMembersTabComponent', () => {
   let fixture: ComponentFixture<OriginMembersTabComponent>;
   let component: OriginMembersTabComponent;
   let element: DebugElement;
   let store: MockAppStore;
 
-  beforeEach(() => {
+  beforeEach( () => {
 
     store = new MockAppStore();
     spyOn(store, 'dispatch');
-    spyOn(actions, 'departOrigin');
 
     TestBed.configureTestingModule({
       imports: [
@@ -101,34 +97,4 @@ fdescribe('OriginMembersTabComponent', () => {
       expect(component).toBeTruthy();
     });
   });
-
-  describe('departing an origin', () => {
-
-    it('shows a depart origin button when user is not the owner', () => {
-      // console.log('*************');
-      // console.log(component.isOriginOwner);
-      fixture.detectChanges();
-      let departButton = fixture.debugElement.query(By.css('#dfo-section button'));
-      expect(departButton).toBeTruthy();
-    });
-
-    it('opens up a modal when depart button is clicked', () => {
-      element.query(By.css('#dfo-section button')).nativeElement.click();
-      fixture.detectChanges();
-      const modalWindow = element.query(By.css('.dialog.depart-origin'));
-
-      expect(modalWindow).toBeTruthy();
-    });
-
-    it('removes the user from the origin when the button is clicked', () => {
-
-      // expect() // user to be gone
-    });
-
-    it('reloads the page after departure', () => {
-      // expect page reload
-    });
-  });
-
-
 });

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.spec.ts
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.spec.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Component, DebugElement } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { MatDialog } from '@angular/material';
+import { List } from 'immutable';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { MockComponent } from 'ng2-mock-component';
+import { AppStore } from '../../../app.store';
+import { Origin } from '../../../records/Origin';
+import { OriginMembersTabComponent } from './origin-members-tab.component';
+import * as actions from '../../../actions';
+
+class MockAppStore {
+  getState() {
+    return {
+      session: {
+        token: 'token'
+      },
+      oauth: {
+        token: 'token'
+      },
+      origins: {
+        mine: List([Origin({ name: 'test' })]),
+        current: {
+          owner_id: 111111,
+          default_package_visibility: 'public'
+        }
+      },
+      users: {
+        current: {
+          profile: {
+            id: 123456
+          }
+        }
+      },
+      app: {
+        name: 'Habitat'
+      }
+    };
+  }
+
+  dispatch() { }
+}
+
+class MockDialog { }
+
+describe('OriginMembersTabComponent', () => {
+  let fixture: ComponentFixture<OriginMembersTabComponent>;
+  let component: OriginMembersTabComponent;
+  let element: DebugElement;
+  let store: MockAppStore;
+
+  beforeEach(() => {
+
+    store = new MockAppStore();
+    spyOn(store, 'dispatch');
+    spyOn(actions, 'departOrigin');
+
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        FormsModule,
+        ReactiveFormsModule
+      ],
+      declarations: [
+        OriginMembersTabComponent,
+        MockComponent({ selector: 'hab-icon', inputs: ['symbol', 'cancel'] })
+      ],
+      providers: [
+        { provide: AppStore, useValue: store },
+        { provide: MatDialog, useClass: MockDialog }
+      ]
+    });
+
+    fixture = TestBed.createComponent(OriginMembersTabComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+  });
+
+  describe('component', () => {
+
+    it('should exist', () => {
+      expect(component).toBeTruthy();
+    });
+  });
+
+  describe('departing an origin', () => {
+
+    it('removes the user from the origin', () => {
+      // component.departFromOrigin();
+      // fixture.detectChanges();
+
+      // expect(store.dispatch).toHaveBeenCalled();
+    });
+  });
+
+
+});

--- a/components/builder-web/app/origin/origin-page/origin-page.module.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page.module.ts
@@ -20,6 +20,7 @@ import { RouterModule } from '@angular/router';
 import { MatTabsModule, MatRadioModule, MatButtonModule, MatDialogModule } from '@angular/material';
 import { IntegrationDeleteConfirmDialog } from './origin-integrations-tab/dialog/integration-delete-confirm/integration-delete-confirm.dialog';
 import { GenerateKeysConfirmDialog } from './origin-keys-tab/dialog/generate-keys-confirm/generate-keys-confirm.dialog';
+import { DepartOriginDialog } from './origin-members-tab/dialog/depart-origin.dialog';
 import { KeyAddFormDialog } from './origin-keys-tab/key-add-form/key-add-form.dialog';
 import { OriginPageRoutingModule } from './origin-page-routing.module';
 import { OriginPageComponent } from './origin-page.component';
@@ -51,6 +52,7 @@ export const imports = [
 export const declarations = [
   IntegrationCredentialsFormDialog,
   GenerateKeysConfirmDialog,
+  DepartOriginDialog,
   IntegrationDeleteConfirmDialog,
   KeyAddFormDialog,
   OriginKeysTabComponent,
@@ -67,6 +69,7 @@ export const declarations = [
 const entryComponents = [
   IntegrationCredentialsFormDialog,
   GenerateKeysConfirmDialog,
+  DepartOriginDialog,
   IntegrationDeleteConfirmDialog,
   KeyAddFormDialog
 ];


### PR DESCRIPTION
This branch allows a user to depart an origin which they are a member of, as long as they are not the owner of that origin.


To Test (Thanks @apriofrost !):

1. Navigate to the members tab of a public origin
2. If the current user is the owner of the origin, show that there is no Depart from Origin button.
3. If the current user is not the owner of the origin, show that there is a Depart from Origin button.
4. As a member (not the owner), click on the "Depart from Origin" button, a confirmation modal shows up as an overlay.
5. On the confirmation modal, click the "Cancel" button, the overlay disappears.
6. Click on the "Depart from Origin" button again. On the confirmation modal, click the Depart from Origin button.
7. See a toast notification pops up from the bottom of the window with two types of messages: successful and failure, with its corresponding body content described in the Acceptance Criteria.
8. Upon success, the user is presented with the public view of the departed origin with the packages tab selected.
9. repeat the same steps for a private origin. In step 8 shows that the user is navigated to the landing page of My Origins (https://bldr.habitat.sh/#/origins).