### PR TITLE
Only run setup steps for `make lint` in CI

### DIFF
--- a/test/run_clippy.sh
+++ b/test/run_clippy.sh
@@ -13,33 +13,41 @@ if ${BUILDKITE:-false}; then
 fi
 
 toolchain="${1:-"$(get_toolchain)"}"
-install_rustup
-install_rust_toolchain "$toolchain"
 
-# TODO: these should be in a shared script?
-sudo hab license accept
-install_hab_pkg core/bzip2 core/libarchive core/libsodium core/openssl core/xz core/zeromq core/libpq
-sudo hab pkg install core/protobuf --binlink
+# If we're in Buildkite, then install Rust, set up Habitat library
+# dependencies, etc.
+#
+# If we're NOT in Buildkite, we'll just run clippy, assuming that
+# the developer has already set up their environment as they like.
+if ${BUILDKITE:-false}; then
+    install_rustup
+    install_rust_toolchain "$toolchain"
 
-export LIBARCHIVE_STATIC=true # so the libarchive crate *builds* statically
-export OPENSSL_DIR # so the openssl crate knows what to build against
-OPENSSL_DIR="$(hab pkg path core/openssl)"
-export OPENSSL_STATIC=true # so the openssl crate builds statically
-export LIBZMQ_PREFIX
-LIBZMQ_PREFIX=$(hab pkg path core/zeromq)
-# now include openssl and zeromq so thney exists in the runtime library path when cargo test is run
-export LD_LIBRARY_PATH
-LD_LIBRARY_PATH="$(hab pkg path core/libpq)/lib:$(hab pkg path core/libsodium)/lib:$(hab pkg path core/zeromq)/lib"
-# include these so that the cargo tests can bind to libarchive (which dynamically binds to xz, bzip, etc), openssl, and sodium at *runtime*
-export LIBRARY_PATH
-LIBRARY_PATH="$(hab pkg path core/libpq)/lib:$(hab pkg path core/bzip2)/lib:$(hab pkg path core/libsodium)/lib:$(hab pkg path core/openssl)/lib:$(hab pkg path core/xz)/lib"
-# setup pkgconfig so the libarchive crate can use pkg-config to fine bzip2 and xz at *build* time
-export PKG_CONFIG_PATH
-PKG_CONFIG_PATH="$(hab pkg path core/libpq)/lib/pkgconfig:$(hab pkg path core/libarchive)/lib/pkgconfig:$(hab pkg path core/libsodium)/lib/pkgconfig:$(hab pkg path core/openssl)/lib/pkgconfig"
+    # TODO: these should be in a shared script?
+    sudo hab license accept
+    install_hab_pkg core/bzip2 core/libarchive core/libsodium core/openssl core/xz core/zeromq core/libpq
+    sudo hab pkg install core/protobuf --binlink
 
-# Install clippy
-echo "--- :rust: Installing clippy"
-rustup component add clippy
+    export LIBARCHIVE_STATIC=true # so the libarchive crate *builds* statically
+    export OPENSSL_DIR # so the openssl crate knows what to build against
+    OPENSSL_DIR="$(hab pkg path core/openssl)"
+    export OPENSSL_STATIC=true # so the openssl crate builds statically
+    export LIBZMQ_PREFIX
+    LIBZMQ_PREFIX=$(hab pkg path core/zeromq)
+    # now include openssl and zeromq so thney exists in the runtime library path when cargo test is run
+    export LD_LIBRARY_PATH
+    LD_LIBRARY_PATH="$(hab pkg path core/libpq)/lib:$(hab pkg path core/libsodium)/lib:$(hab pkg path core/zeromq)/lib"
+    # include these so that the cargo tests can bind to libarchive (which dynamically binds to xz, bzip, etc), openssl, and sodium at *runtime*
+    export LIBRARY_PATH
+    LIBRARY_PATH="$(hab pkg path core/libpq)/lib:$(hab pkg path core/bzip2)/lib:$(hab pkg path core/libsodium)/lib:$(hab pkg path core/openssl)/lib:$(hab pkg path core/xz)/lib"
+    # setup pkgconfig so the libarchive crate can use pkg-config to fine bzip2 and xz at *build* time
+    export PKG_CONFIG_PATH
+    PKG_CONFIG_PATH="$(hab pkg path core/libpq)/lib/pkgconfig:$(hab pkg path core/libarchive)/lib/pkgconfig:$(hab pkg path core/libsodium)/lib/pkgconfig:$(hab pkg path core/openssl)/lib/pkgconfig"
+
+    # Install clippy
+    echo "--- :rust: Installing clippy"
+    rustup component add clippy
+fi
 
 # Lints we need to work through and decide as a team whether to allow or fix
 mapfile -t unexamined_lints < "$2"


### PR DESCRIPTION
Rather than installing Rust, clippy, setting environment variables,
etc. everywhere, we'll only do this in CI. In this way, we can allow
developers to set up their workstation as they want, but still be able
to easily run `make lint`.

Signed-off-by: Christopher Maier <cmaier@chef.io>