### PR TITLE
Wrap package_graph_for_target in package_graph_trait compatible layer

### DIFF
--- a/components/builder-graph/src/cyclic_package_graph.rs
+++ b/components/builder-graph/src/cyclic_package_graph.rs
@@ -53,22 +53,20 @@ impl PackageGraphTrait for CyclicPackageGraph {
 
     fn rdeps(&self, name: &str) -> Option<Vec<(String, String)>> {
         let ident = PackageIdentIntern::from_str(name);
-        let rdeps = ident.ok().map(|r| {
-                                  self.graph
-                                      .rdeps(r, None)
-                                      .iter()
-                                      .map(|(dep, fq_dep)| (dep.to_string(), fq_dep.to_string()))
-                                      .collect()
-                              });
-        rdeps
+        ident.ok().map(|r| {
+                      self.graph
+                          .rdeps(r, None)
+                          .iter()
+                          .map(|(dep, fq_dep)| (dep.to_string(), fq_dep.to_string()))
+                          .collect()
+                  })
     }
 
     fn resolve(&self, name: &str) -> Option<String> {
         let ident = PackageIdent::from_str(name);
-        let resolved = ident.ok()
-                            .map(|r| self.graph.resolve(r.as_ref()).map(|r| r.to_string()))
-                            .flatten();
-        resolved
+        ident.ok()
+             .map(|r| self.graph.resolve(r.as_ref()).map(|r| r.to_string()))
+             .flatten()
     }
 
     fn stats(&self) -> Stats { self.graph.stats() }

--- a/components/builder-graph/src/cyclic_package_graph.rs
+++ b/components/builder-graph/src/cyclic_package_graph.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{str::FromStr,
+          string::ToString};
+
+use crate::protocol::originsrv;
+
+use crate::{hab_core::package::PackageIdent,
+            package_graph_target::PackageGraphForTarget,
+            package_graph_trait::{PackageGraphTrait,
+                                  Stats},
+            package_ident_intern::PackageIdentIntern,
+            package_info::PackageInfo};
+
+struct CyclicPackageGraph {
+    graph: PackageGraphForTarget,
+}
+
+impl PackageGraphTrait for CyclicPackageGraph {
+    fn build(&mut self,
+             packages: &[originsrv::OriginPackage],
+             use_build_deps: bool)
+             -> (usize, usize) {
+        let package_info: Vec<PackageInfo> =
+            packages.iter().cloned().map(PackageInfo::from).collect();
+        self.graph.build(package_info.into_iter(), use_build_deps)
+    }
+
+    fn extend(&mut self,
+              package: &originsrv::OriginPackage,
+              use_build_deps: bool)
+              -> (usize, usize) {
+        let package_info = PackageInfo::from(package.clone());
+        self.graph.extend(&package_info, use_build_deps)
+    }
+
+    fn check_extend(&mut self, package: &originsrv::OriginPackage, use_build_deps: bool) -> bool {
+        let package_info = PackageInfo::from(package.clone());
+        self.graph.check_extend(&package_info, use_build_deps)
+    }
+
+    fn rdeps(&self, name: &str) -> Option<Vec<(String, String)>> {
+        let ident = PackageIdentIntern::from_str(name);
+        let rdeps = ident.ok().map(|r| {
+                                  self.graph
+                                      .rdeps(r, None)
+                                      .iter()
+                                      .map(|(dep, fq_dep)| (dep.to_string(), fq_dep.to_string()))
+                                      .collect()
+                              });
+        rdeps
+    }
+
+    fn resolve(&self, name: &str) -> Option<String> {
+        let ident = PackageIdent::from_str(name);
+        let resolved = ident.ok()
+                            .map(|r| self.graph.resolve(r.as_ref()).map(|r| r.to_string()))
+                            .flatten();
+        resolved
+    }
+
+    fn stats(&self) -> Stats { self.graph.stats() }
+}

--- a/components/builder-graph/src/lib.rs
+++ b/components/builder-graph/src/lib.rs
@@ -16,16 +16,39 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
 #[macro_use]
+extern crate serde_derive;
+
+#[macro_use]
 extern crate log;
+#[macro_use]
+extern crate lazy_static;
+
+extern crate diesel;
+
+extern crate internment;
+extern crate serde;
+extern crate serde_json;
 
 use habitat_builder_db as db;
 use habitat_builder_protocol as protocol;
 use habitat_core as hab_core;
 
+#[macro_use]
+pub mod package_ident_intern;
 pub mod acyclic_package_graph;
 pub mod acyclic_rdeps;
+pub mod config;
+pub mod cyclic_package_graph;
+pub mod data_store;
 pub mod error;
+pub mod graph_helpers;
+pub mod package_build_manifest_graph;
+pub mod package_graph;
+pub mod package_graph_target;
 pub mod package_graph_trait;
+pub mod package_info;
+pub mod rdeps;
 pub mod target_graph;
+pub mod util;
 
 pub use crate::error::Error;

--- a/components/builder-graph/src/main.rs
+++ b/components/builder-graph/src/main.rs
@@ -33,6 +33,8 @@ extern crate serde;
 extern crate serde_json;
 
 use habitat_builder_db as db;
+use habitat_builder_protocol as protocol;
+
 use habitat_core as hab_core;
 
 #[macro_use]
@@ -44,6 +46,7 @@ pub mod graph_helpers;
 pub mod package_build_manifest_graph;
 pub mod package_graph;
 pub mod package_graph_target;
+pub mod package_graph_trait;
 pub mod package_info;
 pub mod rdeps;
 pub mod util;
@@ -504,7 +507,7 @@ fn do_rdeps(graph: &PackageGraph, matches: &ArgMatches) {
     let mut file = File::create(&filename).unwrap();
 
     writeln!(&mut file, "{}", ident).unwrap();
-    for dep in &rdeps {
+    for (dep, _) in &rdeps {
         if *dep != ident {
             writeln!(&mut file, "  {}", dep).unwrap();
         }

--- a/components/builder-graph/src/package_graph.rs
+++ b/components/builder-graph/src/package_graph.rs
@@ -19,8 +19,8 @@ use crate::{data_store::Unbuildable,
             hab_core::package::{PackageIdent,
                                 PackageTarget},
             package_build_manifest_graph::PackageBuild,
-            package_graph_target::{PackageGraphForTarget,
-                                   Stats},
+            package_graph_target::PackageGraphForTarget,
+            package_graph_trait::Stats,
             package_ident_intern::PackageIdentIntern,
             package_info::PackageInfo,
             util::*};
@@ -82,7 +82,7 @@ impl PackageGraph {
     pub fn rdeps(&self,
                  ident: &PackageIdentIntern,
                  origin: Option<&str>)
-                 -> Vec<PackageIdentIntern> {
+                 -> Vec<(PackageIdentIntern, PackageIdentIntern)> {
         if let Some(graph) = self.graphs.get(&self.current_target) {
             graph.borrow().rdeps(*ident, origin)
         } else {

--- a/components/builder-graph/src/package_graph_trait.rs
+++ b/components/builder-graph/src/package_graph_trait.rs
@@ -14,6 +14,9 @@
 
 use crate::protocol::originsrv;
 
+use crate::hab_core::package::{PackageIdent,
+                               PackageTarget};
+
 #[derive(Debug)]
 pub struct Stats {
     pub node_count:     usize,
@@ -32,7 +35,13 @@ pub trait PackageGraphTrait: Send + Sync {
               use_build_deps: bool)
               -> (usize, usize);
     fn check_extend(&mut self, package: &originsrv::OriginPackage, use_build_deps: bool) -> bool;
+    // This probably should be refactored to a return some sort of Result type
+
+    // The tuple returned is the plan name (e.g. short name) and
+    // the fully qualifed package name of the latest package with that short name.
     fn rdeps(&self, name: &str) -> Option<Vec<(String, String)>>;
+
+    // This probably should be refactored to a return some sort of Result type
     fn resolve(&self, name: &str) -> Option<String>;
     fn stats(&self) -> Stats;
 }

--- a/components/builder-graph/src/package_graph_trait.rs
+++ b/components/builder-graph/src/package_graph_trait.rs
@@ -14,9 +14,6 @@
 
 use crate::protocol::originsrv;
 
-use crate::hab_core::package::{PackageIdent,
-                               PackageTarget};
-
 #[derive(Debug)]
 pub struct Stats {
     pub node_count:     usize,


### PR DESCRIPTION
This takes the new cyclic graph work and wraps it in the
package_graph_trait. There's some conversion work required as the
existing API uses Strings where we might have a PackageIdent, and
package information is represented as a originsrv::OriginPackage and
needs to be converted to the internal representation.

This is the first part of the solution to issue  #1476 (closes #1476) and is on the path between #1456 and #1457 

Signed-off-by: Mark Anderson <mark@chef.io>
Co-authored-by: Scott Macfarlane <smacfarlane@chef.io>
Co-authored-by: Mark Anderson <mark@chef.io>