### PR TITLE
builder-base-plan: get version from current rev

### DIFF
--- a/support/ci/builder-base-plan.sh
+++ b/support/ci/builder-base-plan.sh
@@ -1,7 +1,7 @@
 pkg_version() {
   # TED: After migrating the builder repo we needed to add to
   # the rev-count to keep version sorting working
-  echo "$(($(git rev-list master --count) + 5000))"
+  echo "$(($(git rev-list HEAD --count) + 5000))"
 }
 
 do_before() {


### PR DESCRIPTION
When building a package of a past commit, the git-based versioning logic
in builder-base-plan.sh used the master branch to derive the version
number from the number of commits. This resulted in always having a
version number based on your local copy of the master branch, even when
trying to build from an older revision.

This change now uses whatever the user has checked out as HEAD to derive
the version number, resulting in version numbers that more accurately
reflect the version of the code that they were built against.

Signed-off-by: Stephen Delano <stephen@chef.io>