### PR TITLE
Update sha2 crate to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.2",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +656,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags 1.2.1",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +704,12 @@ name = "core-foundation-sys"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
 
 [[package]]
 name = "crc32fast"
@@ -877,6 +901,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.2",
 ]
 
 [[package]]
@@ -1395,6 +1428,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,7 +1590,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.8.2",
+ "sha2 0.9.1",
  "tempfile",
  "toml 0.5.6",
  "url",
@@ -1652,7 +1695,7 @@ dependencies = [
  "rusoto_s3 0.42.0",
  "serde",
  "serde_derive",
- "sha2 0.8.2",
+ "sha2 0.9.1",
  "toml 0.5.6",
  "zmq",
 ]
@@ -1969,6 +2012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69da7ce1490173c2bf4d26bc8be429aaeeaf4cce6c4b970b7949651fa17655fe"
+
+[[package]]
 name = "internment"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2215,15 @@ name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de302ce1fe7482db13738fbaf2e21cfb06a986b89c0bf38d88abf16681aada4e"
 dependencies = [
  "scopeguard",
 ]
@@ -2523,6 +2581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,7 +2636,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
  "rustc_version",
 ]
@@ -2583,8 +2647,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.0",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -2594,7 +2669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc 0.2.71",
  "redox_syscall",
  "rustc_version",
@@ -2609,7 +2684,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
+ "libc 0.2.71",
+ "redox_syscall",
+ "smallvec 1.4.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
  "libc 0.2.71",
  "redox_syscall",
  "smallvec 1.4.0",
@@ -2851,12 +2941,12 @@ dependencies = [
 
 [[package]]
 name = "r2d2"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1497e40855348e4a8a40767d8e55174bce1e445a3ac9254ad44ad468ee0485af"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
  "log",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "scheduled-thread-pool",
 ]
 
@@ -3310,11 +3400,11 @@ dependencies = [
 
 [[package]]
 name = "scheduled-thread-pool"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0988d7fdf88d5e5fcf5923a0f1e8ab345f3e98ab4bc6bc45a2d5ff7f7458fbf6"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
 ]
 
 [[package]]
@@ -3436,7 +3526,20 @@ dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -36,7 +36,7 @@ reqwest = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"
-sha2 = "= 0.8.2"
+sha2 = "*"
 toml = { version = "*", default-features = false }
 futures = "*"
 rand = "*"

--- a/components/builder-api/src/server/services/memcache.rs
+++ b/components/builder-api/src/server/services/memcache.rs
@@ -314,3 +314,21 @@ fn hash_key(key: &str) -> String {
     hasher.update(key);
     format!("{:02x}", hasher.finalize())
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn hash_key_with_empty_input() {
+        let expected = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e".to_string();
+        assert_eq!(hash_key(""), expected);
+    }
+
+    #[test]
+    fn hash_key_with_session_token() {
+        let token =
+            "CIyAhviVt/aAChIFMYz4NYETACIoZDM2NDg9ZjEzOWY0MTQ5YzZiNmNjDMBkYTA4NTAzODkaMzdiNGZlNQ==";
+        let expected = "33a8f10726b1ada86d9f60e4abbb1cb8726798a2303395cecace82225236cfc3d5a82815d1017a1dd6f8d34e8b77a51c30d972ba2031e1207679fb2a4db925ea".to_string();
+        assert_eq!(hash_key(token), expected)
+    }
+}

--- a/components/builder-api/src/server/services/memcache.rs
+++ b/components/builder-api/src/server/services/memcache.rs
@@ -311,6 +311,6 @@ fn member_role_ns_key(origin: &str, account_id: u64) -> String {
 
 fn hash_key(key: &str) -> String {
     let mut hasher = Sha512::new();
-    hasher.input(key);
-    format!("{:02x}", hasher.result())
+    hasher.update(key);
+    format!("{:02x}", hasher.finalize())
 }

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -39,7 +39,7 @@ rand = "*"
 r2d2 = "*"
 serde = "*"
 serde_derive = "*"
-sha2 = "= 0.8.2"
+sha2 = "*"
 toml = { version = "*", default-features = false }
 
 [dependencies.actix-web]

--- a/components/builder-jobsrv/src/server/log_archiver/local.rs
+++ b/components/builder-jobsrv/src/server/log_archiver/local.rs
@@ -54,8 +54,8 @@ impl LocalArchiver {
     /// as not to run afoul of directory limits.
     pub fn archive_path(&self, job_id: u64) -> PathBuf {
         let mut hasher = Sha256::default();
-        hasher.input(job_id.to_string().as_bytes());
-        let checksum = hasher.result();
+        hasher.update(job_id.to_string().as_bytes());
+        let checksum = hasher.finalize();
 
         let mut new_path = self.0.clone();
         for byte in checksum.iter().take(4) {


### PR DESCRIPTION
As part of the update to 0.9.0, the RustCrypto suite of crates has changed some function names in their public api:
https://github.com/RustCrypto/traits/issues/43
https://github.com/RustCrypto/hashes/pull/157

This commit updates to the 0.9.x version of the sha2 crate from that suite and changes function calls as appropriate.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>