### PR TITLE
Swap package count to use origin_package_settings table

### DIFF
--- a/components/builder-db/src/migrations/2020-03-03-000001_origins_with_stats/up.sql
+++ b/components/builder-db/src/migrations/2020-03-03-000001_origins_with_stats/up.sql
@@ -1,0 +1,10 @@
+DROP VIEW origins_with_stats;
+
+CREATE OR REPLACE VIEW origins_with_stats AS
+    SELECT o.*, count(DISTINCT ops.name) as package_count
+        FROM origins o
+        LEFT OUTER JOIN origin_package_settings ops ON o.name = ops.origin
+        GROUP BY o.name
+        ORDER BY o.name;
+
+


### PR DESCRIPTION
This changes our origins_with_stats endpoint to look at the pkg settings table. It should be a marginally quicker query but also will take into account when a "package" has been created but no artifact built or plan connected.

Fixes #1325 