### PR TITLE
Redirect non-origin members from private artifact view

### DIFF
--- a/components/builder-web/app/package/package-release/package-release.component.ts
+++ b/components/builder-web/app/package/package-release/package-release.component.ts
@@ -17,6 +17,7 @@ import { Title } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AppStore } from '../../app.store';
+import { requestRoute } from '../../actions/index';
 
 @Component({
   template: require('./package-release.component.html')
@@ -33,6 +34,14 @@ export class PackageReleaseComponent implements OnDestroy {
       .pipe(takeUntil(this.isDestroyed$))
       .subscribe(({ origin, name, version, release }) => {
         this.title.setTitle(`Packages › ${origin}/${name}/${version}/${release} | ${store.getState().app.name}`);
+      });
+
+    this.store.observe('packages.ui.current.errorMessage')
+      .pipe(takeUntil(this.isDestroyed$))
+      .subscribe(errorMessage => {
+        if (errorMessage) {
+          this.store.dispatch(requestRoute(['/pkgs']));
+        }
       });
   }
 


### PR DESCRIPTION
If an unauthenticated or non-origin member happens to navigate directly to a private artifact, they are redirected to the top-level packages route `/pkgs` instead of seeing a blank artifact view.

Fixes https://github.com/habitat-sh/builder/issues/1480

**Before**
![](https://user-images.githubusercontent.com/479121/91463835-dadef680-e859-11ea-9315-d1d7fd29b351.gif)

**After**
![](https://user-images.githubusercontent.com/479121/91463295-3a88d200-e859-11ea-84d3-f80decd9e24f.gif)


