### PR TITLE
Add Chef patent links

### DIFF
--- a/components/builder-web/app/sign-in-page/sign-in-page.component.html
+++ b/components/builder-web/app/sign-in-page/sign-in-page.component.html
@@ -25,6 +25,7 @@
     By clicking on "Sign in with {{ providerName }}", you are agreeing to the
     <a href="{{ wwwUrl }}/legal/terms-and-conditions/" target="_blank">Terms of Service</a> and
     <a href="{{ wwwUrl }}/legal/privacy-policy/" target="_blank">Privacy Policy</a>.
+    <a href="https://www.chef.io/patents" target="_blank">Chef Patents</a>
   </p>
   <img class="habicat" src="assets/images/habicat.svg">
 </div>

--- a/components/builder-web/app/user-nav/user-nav.component.html
+++ b/components/builder-web/app/user-nav/user-nav.component.html
@@ -12,6 +12,12 @@
         <a [routerLink]="['/profile']" (click)="toggleUserNavMenu()">Profile</a>
       </li>
       <li>
+        <a href="https://www.chef.io/patents" target="_blank">
+          Chef Patents
+          <hab-icon symbol="open-in-new"></hab-icon>
+        </a>
+      </li>
+      <li>
         <a href="#" (click)="signOut()">
           Sign Out
         </a>


### PR DESCRIPTION
Adds Chef patent links to sign-in view and user-nav dropdown.

Closes https://github.com/habitat-sh/builder/issues/1484

![](https://user-images.githubusercontent.com/479121/91461777-66a35380-e857-11ea-8249-1e16f980bff4.gif)


