### PR TITLE
required update of our Windows AMI

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -519,8 +519,8 @@ resource "aws_instance" "linux2-worker" {
 }
 
 resource "aws_instance" "windows-worker" {
-  // Windows_Server-2019-English-Full-ContainersLatest-2019.10.09
-  ami           = "ami-0a6b38f2d62c0cc94"
+  // Windows_Server-2019-English-Full-ContainersLatest-2020.02.12
+  ami           = "ami-001589977a146ef31"
   instance_type = var.instance_size_windows_worker
   key_name      = var.aws_key_pair
 


### PR DESCRIPTION
Came to find out our Windows AMI was no longer available:
```
module.builder_environment.module.builder.aws_instance.windows-worker[0]: Creating...
Error: Expected 1 AMI for ID: ami-0a6b38f2d62c0cc94 (No images found for AMI ami-0a6b38f2d62c0cc94)
```

This PR provides an update to the latest image of the same type.

Signed-off-by: Jeremy J. Miller <jm@chef.io>