### PR TITLE
increase max JsonConfig playload size for jobsrv /rpc endpoint

### DIFF
--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -1193,7 +1193,7 @@ fn do_upload_package_finish(req: &HttpRequest,
                         );
                     }
                     Err(err) => {
-                        debug!("Failed to create job graph package, err={:?}", err);
+                        warn!("Failed to create job graph package, err={:?}", err);
                         return err.into();
                     }
                 }

--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -55,7 +55,7 @@ use std::{collections::{HashMap,
                  RwLock},
           time::Instant};
 
-// Change max size of JsonConfig payload. By default max size is 32Kb
+// Set a max size for JsonConfig payload. Default is 32Kb
 const MAX_JSON_PAYLOAD: usize = 262_144;
 
 features! {

--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -56,7 +56,7 @@ use std::{collections::{HashMap,
           time::Instant};
 
 // Change max size of JsonConfig payload. By default max size is 32Kb
-const MAX_JSON_PAYLOAD: usize = 262144;
+const MAX_JSON_PAYLOAD: usize = 262_144;
 
 features! {
     pub mod feat {

--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -41,7 +41,8 @@ use actix_web::{dev::Body,
                 middleware::Logger,
                 web::{self,
                       Data,
-                      Json},
+                      Json,
+                      JsonConfig},
                 App,
                 HttpResponse,
                 HttpServer};
@@ -53,6 +54,9 @@ use std::{collections::{HashMap,
           sync::{Arc,
                  RwLock},
           time::Instant};
+
+// Change max size of JsonConfig payload. By default max size is 32Kb
+const MAX_JSON_PAYLOAD: usize = 262144;
 
 features! {
     pub mod feat {
@@ -195,7 +199,8 @@ pub fn run(config: Config) -> Result<()> {
     HttpServer::new(move || {
         let app_state = AppState::new(&config, &datastore, db_pool.clone(), &graph_arc);
 
-        App::new().data(app_state)
+        App::new().data(JsonConfig::default().limit(MAX_JSON_PAYLOAD))
+                  .data(app_state)
                   .wrap(Logger::default().exclude("/status"))
                   .service(web::resource("/status").route(web::get().to(status))
                                                    .route(web::head().to(status)))


### PR DESCRIPTION
closes #1365 

This increases the max payload size to 256KB to hopefully eliminate the following error for low-level packages that have lots of metadata:

```
Mar 25 10:42:55 ip-10-0-0-222 hab[23699]: builder-jobsrv.acceptance(O): [2020-03-25T10:42:55Z DEBUG actix_web::types::json] Failed to deserialize Json from payload. Request path: /rpc
Mar 25 10:42:55 ip-10-0-0-222 hab[23699]: builder-jobsrv.acceptance(O): [2020-03-25T10:42:55Z DEBUG actix_web::middleware::logger] Error in response: Overflow
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>