### PR TITLE
x86_64-linux x86_64-linux-kernel2 hab binaries to bootstrap bundle

### DIFF
--- a/terraform/scripts/install_base_packages.sh
+++ b/terraform/scripts/install_base_packages.sh
@@ -125,7 +125,7 @@ ${tar} --extract \
 
 # This is the hab binary from the bootstrap bundle. We'll use this to
 # install everything.
-hab_bootstrap_bin=${tmpdir}/bin/hab
+hab_bootstrap_bin="${tmpdir}/bin/hab-${pkg_target}"
 
 ########################################################################
 # Install the desired packages


### PR DESCRIPTION
The purpose of this PR is to include both linux platform target `hab` binaries in the bootstrap bundle such that we can utilize the appropriate target binary when installing artifacts.

`bin/hab` will remain in place, though as a symlink to `bin/hab-x86_64-linux`

```
root@ip-10-0-0-76:/home/ubuntu# ls -l hab_bootstrap_1584031400/bin/
total 36284
lrwxrwxrwx 1 root root       16 Mar 12 18:55 hab -> hab-x86_64-linux
-rwxr-xr-x 1 root root 18540176 Mar  3 16:39 hab-x86_64-linux
-rwxr-xr-x 1 root root 18611160 Mar  3 16:39 hab-x86_64-linux-kernel2
root@ip-10-0-0-76:/home/ubuntu#
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>