### PR TITLE
Fix some uses of Duration::as_secs to f64

### DIFF
--- a/components/builder-api/src/server/migrations.rs
+++ b/components/builder-api/src/server/migrations.rs
@@ -61,7 +61,7 @@ pub fn migrate_to_encrypted(conn: &PgConnection, key_path: &PathBuf) -> Result<(
     }
 
     warn!("migrate_to_encrypted complete in {} sec, updated {}, skipped {} as already updated",
-          start_time.elapsed().as_secs(),
+          start_time.elapsed().as_secs_f64(),
           updated_keys,
           skipped_keys);
     Ok(())

--- a/components/builder-api/src/server/services/s3.rs
+++ b/components/builder-api/src/server/services/s3.rs
@@ -231,7 +231,7 @@ impl S3Handler {
             Ok(_) => {
                 info!("Upload completed for {} (in {} sec):",
                       path_attr,
-                      start_time.elapsed().as_secs());
+                      start_time.elapsed().as_secs_f64());
                 Ok(())
             }
             Err(e) => {
@@ -304,7 +304,7 @@ impl S3Handler {
                     Ok(_) => {
                         info!("Upload completed for {} (in {} sec):",
                               path_attr,
-                              start_time.elapsed().as_secs());
+                              start_time.elapsed().as_secs_f64());
                         Ok(())
                     }
                     Err(e) => {

--- a/components/builder-core/src/logger.rs
+++ b/components/builder-core/src/logger.rs
@@ -91,11 +91,11 @@ impl Logger {
             let offset = start.signed_duration_since(group_start)
                               .to_std()
                               .unwrap_or(Duration::from_secs(0))
-                              .as_secs();
+                              .as_secs_f64();
             let duration = stop.signed_duration_since(start)
                                .to_std()
                                .unwrap_or(Duration::from_secs(0))
-                               .as_secs();
+                               .as_secs_f64();
 
             format!("{},{},{},{}",
                     offset,

--- a/components/builder-jobsrv/src/server/handlers.rs
+++ b/components/builder-jobsrv/src/server/handlers.rs
@@ -274,7 +274,7 @@ fn populate_build_projects(msg: &jobsrv::JobGroupSpec,
                 Some(rdeps) => {
                     debug!("Graph rdeps: {} items ({} sec)\n",
                            rdeps.len(),
-                           start_time.elapsed().as_secs());
+                           start_time.elapsed().as_secs_f64());
                     for dep in rdeps {
                         excluded.insert(dep.0.clone());
                     }
@@ -345,7 +345,7 @@ pub fn job_group_create(req: &RpcMessage, state: &AppState) -> Result<RpcMessage
             }
         };
         debug!("Resolved project name: {} sec\n",
-               start_time.elapsed().as_secs());
+               start_time.elapsed().as_secs_f64());
         ret
     };
 
@@ -376,7 +376,7 @@ pub fn job_group_create(req: &RpcMessage, state: &AppState) -> Result<RpcMessage
             Some(rdeps) => {
                 debug!("Graph rdeps: {} items ({} sec)\n",
                        rdeps.len(),
-                       start_time.elapsed().as_secs());
+                       start_time.elapsed().as_secs_f64());
                 populate_build_projects(&msg, state, &rdeps, &mut projects);
             }
             None => {
@@ -637,7 +637,7 @@ pub fn job_graph_package_create(req: &RpcMessage, state: &AppState) -> Result<Rp
     debug!("Extended graph, nodes: {}, edges: {} ({} sec)\n",
            ncount,
            ecount,
-           start_time.elapsed().as_secs());
+           start_time.elapsed().as_secs_f64());
 
     RpcMessage::make(package).map_err(Error::BuilderCore)
 }
@@ -665,7 +665,7 @@ pub fn job_graph_package_precreate(req: &RpcMessage, state: &AppState) -> Result
 
         debug!("Graph pre-check: {} ({} sec)\n",
                ret,
-               start_time.elapsed().as_secs());
+               start_time.elapsed().as_secs_f64());
 
         ret
     };

--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -173,7 +173,7 @@ pub fn run(config: Config) -> Result<()> {
                           feat::is_enabled(feat::BuildDeps));
 
     info!("Graph build stats ({} sec):",
-          start_time.elapsed().as_secs());
+          start_time.elapsed().as_secs_f64());
 
     for stat in res {
         info!("Target {}: {} nodes, {} edges",


### PR DESCRIPTION
When we cleaned up our time code, we generally used the
Duration::as_secs api; however that rounds to the nearest integer. For
quick things that isn't too useful.

This is a selective replacement of as_secs with as_secs_f64 where it
seemed to make sense.

Signed-off-by: Mark Anderson <mark@chef.io>