### PR TITLE
Display package viz settings in sidebar instead of legacy project viz

### DIFF
--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
@@ -23,8 +23,8 @@
         Auto-build {{ autoBuildSetting }}
       </li>
       <li>
-        <hab-visibility-icon [visibility]="project.visibility" prefix="Default Package Visibility:"></hab-visibility-icon>
-        {{ project.visibility | titlecase }} packages
+        <hab-visibility-icon [visibility]="visibility" prefix="Default Package Visibility:"></hab-visibility-icon>
+        {{ visibility | titlecase }} packages
       </li>
     </ul>
   </section>

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
@@ -108,4 +108,16 @@ export class PackageSidebarComponent {
   get isBuildable() {
     return this.isOriginMember && this.hasPlan && !this.targetIsMac && !this.building;
   }
+
+  get packageSettings() {
+    return this.store.getState().packages.currentSettings;
+  }
+
+  get defaultVisibility() {
+    return this.store.getState().origins.current.default_package_visibility;
+  }
+
+  get visibility() {
+    return this.packageSettings ? this.packageSettings.visibility : this.defaultVisibility;
+  }
 }


### PR DESCRIPTION
Updates the package sidebar to display visibility settings from the package settings endpoint/table instead of displaying the visibility of individual projects.

Signed-off-by: Scott Christopherson <scott@chef.io>