### PR TITLE
Add a command to map a set of packages to their dependencies

### DIFF
--- a/components/builder-graph/src/error.rs
+++ b/components/builder-graph/src/error.rs
@@ -64,27 +64,7 @@ impl fmt::Display for Error {
     }
 }
 
-<<<<<<< HEAD
 impl error::Error for Error {}
-=======
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Db(ref err) => err.description(),
-            Error::DbPoolTimeout(ref err) => err.description(),
-            Error::DbTransaction(ref err) => err.description(),
-            Error::DieselError(ref err) => err.description(),
-            Error::HabitatCore(ref err) => err.description(),
-            Error::IO(ref err) => err.description(),
-            Error::JobGraphPackagesGet(ref err) => err.description(),
-            Error::Misc(ref s) => s,
-            Error::Protobuf(ref err) => err.description(),
-            Error::Serde(ref err) => err.description(),
-            Error::UnknownJobGraphPackage => "Unknown Package",
-        }
-    }
-}
->>>>>>> 13b7b1e1... Add a command to take a map a set of packages to their plan deps
 
 impl From<hab_core::Error> for Error {
     fn from(err: hab_core::Error) -> Error { Error::HabitatCore(err) }

--- a/components/builder-graph/src/error.rs
+++ b/components/builder-graph/src/error.rs
@@ -33,6 +33,7 @@ pub enum Error {
     HabitatCore(hab_core::Error),
     IO(io::Error),
     JobGraphPackagesGet(postgres::error::Error),
+    Misc(String),
     Protobuf(protobuf::ProtobufError),
     Serde(serde_json::Error),
     UnknownJobGraphPackage,
@@ -54,6 +55,7 @@ impl fmt::Display for Error {
             Error::JobGraphPackagesGet(ref e) => {
                 format!("Database error retrieving packages, {}", e)
             }
+            Error::Misc(ref e) => format!("Misc error {}", e),
             Error::Protobuf(ref e) => format!("{}", e),
             Error::Serde(ref e) => format!("{}", e),
             Error::UnknownJobGraphPackage => "Unknown Package".to_string(),
@@ -62,7 +64,27 @@ impl fmt::Display for Error {
     }
 }
 
+<<<<<<< HEAD
 impl error::Error for Error {}
+=======
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Db(ref err) => err.description(),
+            Error::DbPoolTimeout(ref err) => err.description(),
+            Error::DbTransaction(ref err) => err.description(),
+            Error::DieselError(ref err) => err.description(),
+            Error::HabitatCore(ref err) => err.description(),
+            Error::IO(ref err) => err.description(),
+            Error::JobGraphPackagesGet(ref err) => err.description(),
+            Error::Misc(ref s) => s,
+            Error::Protobuf(ref err) => err.description(),
+            Error::Serde(ref err) => err.description(),
+            Error::UnknownJobGraphPackage => "Unknown Package",
+        }
+    }
+}
+>>>>>>> 13b7b1e1... Add a command to take a map a set of packages to their plan deps
 
 impl From<hab_core::Error> for Error {
     fn from(err: hab_core::Error) -> Error { Error::HabitatCore(err) }

--- a/components/builder-graph/src/package_graph.rs
+++ b/components/builder-graph/src/package_graph.rs
@@ -203,6 +203,14 @@ impl PackageGraph {
                                                               base_set,
                                                               touched)
     }
+
+    pub fn compute_attributed_deps(&self,
+                                   idents: &[PackageIdentIntern],
+                                   include_build_deps: bool)
+                                   -> HashMap<PackageIdentIntern, Vec<PackageIdentIntern>> {
+        self.graphs[&self.current_target].borrow_mut()
+                                         .compute_attributed_deps(idents, include_build_deps)
+    }
 }
 
 #[cfg(test)]

--- a/components/builder-graph/src/package_ident_intern.rs
+++ b/components/builder-graph/src/package_ident_intern.rs
@@ -262,3 +262,39 @@ impl Ord for PackageIdentIntern {
         }
     }
 }
+
+pub fn display_ordering_cmp<T>(a: &T, b: &T) -> Ordering
+    where T: Identifiable
+{
+    let cmp = a.origin().cmp(b.origin());
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = a.name().cmp(b.name());
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = match (a.version(), b.version()) {
+        (None, None) => return Ordering::Equal,
+        (None, Some(_)) => return Ordering::Less,
+        (Some(_), None) => return Ordering::Greater,
+        (Some(a_v), Some(b_v)) => {
+            // We could panic here, but since this is intended for display formatting, we just make
+            // a choice.
+            //
+            version_sort(a_v, b_v).unwrap_or(Ordering::Equal)
+        }
+    };
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    match (a.release(), b.release()) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (Some(a_r), Some(b_r)) => a_r.cmp(b_r),
+    }
+}


### PR DESCRIPTION
Add a command to take a set of packages and produce an annotated list of their plan deps. This is emitted one package per line, with a list of which packages in the original list pull them in.

For example:
```compute_attributed_deps deps_test.out --idents core/ruby core/openssl```

Produces a file that looks like this:
```
core/acl        core/ruby
core/attr       core/ruby
core/binutils   core/ruby
core/cacerts    core/openssl, core/ruby
core/coreutils  core/ruby
```



Signed-off-by: Mark Anderson <mark@chef.io>