### PR TITLE
OriginMemberRole::ReadonlyMember is the new minimum member level

### DIFF
--- a/components/builder-api/src/server/authorize.rs
+++ b/components/builder-api/src/server/authorize.rs
@@ -54,12 +54,9 @@ pub fn authorize_session(req: &HttpRequest,
         let minimum_req_role = match min_role {
             Some(r) => r,
             None => {
-                let r = OriginMemberRole::Maintainer;
-                // TODO: When we have finalized implementation of the various member roles,
-                // we should turn this into a warn level message.
-                // see: https://github.com/habitat-sh/builder/issues/1403
-                debug!("authorize_session: minimum role parameter not set! Assuming {}",
-                       r);
+                let r = OriginMemberRole::ReadonlyMember;
+                warn!("authorize_session: minimum role parameter not set! Assuming {}",
+                      r);
                 r
             }
         };


### PR DESCRIPTION
Circling back around and fixing a TODO.
Previously, when `Maintainer` was the default role for new members and nobody had changed roles from such, this line in `authorize.rs` was fine. 

In many places, resource endpoints make calls such as `authorize_session(&req, Some(&origin), None)` indicating the caller doesn't require a minimum role, but does require origin membership for a read operation.  As the new default membership role is now `ReadonlyMember`, this PR allows those callers to remain unchanged.

I have verified with all the callers that behave as such:
```
✔ ~/Projects/builder [jeremymv2/minimum_req_role L|…12⚑ 13]
14:44 $ find components/ -name \*\.rs | xargs grep -n authorize_session | grep "), *None)"
components//builder-api/src/server/resources/origins.rs:957:    let account_id = match authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/origins.rs:1149:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/origins.rs:1387:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/origins.rs:1472:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/origins.rs:1507:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/origins.rs:1607:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/projects.rs:245:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/projects.rs:440:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/projects.rs:471:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/projects.rs:601:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/settings.rs:59:    if let Err(err) = authorize_session(&req, Some(&origin), None) {
components//builder-api/src/server/resources/jobs.rs:243:               && authorize_session(req, Some(&origin_name), None).is_err()
✔ ~/Projects/builder [jeremymv2/minimum_req_role L|…12⚑ 13]
15:04 $
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>