### PR TITLE
Add API to list latest packages for channel

### DIFF
--- a/components/builder-api/doc/api.raml
+++ b/components/builder-api/doc/api.raml
@@ -1259,6 +1259,38 @@ securitySchemes:
                         description: Channel can not be deleted
                     500:
                         description: Server error
+             /latest:
+                get:
+                    description: List latest packages in a channel, by target (required)
+                    queryParameters:
+                        target:
+                            description: Target architecture
+                            type: string
+                            required: true
+                    responses:
+                        200:
+                            description: Returns a list of packages
+                            body:
+                                application/json:
+                                    example:
+                                        {
+                                            "channel": "stable",
+                                            "target": "x86_64-linux",
+                                            "data": [
+                                                {
+                                                    "origin": "core",
+                                                    "name": "glibc",
+                                                    "version": "2.22",
+                                                    "release": "20160612063629"
+                                                },
+                                                {
+                                                    "origin": "core",
+                                                    "name": "linux-headers",
+                                                    "version": "4.3",
+                                                    "release": "20160612063537"
+                                                }
+
+                                        }
             /pkgs:
                 get:
                     description: List all packages in a channel
@@ -1480,8 +1512,8 @@ securitySchemes:
                   500:
                       description: Internal server error
           /get:
-              description: Get package settings for top level package 
-              responses: Returns current package settings for top level pacakge 
+              description: Get package settings for top level package
+              responses: Returns current package settings for top level package
                   200:
                       description: Successful request of current package settings
                       body:
@@ -1517,9 +1549,8 @@ securitySchemes:
                                     "updated_at": "2300-02-18-1891688"
                                 }
                   400:
-                      description: Visibility setting in request does is not supported 
+                      description: Visibility setting in request is not supported
                   422:
                       description: Body of request did not include a visibility setting
                   500:
                     description: Internal server error
-

--- a/components/builder-api/doc/api.raml
+++ b/components/builder-api/doc/api.raml
@@ -1259,38 +1259,6 @@ securitySchemes:
                         description: Channel can not be deleted
                     500:
                         description: Server error
