### PR TITLE
Reduce connect-plan modal z-index

### DIFF
--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -113,7 +113,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 9999;
+    z-index: 999;
     background: $white;
     overflow: scroll;
 


### PR DESCRIPTION
Fixes https://github.com/habitat-sh/builder/issues/1387

Connect-plan modal had an overly large z-index value. NG material overlays start their z-indexes at `1000` which is why the docker-settings overlay was being hidden by `9999` z-index connect-plan.

![a](https://user-images.githubusercontent.com/479121/79025732-d41e4400-7b43-11ea-9367-267fc6f1e349.gif)


Signed-off-by: Scott Christopherson <scott@chef.io>