### PR TITLE
handle uploading keys after building api and worker services

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -91,6 +91,12 @@ _build-builder-component() {
   echo "builder-$component build succeeded"
 
   start-builder "$component"
+  case "${component}" in
+    api | worker)
+      generate_bldr_keys && upload_github_keys;;
+    *)
+      ;;
+  esac
 }
 build-builder-component() { stop-on-failure _build-builder-component "$@"; }
 


### PR DESCRIPTION
This PR handles the scenario where the user enters the studio and first runs `bb` expecting all services to be built, then started. However, they find that `builder-api` and `builder-worker` services are infinitely waiting on keys.

With this change, a `bb` invocation upon first entering a studio will ensure that these two services are functionally working. Additionally, if a user builds either of these two services individually, we will also ensure the keys have been uploaded after the build.

This is a minor but important scenario that wasn't handled in https://github.com/habitat-sh/builder/pull/1314

Signed-off-by: Jeremy J. Miller <jm@chef.io>