### PR TITLE
accounting for other oauth providers in api run hook

### DIFF
--- a/components/builder-api/habitat/hooks/run
+++ b/components/builder-api/habitat/hooks/run
@@ -12,11 +12,14 @@ echo "_e{${#title},${#text}}:$title|$text|#api"  >/dev/udp/localhost/8125
 # Wait for the .pem file before starting the service, otherwise the service
 # continually panics in a tight loop, blocking the supervisor from writing
 # out the file.
-while ! [ -f "{{pkg.svc_files_path}}/builder-github-app.pem" ];
-do
-    echo "Waiting for builder-github-app.pem"
+# shellcheck disable=SC2050
+if [ "{{cfg.oauth.provider}}" == "github" ]; then
+  while ! [ -f "{{pkg.svc_files_path}}/builder-github-app.pem" ];
+  do
+    echo "Waiting for builder github app private key at: {{pkg.svc_files_path}}/builder-github-app.pem"
     sleep 10
-done
+  done
+fi
 
 if [ "$(whoami)" = "root" ]; then
   exec chpst \

--- a/components/builder-api/habitat/hooks/run
+++ b/components/builder-api/habitat/hooks/run
@@ -13,7 +13,7 @@ echo "_e{${#title},${#text}}:$title|$text|#api"  >/dev/udp/localhost/8125
 # continually panics in a tight loop, blocking the supervisor from writing
 # out the file.
 # shellcheck disable=SC2050
-if [ "{{cfg.oauth.provider}}" == "github" ]; then
+if [[ "{{cfg.api.features_enabled}}" =~ "jobsrv" ]]; then
   while ! [ -f "{{pkg.svc_files_path}}/builder-github-app.pem" ];
   do
     echo "Waiting for builder github app private key at: {{pkg.svc_files_path}}/builder-github-app.pem"

--- a/components/builder-api/habitat/hooks/run
+++ b/components/builder-api/habitat/hooks/run
@@ -11,7 +11,11 @@ echo "_e{${#title},${#text}}:$title|$text|#api"  >/dev/udp/localhost/8125
 
 # Wait for the .pem file before starting the service, otherwise the service
 # continually panics in a tight loop, blocking the supervisor from writing
-# out the file.
+# out the file. This only occurs if "jobsrv" is an enabled feature.
+#
+# We should handle the unwrap to account for the Err condition gracefully.
+# TODO: https://github.com/habitat-sh/builder/issues/1406
+#
 # shellcheck disable=SC2050
 if [[ "{{cfg.api.features_enabled}}" =~ "jobsrv" ]]; then
   while ! [ -f "{{pkg.svc_files_path}}/builder-github-app.pem" ];


### PR DESCRIPTION
We check to see if Jobsrv is enabled in builder-api, only then do we wait on the `builder-github-app.pem` file. 

Noticed this was an issue raised by a user in our forums: https://forums.habitat.sh/t/on-prem-builder-api-port-not-binding/1316

Signed-off-by: Jeremy J. Miller <jm@chef.io>