### PR TITLE
Add configuration for stalebot and noresponsebot

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 14
+# Label requiring a response
+responseRequiredLabel: "Needs Information"
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 365
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 400
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "C - Bug"
+# Label to use when marking an issue as stale
+staleLabel: Stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.
+  We value your input and contribution.
+  Please leave a comment if this issue still affects you.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed after being stale for 400 days.
+  We still value your input and contribution.
+  Please re-open the issue if desired and leave a comment with details.


### PR DESCRIPTION
This adds configuration for probot/stalebot and probot/no-responsebot.     Once the bots are added to the repository, this PR can be merged if we are happy with the configuration. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>