### PR TITLE
Change worker heartbeat log levels

### DIFF
--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -730,11 +730,13 @@ impl RunnerMgr {
 
                 match &op[..] {
                     WORK_START => {
+                        info!("Worker recieved WORK_START: {:?}", &job);
                         self.cancel.store(false, Ordering::SeqCst);
                         self.send_ack(&job)?;
                         self.spawn_job(job, tx.clone())?;
                     }
                     WORK_CANCEL => {
+                        info!("Worker recieved WORK_CANCEL: {:?}", &job);
                         self.cancel.store(true, Ordering::SeqCst);
                         job.set_state(jobsrv::JobState::CancelProcessing);
                         self.send_ack(&job)?;


### PR DESCRIPTION
We are occasionally seeing Workers that appear to be in a semi-connected
state. They are listed as ready in our dashboards, work is assigned to
them but the job isn't dispatched. Logging in the acceptance environment
indicates a zmq issue `(Failed to dispatch job to worker, err=Zmq(Host unreachable))`.

This is a first pass at being able to gather additional information.
Includeing additional state in the logs will help us trace what
machines are involved, along with the work we are attempting to do.
These events should be infrequent and treated as something noteworthy
and worth investigating, so their log level has been adjusted
accordingly.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>