### PR TITLE
Ma/fixup lints

### DIFF
--- a/components/artifactory-client/src/error.rs
+++ b/components/artifactory-client/src/error.rs
@@ -16,9 +16,6 @@ use std::{collections::HashMap,
           fmt,
           io};
 
-use builder_core;
-use reqwest;
-
 pub type ArtifactoryResult<T> = Result<T, ArtifactoryError>;
 
 #[derive(Debug)]

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -25,8 +25,6 @@ use std::{env,
           option::IntoIter,
           path::PathBuf};
 
-use num_cpus;
-
 use artifactory_client::config::ArtifactoryCfg;
 use github_api_client::config::GitHubCfg;
 use oauth_client::config::OAuth2Cfg;

--- a/components/builder-api/src/server/error.rs
+++ b/components/builder-api/src/server/error.rs
@@ -17,14 +17,11 @@ use actix_web::{self,
                 HttpResponse,
                 ResponseError};
 use artifactory_client::error::ArtifactoryError;
-use diesel;
 use github_api_client::HubError;
 use oauth_client::error::Error as OAuthError;
-use protobuf;
-use reqwest;
+
 use rusoto_core::RusotoError;
-use rusoto_s3;
-use serde_json;
+
 use std::{fmt,
           fs,
           io,

--- a/components/builder-api/src/server/framework/middleware.rs
+++ b/components/builder-api/src/server/framework/middleware.rs
@@ -26,9 +26,7 @@ use futures::future::{ok,
                       Either,
                       Future};
 
-use base64;
 use oauth_client::types::OAuth2User;
-use protobuf;
 
 use crate::bldr_core::{self,
                        access_token::{BUILDER_ACCOUNT_ID,

--- a/components/builder-api/src/server/helpers.rs
+++ b/components/builder-api/src/server/helpers.rs
@@ -10,7 +10,6 @@ use actix_web::{http::header,
                 HttpRequest};
 use regex::Regex;
 use serde::Serialize;
-use serde_json;
 use std::str::FromStr;
 
 // TODO - this module should not just be a grab bag of stuff

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -27,7 +27,6 @@ use diesel::{pg::PgConnection,
              result::{DatabaseErrorKind,
                       Error::{DatabaseError,
                               NotFound}}};
-use serde_json;
 
 use crate::{bldr_core::metrics::CounterMetric,
             hab_core::{package::{PackageIdent,

--- a/components/builder-api/src/server/resources/ext.rs
+++ b/components/builder-api/src/server/resources/ext.rs
@@ -22,8 +22,6 @@ use actix_web::{http::StatusCode,
                 HttpRequest,
                 HttpResponse};
 
-use serde_json;
-
 use reqwest::header::HeaderMap;
 
 use builder_core::http_client::{HttpClient,

--- a/components/builder-api/src/server/resources/jobs.rs
+++ b/components/builder-api/src/server/resources/jobs.rs
@@ -26,7 +26,6 @@ use actix_web::{http::{self,
                       ServiceConfig},
                 HttpRequest,
                 HttpResponse};
-use serde_json;
 
 use crate::protocol::{jobsrv,
                       net::NetOk,

--- a/components/builder-api/src/server/resources/origins.rs
+++ b/components/builder-api/src/server/resources/origins.rs
@@ -40,7 +40,6 @@ use builder_core::Error::OriginDeleteError;
 use bytes::Bytes;
 use diesel::{pg::PgConnection,
              result::Error::NotFound};
-use serde_json;
 
 use crate::{bldr_core,
             hab_core::{crypto::{keys::{box_key_pair::WrappedSealedBox,

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -70,10 +70,7 @@ use bytes::Bytes;
 use diesel::result::Error::NotFound;
 use futures::{channel::mpsc,
               StreamExt};
-use percent_encoding;
-use protobuf;
 use serde::ser::Serialize;
-use serde_json;
 use std::{fs::{self,
                remove_file,
                File},

--- a/components/builder-api/src/server/resources/profile.rs
+++ b/components/builder-api/src/server/resources/profile.rs
@@ -21,7 +21,6 @@ use actix_web::{http::{self,
                       ServiceConfig},
                 HttpRequest,
                 HttpResponse};
-use serde_json;
 
 use crate::{bldr_core,
             protocol::originsrv};

--- a/components/builder-api/src/server/resources/projects.rs
+++ b/components/builder-api/src/server/resources/projects.rs
@@ -25,7 +25,6 @@ use actix_web::{http::{self,
                       ServiceConfig},
                 HttpRequest,
                 HttpResponse};
-use serde_json;
 
 use crate::protocol::jobsrv;
 

--- a/components/builder-api/src/server/services/github.rs
+++ b/components/builder-api/src/server/services/github.rs
@@ -28,11 +28,9 @@ use actix_web::{error,
 use github_api_client::{types::GitHubWebhookPush,
                         AppToken,
                         GitHubClient};
-use hex;
 use openssl::{hash::MessageDigest,
               pkey::PKey,
               sign::Signer};
-use serde_json;
 use std::{collections::HashSet,
           path::PathBuf,
           str::FromStr};

--- a/components/builder-api/src/server/services/memcache.rs
+++ b/components/builder-api/src/server/services/memcache.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use memcache;
 use protobuf::{self,
                Message};
 use rand::{self,

--- a/components/builder-core/src/api_client.rs
+++ b/components/builder-core/src/api_client.rs
@@ -28,7 +28,6 @@ use reqwest::{header::HeaderMap,
               StatusCode};
 
 use futures::stream::StreamExt;
-use serde_json;
 use tokio::io::AsyncWriteExt;
 
 use crate::{error::{Error,

--- a/components/builder-core/src/build_config.rs
+++ b/components/builder-core/src/build_config.rs
@@ -22,13 +22,11 @@ use std::{collections::{HashMap,
           str::FromStr,
           string::ToString};
 
-use glob;
 use serde::{de,
             Deserialize,
             Deserializer,
             Serialize,
             Serializer};
-use toml;
 
 use crate::{error::{Error,
                     Result},

--- a/components/builder-core/src/error.rs
+++ b/components/builder-core/src/error.rs
@@ -18,12 +18,6 @@ use std::{error,
           result,
           string};
 
-use base64;
-use chrono;
-use protobuf;
-use reqwest;
-use serde_json;
-
 use crate::{hab_core,
             protocol};
 

--- a/components/builder-core/src/integrations.rs
+++ b/components/builder-core/src/integrations.rs
@@ -17,8 +17,6 @@
 
 use std::path::Path;
 
-use base64;
-
 use crate::{error::{Error,
                     Result},
             hab_core::crypto::{keys::box_key_pair::WrappedSealedBox,

--- a/components/builder-core/src/rpc.rs
+++ b/components/builder-core/src/rpc.rs
@@ -18,9 +18,6 @@ use reqwest::{header::HeaderMap,
               Client,
               StatusCode};
 
-use protobuf;
-use serde_json;
-
 use crate::{error::{Error,
                     Result},
             http_client::{ACCEPT_APPLICATION_JSON,

--- a/components/builder-core/src/socket.rs
+++ b/components/builder-core/src/socket.rs
@@ -17,8 +17,6 @@ use std::{cell::UnsafeCell,
                 SocketAddrV4,
                 SocketAddrV6}};
 
-use zmq;
-
 use crate::hab_core::os;
 
 lazy_static! {

--- a/components/builder-db/src/config.rs
+++ b/components/builder-db/src/config.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use num_cpus;
 use percent_encoding::{utf8_percent_encode,
                        AsciiSet,
                        CONTROLS};

--- a/components/builder-db/src/error.rs
+++ b/components/builder-db/src/error.rs
@@ -15,9 +15,6 @@
 use std::{fmt,
           result};
 
-use postgres;
-use r2d2;
-
 #[derive(Debug)]
 pub enum Error {
     AsyncListen(postgres::error::Error),

--- a/components/builder-db/src/models/origin.rs
+++ b/components/builder-db/src/models/origin.rs
@@ -434,6 +434,7 @@ mod tests {
         let maintainer = OriginMemberRole::Maintainer;
         let administrator = OriginMemberRole::Administrator;
         let owner = OriginMemberRole::Owner;
+        assert_eq!(owner > administrator, true);
         assert_eq!(administrator > maintainer, true);
         assert_eq!(maintainer > member, true);
         assert_eq!(member > readonly_member, true);

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -6,7 +6,6 @@ use std::{fmt,
           time::Instant};
 
 use chrono::NaiveDateTime;
-use protobuf;
 
 use diesel::{self,
              deserialize::{self,

--- a/components/builder-db/src/pool.rs
+++ b/components/builder-db/src/pool.rs
@@ -18,7 +18,6 @@ use std::{fmt,
           thread,
           time::Duration};
 
-use r2d2;
 use r2d2_postgres::{self,
                     PostgresConnectionManager,
                     TlsMode};

--- a/components/builder-graph/src/error.rs
+++ b/components/builder-graph/src/error.rs
@@ -20,10 +20,6 @@ use std::{error,
 use crate::{db,
             hab_core};
 
-use postgres;
-use protobuf;
-use r2d2;
-
 #[derive(Debug)]
 pub enum Error {
     Db(db::error::Error),

--- a/components/builder-graph/src/util.rs
+++ b/components/builder-graph/src/util.rs
@@ -183,7 +183,7 @@ pub fn file_into_idents(path: &str) -> Result<Vec<PackageIdent>, error::Error> {
 }
 
 fn line_to_ident(line: &str) -> Option<Result<PackageIdent, error::Error>> {
-    let trimmed = line.split('#').nth(0).unwrap_or("").trim();
+    let trimmed = line.split('#').next().unwrap_or("").trim();
     match trimmed.len() {
         0 => None,
         _ => Some(PackageIdent::from_str(trimmed).map_err(error::Error::HabitatCore)),

--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -25,8 +25,6 @@ use std::{collections::HashSet,
           option::IntoIter,
           path::PathBuf};
 
-use num_cpus;
-
 use crate::{db::config::DataStoreCfg,
             hab_core::{config::ConfigFile,
                        package::target::{self,

--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -23,7 +23,6 @@ use chrono::{DateTime,
              Utc};
 use diesel::{result::Error as Dre,
              Connection};
-use postgres;
 use protobuf::{self,
                ProtobufEnum,
                RepeatedField};

--- a/components/builder-jobsrv/src/error.rs
+++ b/components/builder-jobsrv/src/error.rs
@@ -22,15 +22,6 @@ use std::{error,
 use actix_web::{http::StatusCode,
                 HttpResponse};
 
-use chrono;
-use diesel;
-use postgres;
-use protobuf;
-use r2d2;
-use rusoto_core;
-use rusoto_s3;
-use zmq;
-
 use crate::{bldr_core,
             db,
             hab_core,

--- a/components/builder-jobsrv/src/server/handlers.rs
+++ b/components/builder-jobsrv/src/server/handlers.rs
@@ -287,7 +287,7 @@ fn populate_build_projects(msg: &jobsrv::JobGroupSpec,
             continue;
         };
 
-        let origin = s.0.split('/').nth(0).unwrap();
+        let origin = s.0.split('/').next().unwrap();
 
         // If the origin_only flag is true, make sure the origin matches
         if !msg.get_origin_only() || origin == msg.get_origin() {

--- a/components/builder-jobsrv/src/server/log_ingester.rs
+++ b/components/builder-jobsrv/src/server/log_ingester.rs
@@ -29,7 +29,6 @@ use std::{fs::{self,
           sync::mpsc,
           thread::{self,
                    JoinHandle}};
-use zmq;
 
 /// ZMQ protocol frame to indicate a log line is being sent
 const LOG_LINE: &str = "L";

--- a/components/builder-jobsrv/src/server/scheduler.rs
+++ b/components/builder-jobsrv/src/server/scheduler.rs
@@ -22,8 +22,6 @@ use std::{collections::{HashMap,
 use chrono::{DateTime,
              Duration,
              Utc};
-use diesel;
-use zmq;
 
 use crate::{config::Config,
             data_store::DataStore,

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -47,8 +47,6 @@ use crate::db::models::{integration::*,
 use crate::protocol::{jobsrv,
                       originsrv};
 
-use zmq;
-
 use crate::{config::Config,
             data_store::DataStore,
             error::{Error,

--- a/components/builder-protocol/src/error.rs
+++ b/components/builder-protocol/src/error.rs
@@ -16,8 +16,6 @@ use std::{fmt,
           result,
           string::FromUtf8Error};
 
-use protobuf;
-
 #[derive(Debug)]
 pub enum ProtocolError {
     BadJobGroupProjectState(String),

--- a/components/builder-protocol/src/message/mod.rs
+++ b/components/builder-protocol/src/message/mod.rs
@@ -19,8 +19,6 @@ pub mod net;
 #[allow(renamed_and_removed_lints)]
 pub mod originsrv;
 
-use protobuf;
-
 use crate::error::ProtocolError;
 
 pub use self::net::{ErrCode,

--- a/components/builder-worker/src/error.rs
+++ b/components/builder-worker/src/error.rs
@@ -12,19 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures_channel;
-use git2;
-use github_api_client;
-use protobuf;
-use retry;
 use std::{error,
           fmt,
           io,
           path::PathBuf,
           result,
           sync::mpsc};
-use url;
-use zmq;
 
 use crate::{bldr_core,
             hab_core,

--- a/components/builder-worker/src/heartbeat.rs
+++ b/components/builder-worker/src/heartbeat.rs
@@ -17,8 +17,6 @@ use std::{sync::mpsc,
                    JoinHandle},
           time::Duration};
 
-use zmq;
-
 use crate::{bldr_core::socket::DEFAULT_CONTEXT,
             protocol::{jobsrv as proto,
                        message}};

--- a/components/builder-worker/src/log_forwarder.rs
+++ b/components/builder-worker/src/log_forwarder.rs
@@ -17,8 +17,6 @@ use std::{sync::mpsc,
                    JoinHandle},
           time::Duration};
 
-use zmq;
-
 use crate::{bldr_core::{logger::Logger,
                         socket::DEFAULT_CONTEXT},
             config::Config,

--- a/components/builder-worker/src/runner/job_streamer.rs
+++ b/components/builder-worker/src/runner/job_streamer.rs
@@ -31,7 +31,6 @@ use std::{fmt,
           thread};
 
 use protobuf::Message;
-use zmq;
 
 use crate::{bldr_core::{logger::Logger,
                         socket::DEFAULT_CONTEXT},

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -46,7 +46,6 @@ use std::{fs,
           thread::{self,
                    JoinHandle},
           time::Duration};
-use zmq;
 
 // TODO fn: copied from `components/common/src/ui.rs`. As this component doesn't currently depend
 // on habitat_common it didnt' seem worth it to add a dependency for only this constant. Probably

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -19,8 +19,6 @@ use std::{collections::HashMap,
           thread,
           time::Duration};
 
-use zmq;
-
 use crate::{bldr_core::{self,
                         socket::DEFAULT_CONTEXT},
             protocol::{jobsrv,

--- a/components/builder-worker/src/vcs.rs
+++ b/components/builder-worker/src/vcs.rs
@@ -14,7 +14,6 @@
 
 use std::path::Path;
 
-use git2;
 use github_api_client::{GitHubCfg,
                         GitHubClient};
 use url::Url;

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -12,7 +12,7 @@ use builder_core::{http_client::{HttpClient,
                    metrics::CounterMetric};
 use reqwest::{header::HeaderMap,
               StatusCode};
-use serde_json;
+
 use std::{collections::HashMap,
           iter::FromIterator,
           path::Path,

--- a/components/github-api-client/src/error.rs
+++ b/components/github-api-client/src/error.rs
@@ -16,11 +16,6 @@ use std::{collections::HashMap,
           fmt,
           io};
 
-use base64;
-use builder_core;
-use reqwest;
-use serde_json;
-
 use crate::{jwt,
             types};
 

--- a/components/github-api-client/src/types.rs
+++ b/components/github-api-client/src/types.rs
@@ -14,8 +14,6 @@
 
 use std::fmt;
 
-use base64;
-
 use crate::error::{HubError,
                    HubResult};
 

--- a/components/oauth-client/src/a2.rs
+++ b/components/oauth-client/src/a2.rs
@@ -14,8 +14,6 @@
 
 use std::iter::FromIterator;
 
-use serde_json;
-
 use reqwest::{header::HeaderMap,
               Body};
 

--- a/components/oauth-client/src/azure_ad.rs
+++ b/components/oauth-client/src/azure_ad.rs
@@ -14,8 +14,6 @@
 
 use std::iter::FromIterator;
 
-use serde_json;
-
 use reqwest::{header::HeaderMap,
               Body};
 

--- a/components/oauth-client/src/bitbucket.rs
+++ b/components/oauth-client/src/bitbucket.rs
@@ -13,8 +13,6 @@
 
 use std::iter::FromIterator;
 
-use serde_json;
-
 use reqwest::{header::HeaderMap,
               Body};
 

--- a/components/oauth-client/src/error.rs
+++ b/components/oauth-client/src/error.rs
@@ -14,10 +14,6 @@
 
 use std::fmt;
 
-use builder_core;
-use reqwest;
-use serde_json;
-
 #[derive(Debug)]
 pub enum Error {
     BuilderCore(builder_core::Error),

--- a/components/oauth-client/src/github.rs
+++ b/components/oauth-client/src/github.rs
@@ -14,8 +14,6 @@
 
 use std::iter::FromIterator;
 
-use serde_json;
-
 use reqwest::header::HeaderMap;
 
 use builder_core::http_client::{HttpClient,

--- a/components/oauth-client/src/gitlab.rs
+++ b/components/oauth-client/src/gitlab.rs
@@ -14,8 +14,6 @@
 
 use std::iter::FromIterator;
 
-use serde_json;
-
 use reqwest::header::HeaderMap;
 
 use builder_core::http_client::{HttpClient,

--- a/components/oauth-client/src/okta.rs
+++ b/components/oauth-client/src/okta.rs
@@ -14,8 +14,6 @@
 
 use std::iter::FromIterator;
 
-use serde_json;
-
 use reqwest::{header::HeaderMap,
               Body};
 

--- a/test/denied_lints.txt
+++ b/test/denied_lints.txt
@@ -59,7 +59,6 @@ clippy::type_repetition_in_bounds
 clippy::unit_arg
 clippy::unnecessary_operation
 clippy::unreadable_literal
-clippy::unused_label
 clippy::unused_unit
 clippy::useless_asref
 clippy::useless_format


### PR DESCRIPTION
At some point it looks like our lints got stricter; fixing the warnings so we can see new issues. 

Fixes are broken up into separate commits for
* unused 'use'
* nth(0) instead of next() in iterators
* removing deprecated lint for unused labels
* fixing a possibly missing test