### PR TITLE
post a datadog event when merge to master occurs

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,3 +22,9 @@ subscriptions:
   - workload: habitat-sh/habitat:master_completed:project_promoted:habitat-sh/habitat:master:current:*
     actions:
       - trigger_pipeline:post_habitat_release
+
+  - workload: pull_request_merged:habitat-sh/builder:master:*
+    actions:
+      - bash:.expeditor/scripts/post_datadog_merge_event.sh
+          always_run: true
+          post_commit: true

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -25,6 +25,6 @@ subscriptions:
 
   - workload: pull_request_merged:habitat-sh/builder:master:*
     actions:
-      - bash:.expeditor/scripts/post_datadog_merge_event.sh
+      - bash:.expeditor/scripts/post_datadog_merge_event.sh:
           always_run: true
           post_commit: true

--- a/.expeditor/scripts/post_datadog_merge_event.sh
+++ b/.expeditor/scripts/post_datadog_merge_event.sh
@@ -24,7 +24,6 @@ curl --connect-timeout 5 \
    "source_type_name":"GIT",
    "tags":[
       "environment:acceptance"
-
 ],
    "text":"'${EXPEDITOR_TITLE}' https://github.com/habitat-sh/builder/pull/${EXPEDITOR_NUMBER} was merged with merge commit ${EXPEDITOR_MERGE_COMMIT}",
    "title":"Builder PR ${EXPEDITOR_NUMBER} merged to master"

--- a/.expeditor/scripts/post_datadog_merge_event.sh
+++ b/.expeditor/scripts/post_datadog_merge_event.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Post a Datadog event indicating a merge to master occurred
+
+set -eou pipefail
+
+DD_CLIENT_API_KEY=$(vault kv get -field api_key_acceptance account/static/datadog/habitat)
+export DD_CLIENT_API_KEY
+
+curl --connect-timeout 5 \
+  --max-time 10 \
+  --retry 5 \
+  --retry-delay 0 \
+  --retry-max-time 40 \
+  --request POST https://api.datadoghq.com/api/v1/events \
+  --header "Expect:" \
+  --header "DD-API-KEY: ${DD_CLIENT_API_KEY}" \
+  --header 'Content-Type: application/json charset=utf-8' \
+  --data-binary @- << EOF
+{  "aggregation_key":"git_merge",
+   "alert_type":"info",
+   "date_happened":$(date "+%s"),
+   "priority":"normal",
+   "source_type_name":"GIT",
+   "tags":[
+      "environment:acceptance"
+
+],
+   "text":"'${EXPEDITOR_TITLE}' https://github.com/habitat-sh/builder/pull/${EXPEDITOR_NUMBER} was merged with merge commit ${EXPEDITOR_MERGE_COMMIT}",
+   "title":"Builder PR ${EXPEDITOR_NUMBER} merged to master"
+}
+EOF


### PR DESCRIPTION
This will allow us to overlay merge events onto our Datadog graphs. 

It should help strengthen our pre-release process to the Live environment by hi-lighting any behavioral changes that may have been introduced as a result of a code change. It should also prove useful in troubleshooting.

Signed-off-by: Jeremy J. Miller <jm@chef.io>