### PR TITLE
[MIGRATION] Stop storing encrypted content as base64-encoded strings

### DIFF
--- a/components/builder-api/src/server/resources/origins.rs
+++ b/components/builder-api/src/server/resources/origins.rs
@@ -1619,7 +1619,6 @@ fn save_public_origin_signing_key(account_id: u64,
                                   key: &PublicOriginSigningKey,
                                   conn: &PgConnection)
                                   -> Result<()> {
-    // Note that this is *not* base64 encoded
     let key_body = key.to_key_string();
 
     let new_pk = NewOriginPublicSigningKey { owner_id: account_id as i64,

--- a/components/builder-core/src/crypto.rs
+++ b/components/builder-core/src/crypto.rs
@@ -9,35 +9,18 @@ use habitat_core::crypto::keys::{BuilderSecretEncryptionKey,
                                  SignedBox};
 
 /// Encrypts bytes using the latest Builder encryption key in the
-/// `KeyCache`, returning the base64-encoded encrypted `SignedBox`,
-/// along with the revision of the Builder key that was used. The
-/// bytes are encrypted such that only Builder could have encrypted
-/// it, and only Builder can decrypt it.
+/// `KeyCache`, returning the encrypted content as a string.
 ///
 /// It is *not* returning the `NamedRevision` because all Builder keys
 /// have the same name, by definition (there's no inherent reason to
 /// *just* return the `KeyRevision`, it's just what other parts of
 /// Builder take right now).
 ///
-/// This function is what all encryption in Builder uses. While the
-/// base64 encoding used here is only strictly necessary for access
-/// tokens, but it is also used for storing encrypted data in the
-/// database, even though the actual cryptographic bits of a
-/// `SignedBox` are already serialized as base64.
-// TODO (CM): If we were to ever change this, we'd need to migrate
-// data stored in the database to decode it first. Furthermore, the
-// paired `decrypt` method below assumes that its input will be base64
-// encoded. Interestingly, we store *public* keys (i.e., unencrypted
-// key strings, which themselves are a mix of plaintext and base64
-// encoded binary information, just like our SignedBoxes are).
-//
-// TODO (CM): If we were to just return a SignedBox, we would be able
-// to get the KeyRevision directly from it, since all SignedBoxes know
-// who the encryptor is. However, that would require knowing that for
-// these SignedBoxes, the encryptor and decryptor are always the
-// same. If we were to do that, it would be useful to create a new
-// type to represent that fact, but that could require database
-// migrations if not done properly.
+/// Returning a String, and not a SignedBox, because at some point
+/// we'd like to transition to symmetric key encryption, the output of
+/// which would be represented by a different type. Also, it's not
+/// really important outside of this module what kind of encryption is
+/// being used, just that there _is_ encryption.
 pub fn encrypt<B>(key_cache: &KeyCache, bytes: B) -> Result<(String, KeyRevision)>
     where B: AsRef<[u8]>
 {
@@ -49,18 +32,22 @@ pub fn encrypt<B>(key_cache: &KeyCache, bytes: B) -> Result<(String, KeyRevision
 pub fn encrypt_with_key<B>(key: &BuilderSecretEncryptionKey, bytes: B) -> (String, KeyRevision)
     where B: AsRef<[u8]>
 {
-    let encrypted: SignedBox = key.encrypt(bytes);
-    let b64 = base64::encode(encrypted.to_string());
-    (b64, key.named_revision().revision().clone())
+    let encrypted = key.encrypt(bytes);
+    (encrypted.to_string(), key.named_revision().revision().clone())
 }
 
-/// Decrypts a given base64 `SignedBox` using the appropriate Builder
-/// encryption key. We pass the `KeyCache` because the encoded message
-/// tells us which key revision to use, so we don't know which key
-/// we're going to use until we dig into the message itself.
-pub fn decrypt(key_cache: &KeyCache, b64text: &str) -> Result<Vec<u8>> {
-    let signed_box = base64::decode(b64text).map(String::from_utf8)??
-                                            .parse::<SignedBox>()?;
-    let builder_key = key_cache.builder_secret_encryption_key(signed_box.decryptor())?;
-    Ok(builder_key.decrypt(&signed_box)?)
+/// Decrypts a given string rendering of encrypted content using the
+/// appropriate Builder encryption key. We pass the `KeyCache` because
+/// the encoded message tells us which key revision to use, so we
+/// don't know which key we're going to use until we dig into the
+/// message itself.
+///
+/// Returns a byte vector because not everything we encrypt is a
+/// string. At some point it may be worthwhile to provide a typed
+/// decryption interface to consolidate incidental logic here, thus
+/// cleaning up callsites. But for now, you get bytes!
+pub fn decrypt(key_cache: &KeyCache, encrypted_message: &str) -> Result<Vec<u8>> {
+    let encrypted_message = encrypted_message.parse::<SignedBox>()?;
+    let builder_key = key_cache.builder_secret_encryption_key(encrypted_message.decryptor())?;
+    Ok(builder_key.decrypt(&encrypted_message)?)
 }

--- a/components/builder-db/src/migrations/2020-09-08-195315_stop_base64_encoding/up.sql
+++ b/components/builder-db/src/migrations/2020-09-08-195315_stop_base64_encoding/up.sql
@@ -1,0 +1,8 @@
+-- Stop base64 encoding our encrypted content; it's already a string
+-- anyway.
+
+UPDATE origin_secret_keys
+SET body = convert_from(decode(body, 'base64'), 'UTF-8');
+
+UPDATE origin_integrations
+SET body = convert_from(decode(body, 'base64'), 'UTF-8');


### PR DESCRIPTION
Previously, we would store all encrypted data in the database as a
base64-encoded string. However, this doesn't actually do anything
meaningful, since our encrypted messages are themselves already
strings (partly plaintext metadata indicating which key(s) are
involved in the encryption/decryption process, and partly
base64-encrypted ciphertext) and not simply binary data. Adding an
additional layer of base64 encoding amounts to "busywork", in addition
to increasing the size of the stored data by 1/3.

We also modify the `crypto` module to stop encoding and decoding
encrypted data, which means that the rest of the code should continue
to work transparently. We still use `String` as the type we pass into
and out of this module because the rest of Builder doesn't really care
what kind of encryption we're doing in there; the `String` format of
our Habitat encrypted messages is fine. It's just that now this
`String` isn't base64-encoded.

The one time where it *is* important to base64-encode an encrypted
message is when we're generating tokens. There's only one place we do
that, though, so it's easy enough to simply encode it where it's
generated.

If there are any old Builder installations that have not already run
the encryption migration that is implemented in Rust code, this should
still be OK, because our pure SQL migration here will run before it
does. Since the data in the database at that point will no longer be
base64-encoded, and since the Rust migration code uses our
newly-modified encryption and decryption functions, everything should
continue to work.

Signed-off-by: Christopher Maier <cmaier@chef.io>