### PR TITLE
Unpin habitat_core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -352,7 +352,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc 0.2.71",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1be3409f94d7bdceeb5f5fac551039d9b3f00e25da7a74fc4d33400a0d96368"
+checksum = "77c1f1d60091c1b73e2b1f4560ab419204b178e625fa945ded7b660becd2bd46"
 dependencies = [
  "jobserver",
 ]
@@ -790,14 +790,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
 dependencies = [
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.8"
+version = "0.99.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc655351f820d774679da6cdc23355a93de496867d8203496675162e17b1d671"
+checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -887,7 +887,7 @@ checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc 0.2.71",
  "redox_users",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -908,7 +908,7 @@ checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc 0.2.71",
  "redox_users",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -925,7 +925,7 @@ checksum = "4cbea23c15f7e685a7ad01c994407f3849fa7c88556aaafe4054215b6df93f78"
 dependencies = [
  "libc 0.2.71",
  "socket2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1077,7 +1077,7 @@ checksum = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
 dependencies = [
  "errno-dragonfly",
  "libc 0.2.71",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1173,7 +1173,7 @@ dependencies = [
  "cfg-if",
  "libc 0.2.71",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1373,7 +1373,7 @@ dependencies = [
  "libc 0.2.71",
  "log",
  "rustc_version",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git?tag=1.6.39#4651e776e7d37c1963a568a06185083be8a74a53"
+source = "git+https://github.com/habitat-sh/habitat.git#5d421011c2043d2b14d6f5569a696f33cf1f2453"
 dependencies = [
  "base64 0.12.3",
  "caps",
@@ -1704,7 +1704,6 @@ dependencies = [
  "habitat_win_users",
  "hex 0.4.2",
  "lazy_static",
- "libarchive",
  "libc 0.2.71",
  "libsodium-sys",
  "log",
@@ -1717,24 +1716,26 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sodiumoxide",
+ "tar",
  "tempfile",
  "toml 0.5.6",
  "typemap",
  "url",
  "widestring",
- "winapi 0.3.8",
+ "winapi 0.3.9",
  "windows-acl",
+ "xz2",
 ]
 
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git?tag=1.6.39#4651e776e7d37c1963a568a06185083be8a74a53"
+source = "git+https://github.com/habitat-sh/habitat.git#5d421011c2043d2b14d6f5569a696f33cf1f2453"
 dependencies = [
  "cc",
  "log",
  "widestring",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1805,7 +1806,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc 0.2.71",
  "match_cfg",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1997,7 +1998,7 @@ checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
  "socket2",
  "widestring",
- "winapi 0.3.8",
+ "winapi 0.3.9",
  "winreg 0.6.2",
 ]
 
@@ -2027,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
+checksum = "c4b9172132a62451e56142bff9afc91c8e4a4500aa5b847da36815b63bfda916"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2130,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45f516b9b19ea6c940b9f36d36734062a153a2b4cc9ef31d82c54bb9780f525"
+checksum = "eafa907407504b0e683786d4aba47acf250f114d37357d56608333fd167dd0fc"
 dependencies = [
  "cc",
  "libc 0.2.71",
@@ -2196,6 +2197,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99"
+dependencies = [
+ "cc",
+ "libc 0.2.71",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2342,14 +2354,14 @@ dependencies = [
 
 [[package]]
 name = "mio-named-pipes"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
  "mio",
  "miow 0.3.5",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2382,7 +2394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
  "socket2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2411,7 +2423,7 @@ checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc 0.2.71",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2551,7 +2563,7 @@ checksum = "67cc1fe7b45f7e51f755195fd86b0483dbae30fdcf831a3254438d29118d12c4"
 dependencies = [
  "log",
  "serde",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2587,7 +2599,7 @@ dependencies = [
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2601,7 +2613,7 @@ dependencies = [
  "libc 0.2.71",
  "redox_syscall",
  "smallvec 1.4.0",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2879,7 +2891,7 @@ dependencies = [
  "libc 0.2.71",
  "rand_core 0.3.1",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2988,7 +3000,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3293,7 +3305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3375,10 +3387,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -3478,7 +3491,7 @@ dependencies = [
  "cfg-if",
  "libc 0.2.71",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3662,7 +3675,7 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3673,7 +3686,7 @@ checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
  "dirs 1.0.5",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3702,7 +3715,7 @@ checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 dependencies = [
  "libc 0.2.71",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3740,7 +3753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc 0.2.71",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3755,7 +3768,7 @@ dependencies = [
  "stdweb",
  "time-macros",
  "version_check",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3841,7 +3854,7 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "tokio-macros",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3945,7 +3958,7 @@ dependencies = [
  "tokio-io",
  "tokio-reactor",
  "tokio-signal",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3981,7 +3994,7 @@ dependencies = [
  "tokio-executor",
  "tokio-io",
  "tokio-reactor",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4120,6 +4133,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
+ "indexmap",
  "serde",
 ]
 
@@ -4236,9 +4250,9 @@ checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -4321,7 +4335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
- "winapi 0.3.8",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -4354,9 +4368,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
+checksum = "6a634620115e4a229108b71bde263bb4220c483b3f07f5ba514ee8d15064c4c2"
 dependencies = [
  "cfg-if",
  "serde",
@@ -4366,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
+checksum = "3e53963b583d18a5aa3aaae4b4c1cb535218246131ba22a71f05b518098571df"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4381,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64487204d863f109eb77e8462189d111f27cb5712cc9fdb3461297a76963a2f6"
+checksum = "dba48d66049d2a6cc8488702e7259ab7afc9043ad0dc5448444f46f2a453b362"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4393,9 +4407,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
+checksum = "3fcfd5ef6eec85623b4c6e844293d4516470d8f19cd72d0d12246017eb9060b8"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -4403,9 +4417,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
+checksum = "9adff9ee0e94b926ca81b57f57f86d5545cdcb1d259e21ec9bdd95b901754c75"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -4416,15 +4430,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
+checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
 
 [[package]]
 name = "web-sys"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b72fe77fd39e4bd3eaa4412fd299a0be6b3dfe9d2597e2f1c20beb968f41d17"
+checksum = "863539788676619aac1a23e2df3655e96b32b0e05eb72ca34ba045ad573c625d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4444,9 +4458,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -4470,7 +4484,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4481,14 +4495,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-acl"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677bd804a3401f76666c566c81b2ba39555006b9d99df368b9399949cc948bdf"
+checksum = "621eb6747b79a4bd7a3f0d96636b4386dc3c615ae24dbd4020ad8a397c41a6b4"
 dependencies = [
  "field-offset",
  "libc 0.2.71",
  "widestring",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4497,7 +4511,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4506,7 +4520,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4533,6 +4547,15 @@ name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+
+[[package]]
+name = "xz2"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "zeroize"

--- a/components/artifactory-client/Cargo.toml
+++ b/components/artifactory-client/Cargo.toml
@@ -13,7 +13,6 @@ serde_derive = "*"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
-tag = "1.6.39"
 
 [dependencies.builder_core]
 path = "../builder-core"

--- a/components/artifactory-client/src/client.rs
+++ b/components/artifactory-client/src/client.rs
@@ -127,7 +127,7 @@ impl ArtifactoryClient {
             while let Some(chunk) = stream.next().await {
                 file.write_all(&chunk?).await?;
             }
-            Ok(PackageArchive::new(destination_path))
+            Ok(PackageArchive::new(destination_path)?)
         } else {
             error!("Artifactory download non-success status: {:?}",
                    resp.status());

--- a/components/artifactory-client/src/error.rs
+++ b/components/artifactory-client/src/error.rs
@@ -28,6 +28,7 @@ pub enum ArtifactoryError {
     ApiError(reqwest::StatusCode, HashMap<String, String>),
     BuilderCore(builder_core::Error),
     IO(io::Error),
+    HabitatCore(habitat_core::error::Error),
 }
 
 impl fmt::Display for ArtifactoryError {
@@ -40,6 +41,7 @@ impl fmt::Display for ArtifactoryError {
             }
             ArtifactoryError::BuilderCore(ref e) => format!("{}", e),
             ArtifactoryError::IO(ref e) => format!("{}", e),
+            ArtifactoryError::HabitatCore(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
     }
@@ -52,6 +54,7 @@ impl error::Error for ArtifactoryError {
             ArtifactoryError::ApiError(..) => "Response returned a non-200 status code.",
             ArtifactoryError::BuilderCore(ref err) => err.description(),
             ArtifactoryError::IO(ref err) => err.description(),
+            ArtifactoryError::HabitatCore(ref err) => err.description(),
         }
     }
 }
@@ -63,6 +66,11 @@ impl From<io::Error> for ArtifactoryError {
 impl From<builder_core::Error> for ArtifactoryError {
     fn from(err: builder_core::Error) -> Self { ArtifactoryError::BuilderCore(err) }
 }
+
 impl From<reqwest::Error> for ArtifactoryError {
     fn from(err: reqwest::Error) -> Self { ArtifactoryError::HttpClient(err) }
+}
+
+impl From<habitat_core::error::Error> for ArtifactoryError {
+    fn from(err: habitat_core::error::Error) -> Self { ArtifactoryError::HabitatCore(err) }
 }

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -77,7 +77,6 @@ path = "../github-api-client"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
-tag = "1.6.39"
 
 [dependencies.builder_core]
 path = "../builder-core"

--- a/components/builder-api/src/server/services/s3.rs
+++ b/components/builder-api/src/server/services/s3.rs
@@ -360,7 +360,7 @@ async fn write_archive(filename: &PathBuf,
             return Err(Error::IO(e));
         }
     }
-    Ok(PackageArchive::new(filename))
+    Ok(PackageArchive::new(filename)?)
 }
 
 #[cfg(test)]

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -33,7 +33,7 @@ zmq = { git = "https://github.com/habitat-sh/rust-zmq", branch = "v0.8-symlinks-
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
-tag = "1.6.39"
+
 [dependencies.reqwest]
 version = "*"
 features = ["stream"]

--- a/components/builder-core/src/api_client.rs
+++ b/components/builder-core/src/api_client.rs
@@ -143,7 +143,7 @@ impl ApiClient {
         qparams.insert("target", target);
 
         match self.download(url, &qparams, dst_path.as_ref(), token).await {
-            Ok(file) => Ok(PackageArchive::new(file)),
+            Ok(file) => Ok(PackageArchive::new(file)?),
             Err(e) => Err(e),
         }
     }

--- a/components/builder-db/Cargo.toml
+++ b/components/builder-db/Cargo.toml
@@ -33,7 +33,6 @@ url = "*"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
-tag = "1.6.39"
 
 [dependencies.builder_core]
 path = "../builder-core"

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -995,8 +995,8 @@ impl FromArchive for NewPackage {
             Err(e) => return Err(e),
         };
 
-        let config = match archive.config()? {
-            Some(config) => config,
+        let config = match archive.config() {
+            Some(config) => config.to_string(),
             None => String::from(""),
         };
 
@@ -1030,7 +1030,7 @@ impl FromArchive for NewPackage {
         Ok(NewPackage { ident: ident.clone(),
                         ident_array: ident.clone().parts(),
                         origin: ident.origin().to_string(),
-                        manifest: archive.manifest()?,
+                        manifest: archive.manifest()?.to_string(),
                         target: BuilderPackageTarget(archive.target()?),
                         deps,
                         tdeps,

--- a/components/builder-graph/Cargo.toml
+++ b/components/builder-graph/Cargo.toml
@@ -39,7 +39,6 @@ internment = "*"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
-tag = "1.6.39"
 
 [dependencies.builder_core]
 path = "../builder-core"

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -56,4 +56,3 @@ branch = "v0.8-symlinks-removed"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
-tag = "1.6.39"

--- a/components/builder-protocol/Cargo.toml
+++ b/components/builder-protocol/Cargo.toml
@@ -19,7 +19,6 @@ lazy_static = "*"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
-tag = "1.6.39"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -46,7 +46,6 @@ path = "../github-api-client"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
-tag = "1.6.39"
 
 [dependencies.builder_core]
 path = "../builder-core"

--- a/components/builder-worker/src/runner/workspace.rs
+++ b/components/builder-worker/src/runner/workspace.rs
@@ -52,7 +52,7 @@ impl Workspace {
     pub fn last_built(&self) -> Result<PackageArchive> {
         let last_build = self.last_build_env();
         match StudioBuild::from_file(&last_build) {
-            Ok(build) => Ok(PackageArchive::new(self.out().join(build.pkg_artifact.unwrap()))),
+            Ok(build) => Ok(PackageArchive::new(self.out().join(build.pkg_artifact.unwrap()))?),
             Err(err) => Err(Error::BuildEnvFile(last_build, err)),
         }
     }


### PR DESCRIPTION
This PR removes the `habitat_core` pins added in 720ce93ecda78a439411e52b05e171a4fd163b67.

The changes are largely mechanical, working the `Result` returned by `PackageArchive::new()` and the `String->&str` return through.  

Lines 1023-1030 and 1044-1050 in  components/builder-api/src/server/resources/pkgs.rs bear closer examination to ensure I've use the correct pattern for returning a new error so that the failure is reported correctly back to the user. 