### PR TITLE
[CI] Update hab cli to version with toml download-file support

### DIFF
--- a/.expeditor/scripts/generate_bootstrap_bundle.sh
+++ b/.expeditor/scripts/generate_bootstrap_bundle.sh
@@ -79,6 +79,14 @@ readonly this_bootstrap_bundle="hab_builder_bootstrap_$(date +%Y%m%d%H%M%S)"
 
 ########################################################################
 
+echo "--- :habicat:  Updating Habitat"
+# The .toml file support for hab pkg download is not in hab provided by
+# the chefes/buildkite image. Update to the just-released version 
+hab pkg install core/hab --binlink --force 
+echo "Using $(hab --version)"
+
+echo "--- Generating bootstrap bundle"
+
 sandbox_dir="${this_bootstrap_bundle}"
 log "Downloading packages into ${sandbox_dir}"
 mkdir "${sandbox_dir}"


### PR DESCRIPTION
The version used by default in CI doesn't support the toml format of the seed file for `hab pkg download`.  This installs the just-released hab cli to be used fetch packages to generate the bootstrap bundle. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>