### PR TITLE
clean up data modeling issues

### DIFF
--- a/components/builder-db/src/migrations/2020-03-27-193418_origin_members_dupe_fixes/up.sql
+++ b/components/builder-db/src/migrations/2020-03-27-193418_origin_members_dupe_fixes/up.sql
@@ -1,0 +1,24 @@
+DELETE FROM
+  origin_members T1
+WHERE
+  EXISTS (
+    SELECT
+      1
+    FROM
+      origin_members T2
+    WHERE
+      T1.account_id = T2.account_id
+      AND T1.origin = T2.origin
+      AND T1.ctid > T2.ctid
+  );
+
+ALTER TABLE
+  origin_members
+ADD
+  CONSTRAINT origin_members_origin_account_id_key UNIQUE(origin, account_id);
+
+ALTER TABLE
+  origin_invitations
+ADD
+  CONSTRAINT origin_invitations_origin_account_id_key UNIQUE(origin, account_id);
+

--- a/components/builder-db/src/migrations/2020-03-27-193418_origin_members_dupe_fixes/up.sql
+++ b/components/builder-db/src/migrations/2020-03-27-193418_origin_members_dupe_fixes/up.sql
@@ -9,7 +9,10 @@ WHERE
     WHERE
       T1.account_id = T2.account_id
       AND T1.origin = T2.origin
-      AND T1.ctid > T2.ctid
+      AND (
+        T1.created_at > T2.created_at
+        OR T1.ctid > T2.ctid
+      )
   );
 
 ALTER TABLE


### PR DESCRIPTION
This PR corrects several issues discovered during preliminary RBAC work:

* adds uniqueness constraints to the origin_members and
origin_invitations tables
* removes duplicate entries from the origin_members table

With these changes, users will not be able to send multiple invitations
to a specific user for any origin. As a result, users should no longer
be able to accept multiple invitations to the same origin which
previously resulted in them having multiple entries for the same origin
in the origins_members table.

As mentioned, the duplicate entries that do currently exist in the origin_members
table will be deleted. We've identified that the calling functions,
including the web UI, handle conflict errors gracefully.

The migrations have been vetted and tested both in local builder studio
and in Acceptance, via transaction and rollback.

Signed-off-by: Jeremy J. Miller <jm@chef.io>