### PR TITLE
Remove description fn from error::Error impl

### DIFF
--- a/components/artifactory-client/src/error.rs
+++ b/components/artifactory-client/src/error.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::{collections::HashMap,
-          error,
           fmt,
           io};
 
@@ -44,18 +43,6 @@ impl fmt::Display for ArtifactoryError {
             ArtifactoryError::HabitatCore(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
-    }
-}
-
-impl error::Error for ArtifactoryError {
-    fn description(&self) -> &str {
-        match *self {
-            ArtifactoryError::HttpClient(ref err) => err.description(),
-            ArtifactoryError::ApiError(..) => "Response returned a non-200 status code.",
-            ArtifactoryError::BuilderCore(ref err) => err.description(),
-            ArtifactoryError::IO(ref err) => err.description(),
-            ArtifactoryError::HabitatCore(ref err) => err.description(),
-        }
     }
 }
 

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -86,9 +86,7 @@ impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", *self) }
 }
 
-impl error::Error for ConfigError {
-    fn description(&self) -> &str { "Error reading config file" }
-}
+impl error::Error for ConfigError {}
 
 impl ConfigFile for Config {
     type Error = ConfigError;

--- a/components/builder-api/src/server/error.rs
+++ b/components/builder-api/src/server/error.rs
@@ -25,8 +25,7 @@ use reqwest;
 use rusoto_core::RusotoError;
 use rusoto_s3;
 use serde_json;
-use std::{error,
-          fmt,
+use std::{fmt,
           fs,
           io,
           result,
@@ -107,43 +106,6 @@ impl fmt::Display for Error {
             Error::Utf8(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Artifactory(ref err) => err.description(),
-            Error::Authentication => "User is not authenticated",
-            Error::Authorization => "User is not authorized to perform operation",
-            Error::BadRequest => "Http request formation error",
-            Error::BuilderCore(ref err) => err.description(),
-            Error::Conflict => "Entity conflict",
-            Error::CreateBucketError(ref err) => err.description(),
-            Error::DbError(ref err) => err.description(),
-            Error::DieselError(ref err) => err.description(),
-            Error::Github(ref err) => err.description(),
-            Error::HabitatCore(ref err) => err.description(),
-            Error::HeadObject(ref err) => err.description(),
-            Error::HttpClient(ref err) => err.description(),
-            Error::InnerError(ref err) => err.error().description(),
-            Error::IO(ref err) => err.description(),
-            Error::ListBuckets(ref err) => err.description(),
-            Error::MultipartCompletion(ref err) => err.description(),
-            Error::MultipartUploadReq(ref err) => err.description(),
-            Error::NotFound => "Entity not found",
-            Error::OAuth(ref err) => err.description(),
-            Error::PackageDownload(ref err) => err.description(),
-            Error::PackageUpload(ref err) => err.description(),
-            Error::PartialUpload(ref err) => err.description(),
-            Error::PayloadError(_) => "Http request stream error",
-            Error::Protobuf(ref err) => err.description(),
-            Error::SerdeJson(ref err) => err.description(),
-            Error::System => "Internal error",
-            Error::TLSError(ref err) => err.description(),
-            Error::Unprocessable => "Unprocessable entity",
-            Error::Utf8(ref err) => err.description(),
-        }
     }
 }
 

--- a/components/builder-core/src/error.rs
+++ b/components/builder-core/src/error.rs
@@ -80,30 +80,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::ApiError(..) => "Response returned a non-200 status code.",
-            Error::RpcError(..) => "Response returned a non-200 status code.",
-            Error::HttpClient(ref err) => err.description(),
-            Error::IO(ref err) => err.description(),
-            Error::Base64Error(ref e) => e.description(),
-            Error::ChronoError(ref e) => e.description(),
-            Error::DecryptError(_) => "Error decrypting integration",
-            Error::EncryptError(_) => "Error encrypting integration",
-            Error::FromUtf8Error(ref e) => e.description(),
-            Error::HabitatCore(ref err) => err.description(),
-            Error::OriginDeleteError(_) => "Error attempting to delete origin",
-            Error::OriginMemberRoleError(_) => "Error parsing member type",
-            Error::Protobuf(ref err) => err.description(),
-            Error::Protocol(ref err) => err.description(),
-            Error::Serialization(ref err) => err.description(),
-            Error::TokenInvalid => "Token is invalid",
-            Error::TokenExpired => "Token is expired",
-            Error::BadResponse => "Response missing required fields",
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl From<hab_core::Error> for Error {
     fn from(err: hab_core::Error) -> Error { Error::HabitatCore(err) }

--- a/components/builder-db/src/error.rs
+++ b/components/builder-db/src/error.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{error,
-          fmt,
+use std::{fmt,
           result};
 
 use postgres;
@@ -87,35 +86,6 @@ impl fmt::Display for Error {
             Error::TransactionCommit(ref e) => format!("Error committing transaction: {}", e),
         };
         write!(f, "{}", msg)
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::AsyncListen(ref e) => e.description(),
-            Error::AsyncNotification(ref e) => e.description(),
-            Error::AsyncMalformedChannel(_) => "Error parsing a channel string",
-            Error::AsyncMalformedShardId(_) => "Error parsing a channel strings shard id",
-            Error::AsyncFunctionCheck(ref e) => e.description(),
-            Error::AsyncFunctionUpdate(ref e) => e.description(),
-            Error::ConnectionTimeout(ref e) => e.description(),
-            Error::FunctionCreate(_) => "Error creating database function",
-            Error::FunctionDrop(_) => "Error dropping database function",
-            Error::FunctionRun(_) => "Error running a database function",
-            Error::Migration(_) => "Error executing migration",
-            Error::MigrationCheck(_) => "Error checking if a migration has run",
-            Error::MigrationTable(_) => "Error creat2ing migration tracking table",
-            Error::MigrationTracking(_) => "Error updating migration tracking table",
-            Error::MigrationLock(_) => "Error getting migration lock",
-            Error::PostgresConnect(ref e) => e.description(),
-            Error::SchemaCreate(_) => "Error creating a schema",
-            Error::SchemaDrop(_) => "Error dropping a schema",
-            Error::SchemaSwitch(_) => "Error switching schema",
-            Error::SetSearchPath(_) => "Error setting local search path",
-            Error::TransactionCreate(_) => "Error creating a transaction",
-            Error::TransactionCommit(_) => "Error committing a transaction",
-        }
     }
 }
 

--- a/components/builder-graph/src/error.rs
+++ b/components/builder-graph/src/error.rs
@@ -62,22 +62,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Db(ref err) => err.description(),
-            Error::DbPoolTimeout(ref err) => err.description(),
-            Error::DbTransaction(ref err) => err.description(),
-            Error::DieselError(ref err) => err.description(),
-            Error::HabitatCore(ref err) => err.description(),
-            Error::IO(ref err) => err.description(),
-            Error::JobGraphPackagesGet(ref err) => err.description(),
-            Error::Protobuf(ref err) => err.description(),
-            Error::Serde(ref err) => err.description(),
-            Error::UnknownJobGraphPackage => "Unknown Package",
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl From<hab_core::Error> for Error {
     fn from(err: hab_core::Error) -> Error { Error::HabitatCore(err) }

--- a/components/builder-jobsrv/src/error.rs
+++ b/components/builder-jobsrv/src/error.rs
@@ -196,66 +196,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::BuilderCore(ref err) => err.description(),
-            Error::BusyWorkerUpsert(ref err) => err.description(),
-            Error::BusyWorkerDelete(ref err) => err.description(),
-            Error::BusyWorkersGet(ref err) => err.description(),
-            Error::CaughtPanic(..) => "Caught a panic",
-            Error::Conflict => "Entity conflict",
-            Error::Db(ref err) => err.description(),
-            Error::DbPoolTimeout(ref err) => err.description(),
-            Error::DbTransaction(ref err) => err.description(),
-            Error::DbTransactionCommit(ref err) => err.description(),
-            Error::DbTransactionStart(ref err) => err.description(),
-            Error::DieselError(ref err) => err.description(),
-            Error::FromUtf8(ref err) => err.description(),
-            Error::HabitatCore(ref err) => err.description(),
-            Error::IO(ref err) => err.description(),
-            Error::InvalidUrl => "Bad Url!",
-            Error::JobGroupAudit(ref err) => err.description(),
-            Error::JobGroupCreate(ref err) => err.description(),
-            Error::JobGroupCancel(ref err) => err.description(),
-            Error::JobGroupGet(ref err) => err.description(),
-            Error::JobGroupOriginGet(ref err) => err.description(),
-            Error::JobGroupPending(ref err) => err.description(),
-            Error::JobGroupSetState(ref err) => err.description(),
-            Error::JobGraphPackageInsert(ref err) => err.description(),
-            Error::JobGraphPackageStats(ref err) => err.description(),
-            Error::JobGraphPackagesGet(ref err) => err.description(),
-            Error::JobGroupProjectSetState(ref err) => err.description(),
-            Error::JobCreate(ref err) => err.description(),
-            Error::JobGet(ref err) => err.description(),
-            Error::JobLogArchive(_, ref err) => err.description(),
-            Error::JobLogRetrieval(_, ref err) => err.description(),
-            Error::JobMarkArchived(ref err) => err.description(),
-            Error::JobPending(ref err) => err.description(),
-            Error::JobReset(ref err) => err.description(),
-            Error::JobSetLogUrl(ref err) => err.description(),
-            Error::JobSetState(ref err) => err.description(),
-            Error::SyncJobs(ref err) => err.description(),
-            Error::LogDirDoesNotExist(_, ref err) => err.description(),
-            Error::LogDirIsNotDir(_) => "Build log directory is not a directory",
-            Error::LogDirNotWritable(_) => "Build log directory is not writable",
-            Error::NotFound => "Entity not found",
-            Error::ParseError(ref err) => err.description(),
-            Error::ParseVCSInstallationId(_) => "VCS installation id could not be parsed as u64",
-            Error::Protobuf(ref err) => err.description(),
-            Error::Protocol(ref err) => err.description(),
-            Error::System => "Internal error",
-            Error::UnknownJobState(ref err) => err.description(),
-            Error::UnknownJobGroup => "Unknown Group",
-            Error::UnknownJobGroupState => "Unknown Group State",
-            Error::UnknownJobGraphPackage => "Unknown Package",
-            Error::UnknownJobGroupProjectState => "Unknown Project State",
-            Error::UnknownVCS => "Unknown VCS",
-            Error::Utf8(ref err) => err.description(),
-            Error::Zmq(ref err) => err.description(),
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl Into<HttpResponse> for Error {
     fn into(self) -> HttpResponse {

--- a/components/builder-protocol/src/error.rs
+++ b/components/builder-protocol/src/error.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{error,
-          fmt,
+use std::{fmt,
           result,
           string::FromUtf8Error};
 
@@ -56,23 +55,5 @@ impl fmt::Display for ProtocolError {
             }
         };
         write!(f, "{}", msg)
-    }
-}
-
-impl error::Error for ProtocolError {
-    fn description(&self) -> &str {
-        match *self {
-            ProtocolError::BadJobGroupProjectState(_) => "Job Group Project state cannot be parsed",
-            ProtocolError::BadJobGroupState(_) => "Job Group state cannot be parsed",
-            ProtocolError::BadJobState(_) => "Job state cannot be parsed",
-            ProtocolError::BadOriginPackageVisibility(_) => {
-                "Origin package visibility cannot be parsed"
-            }
-            ProtocolError::BadOs(_) => "OS cannot be parsed",
-            ProtocolError::Decode(_) => "Unable to decode protocol message",
-            ProtocolError::Encode(_) => "Unable to encode protocol message",
-            ProtocolError::IdentityDecode(_) => "Unable to decode identity message part",
-            ProtocolError::NoProtocol(_) => "No `net::Protocol` matches the given string",
-        }
     }
 }

--- a/components/builder-worker/src/error.rs
+++ b/components/builder-worker/src/error.rs
@@ -140,40 +140,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::BuildEnvFile(..) => "Unable to read workspace build env file",
-            Error::BuildFailure(_) => "Build studio exited with a non-zero exit code",
-            Error::BuilderCore(ref err) => err.description(),
-            Error::CannotAddCreds => "Cannot add credentials to url",
-            Error::Chown(..) => "Unable to recursively chown path",
-            Error::ChownWait(_) => "Unable to complete chown process",
-            Error::CreateDirectory(..) => "Unable to create directory",
-            Error::Exporter(_) => "IO Error while spawning or piping data from exporter proc",
-            Error::ExportFailure(_) => "Docker export exited with a non-zero exit code",
-            Error::Git(ref err) => err.description(),
-            Error::GithubAppAuthErr(ref err) => err.description(),
-            Error::HabitatCore(ref err) => err.description(),
-            Error::InvalidIntegrations(_) => "Invalid integrations detected",
-            Error::NotHTTPSCloneUrl(_) => "Only HTTPS clone urls are supported",
-            Error::Protobuf(ref err) => err.description(),
-            Error::Protocol(ref err) => err.description(),
-            Error::Retry(ref err) => err.description(),
-            Error::StreamTargetSend(_) => "Error while writing message to a job stream",
-            Error::StreamLine(_) => "Error while reading a line while consuming an output stream",
-            Error::StudioBuild(..) => "IO Error while running studio build",
-            Error::StudioTeardown(..) => "IO Error while tearing down studio",
-            Error::WorkspaceSetup(..) => "IO Error while creating workspace on disk",
-            Error::WorkspaceTeardown(..) => "IO Error while destroying workspace on disk",
-            Error::Zmq(ref err) => err.description(),
-            Error::UrlParseError(ref err) => err.description(),
-            Error::Mpsc(ref err) => err.description(),
-            Error::MpscAsync(ref err) => err.description(),
-            Error::JobCanceled => "Job was canceled",
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl From<bldr_core::Error> for Error {
     fn from(err: bldr_core::Error) -> Error { Error::BuilderCore(err) }

--- a/components/github-api-client/src/error.rs
+++ b/components/github-api-client/src/error.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::{collections::HashMap,
-          error,
           fmt,
           io};
 
@@ -55,21 +54,6 @@ impl fmt::Display for HubError {
             HubError::Serialization(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
-    }
-}
-
-impl error::Error for HubError {
-    fn description(&self) -> &str {
-        match *self {
-            HubError::ApiError(..) => "Response returned a non-200 status code.",
-            HubError::AppAuth(_) => "GitHub App authorization error.",
-            HubError::BuilderCore(ref err) => err.description(),
-            HubError::ContentDecode(ref err) => err.description(),
-            HubError::HttpClient(ref err) => err.description(),
-            HubError::IO(ref err) => err.description(),
-            HubError::JWT(_) => "Unable to generate JWT token",
-            HubError::Serialization(ref err) => err.description(),
-        }
     }
 }
 

--- a/components/oauth-client/src/error.rs
+++ b/components/oauth-client/src/error.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{error,
-          fmt};
+use std::fmt;
 
 use builder_core;
 use reqwest;
@@ -41,17 +40,6 @@ impl fmt::Display for Error {
             Error::Serialization(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::BuilderCore(ref err) => err.description(),
-            Error::HttpClient(ref err) => err.description(),
-            Error::HttpResponse(..) => "Non-200 HTTP response.",
-            Error::Serialization(ref err) => err.description(),
-        }
     }
 }
 


### PR DESCRIPTION
The `description` fn in the Error trait has been deprecated since Rust 1.42.0. This commit removes all
usage of it in builder, in addition to removing any error::Error impl that are no longer necessary. 

Reference: https://doc.rust-lang.org/std/error/trait.Error.html#method.description

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>