### PR TITLE
Update package dependencies for builder-worker

### DIFF
--- a/components/builder-worker/build.rs
+++ b/components/builder-worker/build.rs
@@ -7,7 +7,7 @@ fn main() {
     builder::common();
     write_hab_pkg_ident();
     write_studio_pkg_ident();
-    write_docker_exporter_pkg_ident();
+    write_container_exporter_pkg_ident();
     write_docker_pkg_ident();
 }
 
@@ -31,14 +31,14 @@ fn write_studio_pkg_ident() {
     util::write_out_dir_file("STUDIO_PKG_IDENT", ident);
 }
 
-fn write_docker_exporter_pkg_ident() {
-    let ident = match env::var("PLAN_DOCKER_EXPORTER_PKG_IDENT") {
+fn write_container_exporter_pkg_ident() {
+    let ident = match env::var("PLAN_CONTAINER_EXPORTER_PKG_IDENT") {
         // Use the value provided by the build system if present
         Ok(ident) => ident,
         // Use the latest installed package as a default for development
-        _ => String::from("core/hab-pkg-export-docker"),
+        _ => String::from("core/hab-pkg-export-container"),
     };
-    util::write_out_dir_file("DOCKER_EXPORTER_PKG_IDENT", ident);
+    util::write_out_dir_file("CONTAINER_EXPORTER_PKG_IDENT", ident);
 }
 
 fn write_docker_pkg_ident() {

--- a/components/builder-worker/habitat-dev/plan.sh
+++ b/components/builder-worker/habitat-dev/plan.sh
@@ -20,9 +20,9 @@ do_prepare() {
   build_line "Setting PLAN_STUDIO_PKG_IDENT=$PLAN_STUDIO_PKG_IDENT"
 
   # Compile the fully-qualified Docker exporter package identifier into the binary
-  PLAN_DOCKER_EXPORTER_PKG_IDENT=$(pkg_path_for hab-pkg-export-docker | sed "s,^$HAB_PKG_PATH/,,")
-  export PLAN_DOCKER_EXPORTER_PKG_IDENT
-  build_line "Setting PLAN_DOCKER_EXPORTER_PKG_IDENT=$PLAN_DOCKER_EXPORTER_PKG_IDENT"
+  PLAN_CONTAINER_EXPORTER_PKG_IDENT=$(pkg_path_for hab-pkg-export-container | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_CONTAINER_EXPORTER_PKG_IDENT
+  build_line "Setting PLAN_CONTAINER_EXPORTER_PKG_IDENT=$PLAN_CONTAINER_EXPORTER_PKG_IDENT"
 
   # Compile the fully-qualified Docker package identifier into the binary
   PLAN_DOCKER_PKG_IDENT=$(pkg_path_for docker | sed "s,^$HAB_PKG_PATH/,,")

--- a/components/builder-worker/habitat/plan.ps1
+++ b/components/builder-worker/habitat/plan.ps1
@@ -10,7 +10,7 @@ $pkg_deps = @(
     "core/libsodium",
     "core/hab",
     "core/hab-studio",
-    "core/hab-pkg-export-docker",
+    "core/hab-pkg-export-container",
     "core/docker"
 )
 $pkg_bin_dirs = @("bin")

--- a/components/builder-worker/habitat/plan.ps1
+++ b/components/builder-worker/habitat/plan.ps1
@@ -74,8 +74,8 @@ function Invoke-Prepare {
     Write-BuildLine "Setting env:PLAN_STUDIO_PKG_IDENT=$env:PLAN_STUDIO_PKG_IDENT"
 
     # Compile the fully-qualified Docker exporter package identifier into the binary
-    $env:PLAN_DOCKER_EXPORTER_PKG_IDENT = $(Get-HabPackagePath "hab-pkg-export-docker").replace("$HAB_PKG_PATH\","").replace("\", "/")
-    Write-BuildLine "Setting env:PLAN_DOCKER_EXPORTER_PKG_IDENT=$env:PLAN_DOCKER_EXPORTER_PKG_IDENT"
+    $env:PLAN_CONTAINER_EXPORTER_PKG_IDENT = $(Get-HabPackagePath "hab-pkg-export-container").replace("$HAB_PKG_PATH\","").replace("\", "/")
+    Write-BuildLine "Setting env:PLAN_CONTAINER_EXPORTER_PKG_IDENT=$env:PLAN_CONTAINER_EXPORTER_PKG_IDENT"
 }
 
 function Invoke-BuildConfig {

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -37,9 +37,9 @@ do_prepare() {
   build_line "Setting PLAN_STUDIO_PKG_IDENT=$PLAN_STUDIO_PKG_IDENT"
 
   # Compile the fully-qualified Docker exporter package identifier into the binary
-  PLAN_DOCKER_EXPORTER_PKG_IDENT=$(pkg_path_for hab-pkg-export-docker | sed "s,^$HAB_PKG_PATH/,,")
-  export PLAN_DOCKER_EXPORTER_PKG_IDENT
-  build_line "Setting PLAN_DOCKER_EXPORTER_PKG_IDENT=$PLAN_DOCKER_EXPORTER_PKG_IDENT"
+  PLAN_CONTAINER_EXPORTER_PKG_IDENT=$(pkg_path_for hab-pkg-export-container | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_CONTAINER_EXPORTER_PKG_IDENT
+  build_line "Setting PLAN_CONTAINER_EXPORTER_PKG_IDENT=$PLAN_CONTAINER_EXPORTER_PKG_IDENT"
 
   # Compile the fully-qualified Docker package identifier into the binary
   PLAN_DOCKER_PKG_IDENT=$(pkg_path_for docker | sed "s,^$HAB_PKG_PATH/,,")

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -5,33 +5,11 @@ pkg_origin=habitat
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-# TODO: Remove pins after Habitat 1.6.23 or later is released
-pkg_deps=(
-    core/glibc/2.27/20190115002733
-    core/openssl/1.0.2r/20190305210149
-    core/gcc-libs/8.2.0/20190115011926
-    core/zeromq/4.3.1/20190802173651
-    core/libsodium/1.0.16/20190116014025
-    core/libarchive/3.3.3/20190305214120
-    core/zlib/1.2.11/20190115003728
-    core/hab/1.6.0/20200420200029
-    core/hab-studio/1.6.0/20200420202004
-    core/hab-pkg-export-docker/1.6.0/20200420202330
-    core/docker/19.03.3/20191025053746
-    core/curl/7.68.0/20200309012427
-)
-pkg_build_deps=(
-    core/make/4.2.1/20190115013626
-    core/cmake/3.16.0/20191204143727
-    core/protobuf-cpp/3.9.2/20191001233803
-    core/protobuf-rust/1.7.4/20190116233225
-    core/coreutils/8.30/20190115012313
-    core/cacerts/2018.12.05/20190115014206
-    core/rust/1.41.0/20200217103343
-    core/gcc/8.2.0/20190115004042
-    core/git/2.25.1/20200309023931
-    core/pkg-config/0.29.2/20190115011955
-)
+pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
+  core/libarchive core/zlib core/hab core/hab-studio core/hab-pkg-export-docker
+  core/docker core/curl)
+pkg_build_deps=(core/make core/cmake core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
+  core/rust core/gcc core/git core/pkg-config)
 pkg_binds=(
   [jobsrv]="worker_port worker_heartbeat log_port"
   [depot]="url"

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
-  core/libarchive core/zlib core/hab core/hab-studio core/hab-pkg-export-docker
+  core/libarchive core/zlib core/hab core/hab-studio core/hab-pkg-export-container
   core/docker core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)

--- a/components/builder-worker/src/runner/docker.rs
+++ b/components/builder-worker/src/runner/docker.rs
@@ -51,9 +51,9 @@ use crate::runner::{job_streamer::JobStreamer,
 
 lazy_static! {
     /// Absolute path to the Docker exporter program
-    static ref DOCKER_EXPORTER_PROGRAM: PathBuf = hfs::resolve_cmd_in_pkg(
-        "hab-pkg-export-docker",
-        include_str!(concat!(env!("OUT_DIR"), "/DOCKER_EXPORTER_PKG_IDENT")),
+    static ref CONTAINER_EXPORTER_PROGRAM: PathBuf = hfs::resolve_cmd_in_pkg(
+        "hab-pkg-export-container",
+        include_str!(concat!(env!("OUT_DIR"), "/CONTAINER_EXPORTER_PKG_IDENT")),
     );
 
     /// Absolute path to the Dockerd program
@@ -109,12 +109,12 @@ impl<'a> DockerExporter<'a> {
     }
 
     fn run_export(&self, streamer: &mut JobStreamer) -> Result<ExitStatus> {
-        debug!("Using pre-configured docker exporter program: {:?}",
-               &*DOCKER_EXPORTER_PROGRAM);
+        debug!("Using pre-configured container exporter program: {:?}",
+               &*CONTAINER_EXPORTER_PROGRAM);
 
-        let mut cmd = Command::new(&*DOCKER_EXPORTER_PROGRAM);
+        let mut cmd = Command::new(&*CONTAINER_EXPORTER_PROGRAM);
 
-        let exporter_ident = PackageIdent::from_str("core/hab-pkg-export-docker")?;
+        let exporter_ident = PackageIdent::from_str("core/hab-pkg-export-container")?;
         let pkg_install = PackageInstall::load(&exporter_ident, Some(&*FS_ROOT_PATH))?;
 
         cmd.current_dir(self.workspace.root());
@@ -154,8 +154,8 @@ impl<'a> DockerExporter<'a> {
 
         cmd.arg(self.workspace.last_built()?.path); // Locally built artifact
         debug!(
-            "building docker export command, cmd={}",
-            format!("building docker export command, cmd={:?}", &cmd)
+            "building container export command, cmd={}",
+            format!("building container export command, cmd={:?}", &cmd)
                 .replace(&self.spec.username, "<username-redacted>")
                 .replace(&self.spec.password, "<password-redacted>")
         );
@@ -188,11 +188,12 @@ impl<'a> DockerExporter<'a> {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
-        debug!("spawning docker export command");
+        debug!("spawning container export command");
         let mut child = cmd.spawn().map_err(Error::Exporter)?;
         streamer.consume_child(&mut child)?;
         let exit_status = child.wait().map_err(Error::Exporter)?;
-        debug!("completed docker export command, status={:?}", exit_status);
+        debug!("completed container export command, status={:?}",
+               exit_status);
 
         Ok(exit_status)
     }

--- a/components/builder-worker/src/runner/job_streamer.rs
+++ b/components/builder-worker/src/runner/job_streamer.rs
@@ -44,7 +44,7 @@ use crate::error::{Error,
 
 /// Streams the contents of a Builder job to a remote target. The contents of the stream consist of
 /// consuming the output streams of child processes (such as `hab-studio`,
-/// `hab-pkg-export-docker`, etc.), section start/end delimiters, and any user-facing error
+/// `hab-pkg-export-container`, etc.), section start/end delimiters, and any user-facing error
 /// messaging (usually written to a stderr output stream).
 ///
 /// A `JobStreamer` is associated with a Builder job identifer and should be used for the duration


### PR DESCRIPTION
This unpins the dependencies for the linux builder-worker to start using the post-refresh versions of packages. It also updates the dependencies to use the renamed container exporter package.