### PR TITLE
updates builder-api-proxy to allow for nginx rate limiting

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -83,7 +83,7 @@ http {
 
   log_format nginx '$remote_addr - $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent $request_time '
-                   '"$http_referer" "$http_user_agent" - $http_x_forwarded_for ' 
+                   '"$http_referer" "$http_user_agent" - $http_x_forwarded_for '
                    '"$upstream_status" - $upstream_response_time';
 
   upstream backend {
@@ -187,6 +187,11 @@ http {
     location ~* ^/v1/depot/.*/latest$ {
       add_header Cache-Control "private, no-cache, no-store";
       proxy_pass http://backend;
+
+      {{~#if cfg.nginx.depot_limit_rate_enable}}
+      limit_rate_after {{cfg.nginx.depot_limit_rate_after}};
+      limit_rate       {{cfg.nginx.depot_limit_rate}};
+      {{~/if}}
     }
 
     location /v1/depot {
@@ -197,6 +202,11 @@ http {
       proxy_no_cache $flag_cache_empty;
       proxy_cache_bypass $flag_cache_empty;
       proxy_cache my_cache;
+      {{~/if}}
+
+      {{~#if cfg.nginx.depot_limit_rate_enable}}
+      limit_rate_after {{cfg.nginx.depot_limit_rate_after}};
+      limit_rate       {{cfg.nginx.depot_limit_rate}};
       {{~/if}}
     }
 

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -55,6 +55,9 @@ limit_ua_unknown_target   = "$http_x_forwarded_for"
 enable_caching            = false
 enable_gzip               = false
 enable_ipv6               = true
+depot_limit_rate_enable   = false
+depot_limit_rate_after    = "5k"
+depot_limit_rate          = "50k"
 
 [http]
 keepalive_connections     = 16


### PR DESCRIPTION
updates builder-api-proxy to allow for nginx rate limiting to depot locations

Allows for uses of `on-prem-builder` to have a method to implement nginx rate limiting for depot locations if needed to help as a component prevent network over-saturation in the event of an intended or accidental mass package deployment.  Applies configuration to `depot` locations from `builder-api-proxy` and seeds with some sample initial values, also adding a toggle to default to false.

Signed-off-by: Collin McNeese <cmcneese@chef.io>