### PR TITLE
[MIGRATION + REFACTOR] Ensure keys are encrypted at rest in database

### DIFF
--- a/components/builder-api/src/server/migrations.rs
+++ b/components/builder-api/src/server/migrations.rs
@@ -7,6 +7,8 @@ use habitat_core::crypto::keys::{Key,
                                  KeyCache};
 use std::time::Instant;
 
+pub mod encrypt_secret_keys;
+
 // This value was arbitrarily chosen and might need some tuning
 const KEY_MIGRATION_CHUNK_SIZE: i64 = 100;
 

--- a/components/builder-api/src/server/migrations/encrypt_secret_keys.rs
+++ b/components/builder-api/src/server/migrations/encrypt_secret_keys.rs
@@ -1,0 +1,27 @@
+//! Ensure that existing origin secret encryption keys are themselves
+//! encrypted at rest in the database.
+
+use crate::server::error::{Error,
+                           Result};
+use diesel::{connection::Connection,
+             pg::PgConnection};
+use habitat_builder_db::models::keys as db_keys;
+use habitat_core::crypto::keys::KeyCache;
+use std::time::Instant;
+
+/// Perform the actual migration of data.
+pub fn run(conn: &PgConnection, key_cache: &KeyCache) -> Result<()> {
+    let start_time = Instant::now();
+    let builder_encryption_key = key_cache.latest_builder_key()?;
+
+    let updated_rows = conn.transaction::<_, Error, _>(|| {
+                           Ok(db_keys::OriginPrivateEncryptionKey::encrypt_unencrypted_keys(conn,
+                                                                      &builder_encryption_key)?)
+                       })?;
+
+    warn!("secret key encryption completed in {} sec; updated {} rows",
+          start_time.elapsed().as_secs_f64(),
+          updated_rows);
+
+    Ok(())
+}

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -155,6 +155,8 @@ pub async fn run(config: Config) -> error::Result<()> {
 
     migrations::migrate_to_encrypted(&db_pool.get_conn().unwrap(), &config.api.key_path).unwrap();
 
+    migrations::encrypt_secret_keys::run(&db_pool.get_conn().unwrap(), &config.api.key_path).expect("Error encrypting secret keys");
+
     let mut srv = HttpServer::new(move || {
                       let app_state = match AppState::new(&config, db_pool.clone()) {
                           Ok(state) => state,

--- a/components/builder-api/src/server/resources/origins.rs
+++ b/components/builder-api/src/server/resources/origins.rs
@@ -1604,7 +1604,7 @@ fn save_secret_origin_encryption_key(key: &core_keys::OriginSecretEncryptionKey,
 fn get_secret_origin_encryption_key(origin: &str,
                                     conn: &PgConnection)
                                     -> Result<core_keys::OriginSecretEncryptionKey> {
-    let db_record = db_keys::OriginPrivateEncryptionKey::get(origin, conn)?;
+    let db_record = db_keys::OriginPrivateEncryptionKey::latest(origin, conn)?;
     Ok(db_record.body.parse()?)
 }
 

--- a/components/builder-api/src/server/resources/origins.rs
+++ b/components/builder-api/src/server/resources/origins.rs
@@ -541,17 +541,16 @@ fn download_origin_key(path: Path<(String, String)>, state: Data<AppState>) -> H
         Err(err) => return err.into(),
     };
 
-    let key =
-        match db_keys::OriginPublicSigningKey::get(&origin, &revision, &*conn).map_err(Error::DieselError) {
-            Ok(key) => key,
-            Err(err) => {
-                debug!("{}", err);
-                return err.into();
-            }
-        };
+    let key = match get_specific_public_origin_signing_key(&origin, &revision, &*conn) {
+        Ok(key) => key,
+        Err(err) => {
+            debug!("{}", err);
+            return err.into();
+        }
+    };
 
-    let xfilename = format!("{}-{}.pub", key.name, key.revision);
-    download_content_as_file(key.body, xfilename)
+    download_content_as_file(key.to_key_string(),
+                             key.own_filename().to_string_lossy().into_owned())
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -1645,6 +1644,16 @@ fn get_latest_public_origin_signing_key(origin: &str,
                                         conn: &PgConnection)
                                         -> Result<core_keys::PublicOriginSigningKey> {
     let db_record = db_keys::OriginPublicSigningKey::latest(origin, conn)?;
+    Ok(db_record.body.parse()?)
+}
+
+/// Retrieve a specific revision of the origin's public
+/// signing key from the database.
+fn get_specific_public_origin_signing_key(origin: &str,
+                                          revision: &str, // TODO (CM): KeyRevision
+                                          conn: &PgConnection)
+                                          -> Result<core_keys::PublicOriginSigningKey> {
+    let db_record = db_keys::OriginPublicSigningKey::get(origin, revision, conn)?;
     Ok(db_record.body.parse()?)
 }
 

--- a/components/builder-db/src/models/keys.rs
+++ b/components/builder-db/src/models/keys.rs
@@ -161,7 +161,7 @@ impl OriginPublicEncryptionKey {
 }
 
 impl OriginPrivateEncryptionKey {
-    pub fn get(origin: &str, conn: &PgConnection) -> QueryResult<OriginPrivateEncryptionKey> {
+    pub fn latest(origin: &str, conn: &PgConnection) -> QueryResult<OriginPrivateEncryptionKey> {
         Counter::DBCall.increment();
         // This is really latest because you're not allowed to get old keys
         origin_private_encryption_keys::table

--- a/components/builder-db/src/models/migration_support.rs
+++ b/components/builder-db/src/models/migration_support.rs
@@ -1,0 +1,48 @@
+//! Accessory code to add to various models to support various
+//! non-SQL, active data migrations.
+//!
+//! The idea is that these are not intended for use in "normal" code,
+//! wil be removed at some point in the future, and thus should be
+//! sequestered apart as "special" code
+
+use crate::models::keys as db_keys;
+use diesel::{self,
+             pg::PgConnection,
+             result::QueryResult,
+             ExpressionMethods,
+             QueryDsl,
+             RunQueryDsl};
+use habitat_core::crypto::keys as core_keys;
+
+impl db_keys::OriginPrivateEncryptionKey {
+    /// Encrypts any unencrypted secret encryption keys in the
+    /// database with the given Builder secret encryption key.
+    ///
+    /// Returns the number of updated rows for user feedback purposes.
+    ///
+    /// Should be run in a transaction!
+    pub fn encrypt_unencrypted_keys(conn: &PgConnection,
+                                    encryption_key: &core_keys::BuilderSecretEncryptionKey)
+                                    -> QueryResult<u32> {
+        use crate::schema::key::origin_private_encryption_keys::dsl::*;
+
+        let mut updated_rows = 0;
+        for row in origin_private_encryption_keys.for_update()
+                                                 .get_results::<Self>(conn)?
+        {
+            // If contents are not encrypted, then encrypt and update. The
+            // key can't be parsed if it's encrypted.
+            if row.body
+                  .parse::<core_keys::OriginSecretEncryptionKey>()
+                  .is_ok()
+            {
+                let encrypted = encryption_key.encrypt(&row.body);
+                diesel::update(origin_private_encryption_keys.filter(id.eq(row.id)))
+                    .set((body.eq(&encrypted.to_string()),))
+                    .get_result::<Self>(conn)?;
+                updated_rows += 1;
+            }
+        }
+        Ok(updated_rows)
+    }
+}

--- a/components/builder-db/src/models/mod.rs
+++ b/components/builder-db/src/models/mod.rs
@@ -2,6 +2,9 @@
 // https://github.com/rust-lang/rust/issues/50504
 #![allow(proc_macro_derive_resolution_fallback)]
 
+#[macro_use]
+mod migration_support;
+
 pub mod account;
 pub mod channel;
 pub mod integration;

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -558,7 +558,7 @@ impl WorkerMgr {
             Ok(secrets_list) => {
                 if !secrets_list.is_empty() {
                     // fetch the private origin encryption key from the database
-                    let priv_key = match OriginPrivateEncryptionKey::get(&origin, &*conn)
+                    let priv_key = match OriginPrivateEncryptionKey::latest(&origin, &*conn)
                         .map_err(Error::DieselError)
                     {
                         Ok(key) => {

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -16,6 +16,8 @@ use crate::{bldr_core::{self,
                     Result},
             protocol::{jobsrv,
                        originsrv}};
+use builder_core::crypto;
+use diesel::pg::PgConnection;
 use habitat_core::{crypto::keys::{AnonymousBox,
                                   KeyCache,
                                   OriginSecretEncryptionKey},
@@ -26,6 +28,7 @@ use protobuf::{parse_from_bytes,
                Message,
                RepeatedField};
 use std::{collections::HashSet,
+          convert::TryInto,
           str::FromStr,
           sync::mpsc,
           thread::{self,
@@ -548,6 +551,23 @@ impl WorkerMgr {
         }
     }
 
+    // TODO (CM): This is a duplicate of the same function from
+    // habitat_builder_api::server::resources::origins. We need to
+    // consolidate these functions a bit better. It probably amounts
+    // to creating some kind of "repository" abstraction in the db
+    // crate.
+    //
+    // For now, it's more straightforward to copy the function
+    // implementation :/
+    fn get_secret_origin_encryption_key(origin: &str,
+                                        key_cache: &KeyCache,
+                                        conn: &PgConnection)
+                                        -> Result<OriginSecretEncryptionKey> {
+        let db_record = OriginPrivateEncryptionKey::latest(origin, conn)?;
+        let decrypted = crypto::decrypt(key_cache, &db_record.body)?;
+        Ok(AsRef::<[u8]>::as_ref(&decrypted).try_into()?)
+    }
+
     fn add_secrets_to_job(&mut self, job: &mut Job) -> Result<()> {
         let origin = job.get_project().get_origin_name().to_string();
         let conn = self.db.get_conn().map_err(Error::Db)?;
@@ -557,15 +577,27 @@ impl WorkerMgr {
         match OriginSecret::list(&origin, &*conn).map_err(Error::DieselError) {
             Ok(secrets_list) => {
                 if !secrets_list.is_empty() {
-                    // fetch the private origin encryption key from the database
-                    let priv_key = match OriginPrivateEncryptionKey::latest(&origin, &*conn)
-                        .map_err(Error::DieselError)
-                    {
-                        Ok(key) => {
-                            key.body.parse::<OriginSecretEncryptionKey>()?
-                        }
-                        Err(err) => return Err(err),
-                    };
+                    // fetch the private origin encryption key from
+                    // the database
+
+                    // NOTE: This retrieves the *latest* origin
+                    // encryption key from the database and assumes
+                    // that it is the one that each secret can be
+                    // decrypted by. In practice, this is currently
+                    // correct, as there is no way to update the
+                    // encryption key. However, this is not currently
+                    // very clearly conveyed in the overall code of
+                    // Builder.
+                    //
+                    // Strictly speaking, we should first parse the
+                    // secret as an AnonymousBox, ask it what key
+                    // revision is needed to decrypt, and *then* fetch
+                    // that revision from the database. That would
+                    // result in an additional database round trip for
+                    // each secret.
+
+                    let priv_key =
+                        Self::get_secret_origin_encryption_key(&origin, &self.key_cache, &conn)?;
 
                     for secret in secrets_list {
                         debug!("Adding secret to job: {:?}", secret);


### PR DESCRIPTION
There's a mixture of refactorings here to further consolidate key retrieval operations. Ideally, we just "ask for keys" and we get the core business logic types, with things like decryption handled transparently for us. Similarly, when saving keys to the database, we should only have to pass in one of the core business logic key types, and the encryption and saving is handled for us.

Additionally, recent refactorings revealed that origin secret encryption keys were not themselves encrypted in the database. This PR introduces a migration to encrypt everything currently in the database, and handle encryption/decryption on save/retrieval as necessary.

Of particular note for reviewers is the structure set up around the "live" migration code. Since this migration involves complex business logic, it was not possible to express it as pure SQL, so we need some actual Rust code. 