### PR TITLE
First pass at adding db metrics

### DIFF
--- a/components/builder-db/src/metrics.rs
+++ b/components/builder-db/src/metrics.rs
@@ -34,10 +34,24 @@ impl metrics::Metric for Counter {
 
 pub enum Histogram {
     DbCallTime,
+    CountOriginPackagesCallTime,
     GetAllLatestCallTime,
+    GetAllPackageCallTime,
+    GetGroupPackageCallTime,
     GetLatestChannelPackageCallTime,
     GetLatestPackageCallTime,
+    GetPackageCallTime,
+    GetWithoutTargetPackageCallTime,
     ListAllChannelPackagesCallTime,
+    ListChannelPackagesCallTime,
+    ListDistinctForOriginPackageCallTime,
+    ListDistinctPackageCallTime,
+    ListPackageChannelsPackageCallTime,
+    ListPackagePlatformsCallTime,
+    ListPackageVersionsPackageCallTime,
+    ListPackagesCallTime,
+    SearchPackagesCallTime,
+    SearchDistinctPackagesCallTime,
 }
 
 impl metrics::HistogramMetric for Histogram {}
@@ -46,13 +60,41 @@ impl metrics::Metric for Histogram {
     fn id(&self) -> Cow<'static, str> {
         match *self {
             Histogram::DbCallTime => "db-call.call-time".into(),
+            Histogram::CountOriginPackagesCallTime => {
+                "db-call.count-origin-packages-call-time".into()
+            }
             Histogram::GetAllLatestCallTime => "db-call.all-latest-call-time".into(),
+            Histogram::GetAllPackageCallTime => "db-call.get-all-package-call-time".into(),
+            Histogram::GetGroupPackageCallTime => "db-call.get-group-package-call-time".into(),
             Histogram::GetLatestChannelPackageCallTime => {
                 "db-call.latest-channel-pkg-call-time".into()
             }
             Histogram::GetLatestPackageCallTime => "db-call.latest-pkg-call-time".into(),
+            Histogram::GetPackageCallTime => "db-call.get-pkg-call-time".into(),
+            Histogram::GetWithoutTargetPackageCallTime => {
+                "db-call.get-without-target-pkg-call-time".into()
+            }
             Histogram::ListAllChannelPackagesCallTime => {
                 "db-call.list-all-channel-pkgs-call-time".into()
+            }
+            Histogram::ListChannelPackagesCallTime => "db-call.list-channel-pkgs-call-time".into(),
+            Histogram::ListDistinctPackageCallTime => "db-call.list-distinct-pkgs-call-time".into(),
+            Histogram::ListDistinctForOriginPackageCallTime => {
+                "db-call.list-distinct-for-origin-pkgs-call-time".into()
+            }
+            Histogram::ListPackageChannelsPackageCallTime => {
+                "db-call.list-package-channels-call-time".into()
+            }
+            Histogram::ListPackagesCallTime => "db-call.list-packages-call-time".into(),
+            Histogram::ListPackageVersionsPackageCallTime => {
+                "db-call.list-package-versions-call-time".into()
+            }
+            Histogram::ListPackagePlatformsCallTime => {
+                "db-call.list-package-versions-call-time".into()
+            }
+            Histogram::SearchPackagesCallTime => "db-call.search-packages-call-time".into(),
+            Histogram::SearchDistinctPackagesCallTime => {
+                "db-call.search-distinct-packages-call-time".into()
             }
         }
     }

--- a/components/builder-db/src/metrics.rs
+++ b/components/builder-db/src/metrics.rs
@@ -34,24 +34,24 @@ impl metrics::Metric for Counter {
 
 pub enum Histogram {
     DbCallTime,
-    CountOriginPackagesCallTime,
-    GetAllLatestCallTime,
-    GetAllPackageCallTime,
-    GetGroupPackageCallTime,
-    GetLatestChannelPackageCallTime,
-    GetLatestPackageCallTime,
-    GetPackageCallTime,
-    GetWithoutTargetPackageCallTime,
-    ListAllChannelPackagesCallTime,
-    ListChannelPackagesCallTime,
-    ListDistinctForOriginPackageCallTime,
-    ListDistinctPackageCallTime,
-    ListPackageChannelsPackageCallTime,
-    ListPackagePlatformsCallTime,
-    ListPackageVersionsPackageCallTime,
-    ListPackagesCallTime,
-    SearchPackagesCallTime,
-    SearchDistinctPackagesCallTime,
+    ChannelGetLatestPackageCallTime,
+    ChannelListAllPackagesCallTime,
+    ChannelListPackagesCallTime,
+    PackageCountOriginPackages,
+    PackageGetAllCallTime,
+    PackageGetAllLatestCallTime,
+    PackageGetCallTime,
+    PackageGetGroupCallTime,
+    PackageGetLatestCallTime,
+    PackageGetWithoutTargetCallTime,
+    PackageListCallTime,
+    PackageListDistinctCallTime,
+    PackageListDistinctForOriginCallTime,
+    PackageListPackageChannelsCallTime,
+    PackageListPackagePlatformsCallTime,
+    PackageListPackageVersionsCallTime,
+    PackageSearchCallTime,
+    PackageSearchDistinctCallTime,
 }
 
 impl metrics::HistogramMetric for Histogram {}
@@ -60,41 +60,49 @@ impl metrics::Metric for Histogram {
     fn id(&self) -> Cow<'static, str> {
         match *self {
             Histogram::DbCallTime => "db-call.call-time".into(),
-            Histogram::CountOriginPackagesCallTime => {
-                "db-call.count-origin-packages-call-time".into()
+
+            Histogram::ChannelGetLatestPackageCallTime => {
+                "db-call.channel-get-latest-package-call-time".into()
             }
-            Histogram::GetAllLatestCallTime => "db-call.all-latest-call-time".into(),
-            Histogram::GetAllPackageCallTime => "db-call.get-all-package-call-time".into(),
-            Histogram::GetGroupPackageCallTime => "db-call.get-group-package-call-time".into(),
-            Histogram::GetLatestChannelPackageCallTime => {
-                "db-call.latest-channel-pkg-call-time".into()
+            Histogram::ChannelListAllPackagesCallTime => {
+                "db-call.channel-list-all-packages-call-time".into()
             }
-            Histogram::GetLatestPackageCallTime => "db-call.latest-pkg-call-time".into(),
-            Histogram::GetPackageCallTime => "db-call.get-pkg-call-time".into(),
-            Histogram::GetWithoutTargetPackageCallTime => {
-                "db-call.get-without-target-pkg-call-time".into()
+            Histogram::ChannelListPackagesCallTime => {
+                "db-call.channel-list-packages-call-time".into()
             }
-            Histogram::ListAllChannelPackagesCallTime => {
-                "db-call.list-all-channel-pkgs-call-time".into()
+
+            Histogram::PackageCountOriginPackages => {
+                "db-call.package-count-origin-packages-call-time".into()
             }
-            Histogram::ListChannelPackagesCallTime => "db-call.list-channel-pkgs-call-time".into(),
-            Histogram::ListDistinctPackageCallTime => "db-call.list-distinct-pkgs-call-time".into(),
-            Histogram::ListDistinctForOriginPackageCallTime => {
-                "db-call.list-distinct-for-origin-pkgs-call-time".into()
+            Histogram::PackageGetAllCallTime => "db-call.package-get-all-call-time".into(),
+            Histogram::PackageGetAllLatestCallTime => {
+                "db-call.package-get-all-latest-call-time".into()
             }
-            Histogram::ListPackageChannelsPackageCallTime => {
-                "db-call.list-package-channels-call-time".into()
+            Histogram::PackageGetCallTime => "db-call.package-get-call-time".into(),
+            Histogram::PackageGetGroupCallTime => "db-call.package-get-group-call-time".into(),
+            Histogram::PackageGetLatestCallTime => "db-call.package-get-latest-call-time".into(),
+            Histogram::PackageGetWithoutTargetCallTime => {
+                "db-call.package-get-without-target-call-time".into()
             }
-            Histogram::ListPackagesCallTime => "db-call.list-packages-call-time".into(),
-            Histogram::ListPackageVersionsPackageCallTime => {
-                "db-call.list-package-versions-call-time".into()
+            Histogram::PackageListCallTime => "db-call.package-list-call-time".into(),
+            Histogram::PackageListDistinctCallTime => {
+                "db-call.package-list-distinct-call-time".into()
             }
-            Histogram::ListPackagePlatformsCallTime => {
-                "db-call.list-package-versions-call-time".into()
+            Histogram::PackageListDistinctForOriginCallTime => {
+                "db-call.package-list-distinct-for-origin-call-time".into()
             }
-            Histogram::SearchPackagesCallTime => "db-call.search-packages-call-time".into(),
-            Histogram::SearchDistinctPackagesCallTime => {
-                "db-call.search-distinct-packages-call-time".into()
+            Histogram::PackageListPackageChannelsCallTime => {
+                "db-call.list-package-list-package-channels-call-time".into()
+            }
+            Histogram::PackageListPackagePlatformsCallTime => {
+                "db-call.package-list-package-platforms-call-time".into()
+            }
+            Histogram::PackageListPackageVersionsCallTime => {
+                "db-call.package-list-package-versions-call-time".into()
+            }
+            Histogram::PackageSearchCallTime => "db-call.package-search-call-time".into(),
+            Histogram::PackageSearchDistinctCallTime => {
+                "db-call.package-search-distinct-call-time".into()
             }
         }
     }

--- a/components/builder-db/src/models/channel.rs
+++ b/components/builder-db/src/models/channel.rs
@@ -154,7 +154,7 @@ impl Channel {
         trace!("DBCall channel::get_latest_package time: {} ms",
                duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::GetLatestChannelPackageCallTime.set(duration_millis as f64);
+        Histogram::ChannelGetLatestPackageCallTime.set(duration_millis as f64);
 
         result
     }
@@ -183,7 +183,7 @@ impl Channel {
         let duration_millis = start_time.elapsed().as_millis();
         trace!("DBCall channel::list_package time: {} ms", duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::ListChannelPackagesCallTime.set(duration_millis as f64);
+        Histogram::ChannelListPackagesCallTime.set(duration_millis as f64);
         result
     }
 
@@ -209,7 +209,7 @@ impl Channel {
         trace!("DBCall channel::list_all_packages time: {} ms",
                duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::ListAllChannelPackagesCallTime.set(duration_millis as f64);
+        Histogram::ChannelListAllPackagesCallTime.set(duration_millis as f64);
         result
     }
 
@@ -225,13 +225,12 @@ impl Channel {
                             conn: &PgConnection)
                             -> QueryResult<usize> {
         Counter::DBCall.increment();
-        let insert: Vec<(_, _)> =
-            package_ids.iter()
-                       .map(|id| {
-                           (origin_channel_packages::package_id.eq(id),
+        let insert: Vec<(_, _)> = package_ids.iter()
+                                             .map(|id| {
+                                                 (origin_channel_packages::package_id.eq(id),
                             origin_channel_packages::channel_id.eq(channel_id))
-                       })
-                       .collect();
+                                             })
+                                             .collect();
         diesel::insert_into(origin_channel_packages::table).values(insert)
                                                            .on_conflict_do_nothing()
                                                            .execute(conn)

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -414,7 +414,7 @@ impl Package {
         trace!("DBCall package::get_without_target time: {} ms",
                duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::GetWithoutTargetPackageCallTime.set(duration_millis as f64);
+        Histogram::PackageGetWithoutTargetCallTime.set(duration_millis as f64);
         result
     }
 
@@ -430,7 +430,7 @@ impl Package {
         let duration_millis = start_time.elapsed().as_millis();
         trace!("DBCall package::get time: {} ms", duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::GetPackageCallTime.set(duration_millis as f64);
+        Histogram::PackageGetCallTime.set(duration_millis as f64);
         result
     }
 
@@ -455,7 +455,7 @@ impl Package {
         let duration_millis = start_time.elapsed().as_millis();
         trace!("DBCall package::get_group time: {} ms", duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::GetGroupPackageCallTime.set(duration_millis as f64);
+        Histogram::PackageGetGroupCallTime.set(duration_millis as f64);
         result
     }
 
@@ -471,7 +471,7 @@ impl Package {
         let duration_millis = start_time.elapsed().as_millis();
         trace!("DBCall package::get_all time: {} ms", duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::GetAllPackageCallTime.set(duration_millis as f64);
+        Histogram::PackageGetAllCallTime.set(duration_millis as f64);
         result
     }
 
@@ -498,7 +498,7 @@ impl Package {
         let duration_millis = start_time.elapsed().as_millis();
         trace!("DBCall package::get_latest time: {} ms", duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::GetLatestPackageCallTime.set(duration_millis as f64);
+        Histogram::PackageGetLatestCallTime.set(duration_millis as f64);
 
         result
     }
@@ -521,7 +521,7 @@ impl Package {
         trace!("DBCall package::get_all_latest time: {} ms",
                duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::GetAllLatestCallTime.set(duration_millis as f64);
+        Histogram::PackageGetAllLatestCallTime.set(duration_millis as f64);
         result
     }
 
@@ -596,7 +596,7 @@ impl Package {
 
         let duration_millis = start_time.elapsed().as_millis();
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::ListPackagesCallTime.set(duration_millis as f64);
+        Histogram::PackageListCallTime.set(duration_millis as f64);
 
         trace!(target: "habitat_builder_api::server::resources::pkgs::versions", "Package::list for {:?}, returned {} items", pl.ident, pkgs.len());
 
@@ -634,7 +634,7 @@ impl Package {
         let duration_millis = start_time.elapsed().as_millis();
         trace!("DBCall package::list_distinct time: {} ms", duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::ListDistinctPackageCallTime.set(duration_millis as f64);
+        Histogram::PackageListDistinctCallTime.set(duration_millis as f64);
         result
     }
 
@@ -658,7 +658,7 @@ impl Package {
         trace!("DBCall package::list_distinct_for_origin time: {} ms",
                duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::ListDistinctForOriginPackageCallTime.set(duration_millis as f64);
+        Histogram::PackageListDistinctForOriginCallTime.set(duration_millis as f64);
         result
     }
 
@@ -683,7 +683,7 @@ impl Package {
         trace!("DBCall package::list_package_channels time: {} ms",
                duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::ListPackageChannelsPackageCallTime.set(duration_millis as f64);
+        Histogram::PackageListPackageChannelsCallTime.set(duration_millis as f64);
         result
     }
 
@@ -707,7 +707,7 @@ impl Package {
         trace!("DBCall package::list_package_versions time: {} ms",
                duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::ListPackageVersionsPackageCallTime.set(duration_millis as f64);
+        Histogram::PackageListPackageVersionsCallTime.set(duration_millis as f64);
         result
     }
 
@@ -723,7 +723,7 @@ impl Package {
         trace!("DBCall package::count_origin_packages time: {} ms",
                duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::CountOriginPackagesCallTime.set(duration_millis as f64);
+        Histogram::PackageCountOriginPackages.set(duration_millis as f64);
         result
     }
 
@@ -759,7 +759,7 @@ impl Package {
         let duration_millis = start_time.elapsed().as_millis();
         trace!("DBCall package::search time: {} ms", duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::SearchPackagesCallTime.set(duration_millis as f64);
+        Histogram::PackageSearchCallTime.set(duration_millis as f64);
         result
     }
 
@@ -798,7 +798,7 @@ impl Package {
         let duration_millis = start_time.elapsed().as_millis();
         trace!("DBCall package::search time: {} ms", duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::SearchDistinctPackagesCallTime.set(duration_millis as f64);
+        Histogram::PackageSearchDistinctCallTime.set(duration_millis as f64);
         result
     }
 
@@ -821,7 +821,7 @@ impl Package {
         trace!("DBCall package::list_package_platforms time: {} ms",
                duration_millis);
         Histogram::DbCallTime.set(duration_millis as f64);
-        Histogram::ListPackagePlatformsCallTime.set(duration_millis as f64);
+        Histogram::PackageListPackagePlatformsCallTime.set(duration_millis as f64);
         result
     }
 


### PR DESCRIPTION
This adds metrics to everything that queries the origin_packages table
in a way that looks likely perform poorly. This addresses issue #1391.

It follows the existing naming convention as best I could. There's a
lot of boilerplate, which seems a little bit hard to remove.

However I'd like to suggest a different convention: let's construct
the name as structname,functionname using the approprate
inflection/casing scheme. E.g. for the Packages::count_origin_packages
functionthe enum names would be PackagesCountOriginPackagesCallTime,
and the logging keys would be
db-call.packages-count-origin-packages-call-time. I find it easier to
figure out, and I believe it will make it easier to group related
statistics.

This potentially breaks existing logs, and I'd suggest we log twice,
once with the old and once with the new.

One advantage of this scheme is that I believe it makes it easier to
write a macro that would reduce the boilerplate substantially.

Signed-off-by: Mark Anderson <mark@chef.io>