### PR TITLE
bump postgres max_connections for local studio dev

### DIFF
--- a/support/builder/datastore.toml
+++ b/support/builder/datastore.toml
@@ -1,3 +1,4 @@
+max_connections = 200
 max_locks_per_transaction = 128
 dynamic_shared_memory_type = 'none'
 port = 5433 # To avoid conflict with travis' own postgres instance


### PR DESCRIPTION
Sometimes a developer's CPU thread number can cause the default workers to exceed the prior limits, inhibiting their ability to test in the studio.

This raises the `max_connections` from the default of 100->200.

Signed-off-by: Jeremy J. Miller <jm@chef.io>