-             /latest:
-                get:
-                    description: List latest packages in a channel, by target (required)
-                    queryParameters:
-                        target:
-                            description: Target architecture
-                            type: string
-                            required: true
-                    responses:
-                        200:
-                            description: Returns a list of packages
-                            body:
-                                application/json:
-                                    example:
-                                        {
-                                            "channel": "stable",
-                                            "target": "x86_64-linux",
-                                            "data": [
-                                                {
-                                                    "origin": "core",
-                                                    "name": "glibc",
-                                                    "version": "2.22",
-                                                    "release": "20160612063629"
-                                                },
-                                                {
-                                                    "origin": "core",
-                                                    "name": "linux-headers",
-                                                    "version": "4.3",
-                                                    "release": "20160612063537"
-                                                }
-
-                                        }
             /pkgs:
                 get:
                     description: List all packages in a channel
@@ -1325,6 +1293,39 @@ securitySchemes:
                             description: Origin or channel does not exist
                         500:
                             description: Server error
+                /_latest:
+                    get:
+                        description: List latest packages in a channel, by target (required)
+                        queryParameters:
+                        target:
+                          description: Target architecture
+                          type: string
+                          required: true
+                        responses:
+                          200:
+                            description: Returns a list of packages
+                            body:
+                              application/json:
+                                example:
+                                  {
+                                  "channel": "stable",
+                                  "target": "x86_64-linux",
+                                  "data": [
+                                       {
+                                       "origin": "core",
+                                       "name": "glibc",
+                                       "version": "2.22",
+                                       "release": "20160612063629"
+                                       },
+                                       {
+                                       "origin": "core",
+                                       "name": "linux-headers",
+                                       "version": "4.3",
+                                       "release": "20160612063537"
+                                       }
+                                       ]
+                                  }
+
                 /promote:
                     post:
                         description: Promotes all packages in a channel

--- a/components/builder-api/src/server/helpers.rs
+++ b/components/builder-api/src/server/helpers.rs
@@ -83,8 +83,7 @@ pub fn channel_listing_results_json<T: Serialize>(channel: &str,
     let results = ChannelListingResults { channel: channel.to_string(),
                                           target:  target.to_string(),
                                           data:    packages, };
-    let r = serde_json::to_string(&results).unwrap();
-    r
+    serde_json::to_string(&results).unwrap()
 }
 
 pub fn extract_pagination(pagination: &Query<Pagination>) -> (isize, isize) {

--- a/components/builder-api/src/server/helpers.rs
+++ b/components/builder-api/src/server/helpers.rs
@@ -39,6 +39,13 @@ pub struct PaginatedResults<'a, T: 'a> {
     data:        &'a [T],
 }
 
+#[derive(Serialize)]
+pub struct ChannelListingResults<'a, T: 'a> {
+    channel: String,
+    target:  String,
+    data:    &'a [T],
+}
+
 #[derive(Deserialize)]
 pub struct ToChannel {
     #[serde(default)]
@@ -67,6 +74,19 @@ pub fn package_results_json<T: Serialize>(packages: &[T],
                                      data:        packages, };
 
     serde_json::to_string(&results).unwrap()
+}
+
+pub fn channel_listing_results_json<T: Serialize>(channel: &str,
+                                                  target: &str,
+                                                  packages: &[T])
+                                                  -> String {
+    let results = ChannelListingResults { channel: channel.to_string(),
+                                          target:  target.to_string(),
+                                          data:    packages, };
+    let r = serde_json::to_string(&results).unwrap();
+    trace!("LOGLOG-t {} {} {}", channel, target, r);
+    println!("LOGLOG-p{} {} {}", channel, target, r);
+    r
 }
 
 pub fn extract_pagination(pagination: &Query<Pagination>) -> (isize, isize) {

--- a/components/builder-api/src/server/helpers.rs
+++ b/components/builder-api/src/server/helpers.rs
@@ -84,8 +84,6 @@ pub fn channel_listing_results_json<T: Serialize>(channel: &str,
                                           target:  target.to_string(),
                                           data:    packages, };
     let r = serde_json::to_string(&results).unwrap();
-    trace!("LOGLOG-t {} {} {}", channel, target, r);
-    println!("LOGLOG-p{} {} {}", channel, target, r);
     r
 }
 

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -71,10 +71,10 @@ impl Channels {
                   web::post().to(create_channel))
            .route("/depot/channels/{origin}/{channel}",
                   web::delete().to(delete_channel))
-           .route("/depot/channels/{origin}/{channel}/latest",
-                  web::get().to(get_latest_packages_for_origin_channel))
            .route("/depot/channels/{origin}/{channel}/pkgs",
                   web::get().to(get_packages_for_origin_channel))
+           .route("/depot/channels/{origin}/{channel}/pkgs/_latest",
+                  web::get().to(get_latest_packages_for_origin_channel))
            .route("/depot/channels/{origin}/{channel}/pkgs/{pkg}",
                   web::get().to(get_packages_for_origin_channel_package))
            .route("/depot/channels/{origin}/{channel}/pkgs/{pkg}/latest",

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -687,9 +687,6 @@ fn get_latest_packages_for_origin_channel(req: HttpRequest,
     let (origin, channel) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 
-    trace!("LOGLOG-t1 {} {}", origin, channel);
-    println!("LOGLOG-p1 {} {}", origin, channel);
-
     match do_get_latest_channel_packages(&req, &qtarget, &origin, &channel) {
         Ok((channel, target, data)) => {
             let json_body = helpers::channel_listing_results_json(&channel, &target, &data);

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -680,6 +680,7 @@ fn get_package_fully_qualified(req: HttpRequest,
     }
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn get_latest_packages_for_origin_channel(req: HttpRequest,
                                           path: Path<(String, String)>,
                                           qtarget: Query<Target>)
@@ -709,7 +710,7 @@ fn get_latest_packages_for_origin_channel(req: HttpRequest,
 
 fn do_get_latest_channel_packages(req: &HttpRequest,
                                   qtarget: &Query<Target>,
-                                  origin: &String,
+                                  origin: &str,
                                   channel: &ChannelIdent)
                                   -> Result<(String, String, Vec<BuilderPackageIdent>)> {
     let opt_session_id = match authorize_session(&req, None, None) {

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -71,10 +71,10 @@ impl Channels {
                   web::post().to(create_channel))
            .route("/depot/channels/{origin}/{channel}",
                   web::delete().to(delete_channel))
+           .route("/depot/channels/{origin}/{channel}/latest",
+                  web::get().to(get_latest_packages_for_origin_channel))
            .route("/depot/channels/{origin}/{channel}/pkgs",
                   web::get().to(get_packages_for_origin_channel))
-           .route("/depot/channels/{origin}/{channel}/pkgs/latest",
-                  web::get().to(get_latest_packages_for_origin_channel))
            .route("/depot/channels/{origin}/{channel}/pkgs/{pkg}",
                   web::get().to(get_packages_for_origin_channel_package))
            .route("/depot/channels/{origin}/{channel}/pkgs/{pkg}/latest",

--- a/components/builder-db/src/metrics.rs
+++ b/components/builder-db/src/metrics.rs
@@ -37,6 +37,7 @@ pub enum Histogram {
     DbCallTime,
     ChannelGetLatestPackageCallTime,
     ChannelListAllPackagesCallTime,
+    ChannelListLatestPackagesCallTime,
     ChannelListPackagesCallTime,
     ChannelListPackagesOriginNameCallTime,
     ChannelListPackagesOriginOnlyCallTime,
@@ -76,6 +77,9 @@ impl metrics::Metric for Histogram {
             }
             Histogram::ChannelListPackagesCallTime => {
                 "db-call.channel-list-packages-call-time".into()
+            }
+            Histogram::ChannelListLatestPackagesCallTime => {
+                "db-call.channel-list-latest-packages-call-time".into()
             }
             Histogram::ChannelListPackagesOriginNameCallTime => {
                 "db-call.channel-list-packages-origin-name-call-time".into()

--- a/test/builder-api/src/channels.js
+++ b/test/builder-api/src/channels.js
@@ -310,7 +310,7 @@ describe('Channels API', function () {
   describe('Latest packages in an origin', function () {
 
     it('returns latest packages in a channel fails without a target', function (done) {
-      request.get('/depot/channels/neurosis/foo/latest')
+      request.get('/depot/channels/neurosis/foo/pkgs/_latest')
         .type('application/json')
         .accept('application/json')
         .expect(400)
@@ -321,7 +321,7 @@ describe('Channels API', function () {
     });
 
     it('returns latest packages in a channel', function (done) {
-      request.get('/depot/channels/neurosis/foo/latest?target=x86_64-linux')
+      request.get('/depot/channels/neurosis/foo/pkgs/_latest?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -377,7 +377,7 @@ describe('Channels API', function () {
       // })
 
       it('returns latest packages in a channel', function (done) {
-        request.get('/depot/channels/neurosis/foo/latest?target=x86_64-linux')
+        request.get('/depot/channels/neurosis/foo/pkgs/_latest?target=x86_64-linux')
           .type('application/json')
           .accept('application/json')
           .expect(200)
@@ -393,7 +393,7 @@ describe('Channels API', function () {
         });
 
       it('returns latest packages in a channel, but not the private ones', function (done) {
-        request.get('/depot/channels/neurosis/baz/latest?target=x86_64-linux')
+        request.get('/depot/channels/neurosis/baz/pkgs/_latest?target=x86_64-linux')
            .type('application/json')
            .accept('application/json')
            .expect(200)
@@ -409,7 +409,7 @@ describe('Channels API', function () {
       //
 
       it('returns latest packages in a channel but not the older ones', function (done) {
-          request.get('/depot/channels/neurosis/unstable/latest?target=x86_64-linux')
+          request.get('/depot/channels/neurosis/unstable/pkgs/_latest?target=x86_64-linux')
             .type('application/json')
             .accept('application/json')
             .expect(200)

--- a/test/builder-api/src/channels.js
+++ b/test/builder-api/src/channels.js
@@ -119,6 +119,34 @@ describe('Channels API', function () {
         });
     });
 
+
+    it('returns latest packages in a channel fails without a target', function (done) {
+      request.get('/depot/channels/neurosis/foo/pkgs/latest')
+        .type('application/json')
+        .accept('application/json')
+        .expect(400)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('returns latest packages in a channel', function (done) {
+      request.get('/depot/channels/neurosis/foo/pkgs/latest?target=x86_64-linux')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.channel).to.equal('foo');
+          expect(res.body.target).to.equal('x86_64-linux');
+//          expect(res.body.data).length.to.equal(1);
+          expect(res.body.data[0].name).to.equal('testapp');
+          expect(res.body.data[0].version).to.equal('0.1.3');
+          expect(res.body.data[0].release).to.equal('20171205003213');
+          done(err);
+        });
+    });
+
     it('returns all packages with the given name in a channel', function (done) {
       request.get('/depot/channels/neurosis/foo/pkgs/testapp')
         .type('application/json')

--- a/test/builder-api/src/channels.js
+++ b/test/builder-api/src/channels.js
@@ -310,7 +310,7 @@ describe('Channels API', function () {
   describe('Latest packages in an origin', function () {
 
     it('returns latest packages in a channel fails without a target', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/latest')
+      request.get('/depot/channels/neurosis/foo/latest')
         .type('application/json')
         .accept('application/json')
         .expect(400)
@@ -321,7 +321,7 @@ describe('Channels API', function () {
     });
 
     it('returns latest packages in a channel', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/latest?target=x86_64-linux')
+      request.get('/depot/channels/neurosis/foo/latest?target=x86_64-linux')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -377,7 +377,7 @@ describe('Channels API', function () {
       // })
 
       it('returns latest packages in a channel', function (done) {
-        request.get('/depot/channels/neurosis/foo/pkgs/latest?target=x86_64-linux')
+        request.get('/depot/channels/neurosis/foo/latest?target=x86_64-linux')
           .type('application/json')
           .accept('application/json')
           .expect(200)
@@ -393,7 +393,7 @@ describe('Channels API', function () {
         });
 
       it('returns latest packages in a channel, but not the private ones', function (done) {
-        request.get('/depot/channels/neurosis/baz/pkgs/latest?target=x86_64-linux')
+        request.get('/depot/channels/neurosis/baz/latest?target=x86_64-linux')
            .type('application/json')
            .accept('application/json')
            .expect(200)
@@ -409,7 +409,7 @@ describe('Channels API', function () {
       //
 
       it('returns latest packages in a channel but not the older ones', function (done) {
-          request.get('/depot/channels/neurosis/unstable/pkgs/latest?target=x86_64-linux')
+          request.get('/depot/channels/neurosis/unstable/latest?target=x86_64-linux')
             .type('application/json')
             .accept('application/json')
             .expect(200)
@@ -417,12 +417,15 @@ describe('Channels API', function () {
               expect(res.body.channel).to.equal('unstable');
               expect(res.body.target).to.equal('x86_64-linux');
               expect(res.body.data.length).to.equal(12);
+              expect(res.body.data[0].origin).to.equal('neurosis');
               expect(res.body.data[0].name).to.equal('abracadabra');
               expect(res.body.data[0].version).to.equal('3.0');
               expect(res.body.data[0].release).to.equal('20190618175235');
+              expect(res.body.data[10].origin).to.equal('neurosis');
               expect(res.body.data[10].name).to.equal('testapp');
               expect(res.body.data[10].version).to.equal('0.1.13');
               expect(res.body.data[10].release).to.equal('20190511004436');
+              expect(res.body.data[11].origin).to.equal('neurosis');
               expect(res.body.data[11].name).to.equal('testapp2');
               expect(res.body.data[11].version).to.equal('v1.2.3-master');
               expect(res.body.data[11].release).to.equal('20181018162212');

--- a/test/builder-api/src/channels.js
+++ b/test/builder-api/src/channels.js
@@ -119,34 +119,6 @@ describe('Channels API', function () {
         });
     });
 
-
-    it('returns latest packages in a channel fails without a target', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/latest')
-        .type('application/json')
-        .accept('application/json')
-        .expect(400)
-        .end(function (err, res) {
-          expect(res.text).to.be.empty;
-          done(err);
-        });
-    });
-
-    it('returns latest packages in a channel', function (done) {
-      request.get('/depot/channels/neurosis/foo/pkgs/latest?target=x86_64-linux')
-        .type('application/json')
-        .accept('application/json')
-        .expect(200)
-        .end(function (err, res) {
-          expect(res.body.channel).to.equal('foo');
-          expect(res.body.target).to.equal('x86_64-linux');
-//          expect(res.body.data).length.to.equal(1);
-          expect(res.body.data[0].name).to.equal('testapp');
-          expect(res.body.data[0].version).to.equal('0.1.3');
-          expect(res.body.data[0].release).to.equal('20171205003213');
-          done(err);
-        });
-    });
-
     it('returns all packages with the given name in a channel', function (done) {
       request.get('/depot/channels/neurosis/foo/pkgs/testapp')
         .type('application/json')
@@ -253,8 +225,8 @@ describe('Channels API', function () {
         .accept('application/json')
         .expect(404)
         .end(function (err, res) {
-            expect(res.text).to.be.empty;
-            done(err);
+          expect(res.text).to.be.empty;
+          done(err);
         });
     });
 
@@ -333,6 +305,131 @@ describe('Channels API', function () {
           done(err);
         });
     });
+  });
+
+  describe('Latest packages in an origin', function () {
+
+    it('returns latest packages in a channel fails without a target', function (done) {
+      request.get('/depot/channels/neurosis/foo/pkgs/latest')
+        .type('application/json')
+        .accept('application/json')
+        .expect(400)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+
+    it('returns latest packages in a channel', function (done) {
+      request.get('/depot/channels/neurosis/foo/pkgs/latest?target=x86_64-linux')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.channel).to.equal('foo');
+          expect(res.body.target).to.equal('x86_64-linux');
+          expect(res.body.data.length).to.equal(1);
+          expect(res.body.data[0].name).to.equal('testapp');
+          expect(res.body.data[0].version).to.equal('0.1.3');
+          expect(res.body.data[0].release).to.equal('20171205003213');
+          done(err);
+        });
+    });
+
+    describe('with multiple versions of package in channel', function () {
+
+      // What I really want to do is have a separate channel for the tests, with promotion/demotion and isolation from the other tests
+      // But for the the life of me I can't get the before/after clauses to work.
+      // They execute at random times, often the before clause runs *AFTER* the test, and I have no clue why.
+      //
+      // So for now, we test against existing channels, as fragile as that might be
+      //
+
+      // Below is one variant, but
+      // before(function () {
+      //   request.post('/depot/channels/neurosis/baz')
+      //     .set('Authorization', global.boboBearer)
+      //     .expect(201)
+      //     .end();
+      //   request.put('/depot/channels/neurosis/baz/pkgs/testapp/0.1.3/20171205003213/promote')
+      //     .set('Authorization', global.boboBearer)
+      //     .expect(200)
+      //     .end();
+      //   request.put('/depot/channels/neurosis/baz/pkgs/neurosis/testapp/0.1.4/20171206004139/promote')
+      //     .set('Authorization', global.boboBearer)
+      //     .expect(200)
+      //     .end();
+      //   request.put('/depot/channels/neurosis/baz/pkgs/neurosis/neurosis/testapp/0.1.4/20181115124506/promote')
+      //     .set('Authorization', global.boboBearer)
+      //     .expect(200)
+      //     .end();
+      //   request.put('/depot/channels/neurosis/baz/pkgs/testapp2/v1.2.3-aaster/20181018162220/promote')
+      //     .set('Authorization', global.boboBearer)
+      //     .expect(200)
+      //     .end();
+      // });
+
+      // after(function () {
+      //   request.delete('/depot/channels/neurosis/baz')
+      //     .set('Authorization', global.boboBearer)
+      //     .expect(200)
+      //     .end();
+      // })
+
+      it('returns latest packages in a channel', function (done) {
+        request.get('/depot/channels/neurosis/foo/pkgs/latest?target=x86_64-linux')
+          .type('application/json')
+          .accept('application/json')
+          .expect(200)
+          .end(function (err, res) {
+            expect(res.body.channel).to.equal('foo');
+            expect(res.body.target).to.equal('x86_64-linux');
+            expect(res.body.data.length).to.equal(1);
+            expect(res.body.data[0].name).to.equal('testapp');
+            expect(res.body.data[0].version).to.equal('0.1.3');
+            expect(res.body.data[0].release).to.equal('20171205003213');
+            done(err);
+          });
+        });
+
+      it('returns latest packages in a channel, but not the private ones', function (done) {
+        request.get('/depot/channels/neurosis/baz/pkgs/latest?target=x86_64-linux')
+           .type('application/json')
+           .accept('application/json')
+           .expect(200)
+           .end(function (err, res) {
+             expect(res.body.channel).to.equal('baz');
+             expect(res.body.target).to.equal('x86_64-linux');
+             expect(res.body.data.length).to.equal(0);
+             done(err);
+           });
+      });
+
+      // Wishful verify that it can see the private ones if the right auth is provided
+      //
+
+      it('returns latest packages in a channel but not the older ones', function (done) {
+          request.get('/depot/channels/neurosis/unstable/pkgs/latest?target=x86_64-linux')
+            .type('application/json')
+            .accept('application/json')
+            .expect(200)
+            .end(function (err, res) {
+              expect(res.body.channel).to.equal('unstable');
+              expect(res.body.target).to.equal('x86_64-linux');
+              expect(res.body.data.length).to.equal(12);
+              expect(res.body.data[0].name).to.equal('abracadabra');
+              expect(res.body.data[0].version).to.equal('3.0');
+              expect(res.body.data[0].release).to.equal('20190618175235');
+              expect(res.body.data[10].name).to.equal('testapp');
+              expect(res.body.data[10].version).to.equal('0.1.13');
+              expect(res.body.data[10].release).to.equal('20190511004436');
+              expect(res.body.data[11].name).to.equal('testapp2');
+              expect(res.body.data[11].version).to.equal('v1.2.3-master');
+              expect(res.body.data[11].release).to.equal('20181018162212');
+              done(err);
+            });
+        });
+      });
   });
 
   describe('Listing channels in an origin', function () {


### PR DESCRIPTION
First pass at #1419

This provides a way to list all latest packages for a channel.

We chose the endpoint
/depot/channels/{origin}/{channel}/pkgs/latest?target=TARGET which is
mildly problematic, as it aliases with any package called latest. This
is an existing problem, in that we also alias for promote, but in that
case we can differentiate because one is GET and the other PUT.

One possibility would be to revert to the suggested
/depot/channels/ORIGIN/CHANNEL/latest?target=TARGET endpoint, but that
has it's own problems, as discussed in #1419
(https://github.com/habitat-sh/builder/issues/1419#issuecomment-632667908)

Further testing would be useful; the current test only has one package
in the origin.

Signed-off-by: Mark Anderson <mark@chef.io>