### PR TITLE
Set HOME in job dispatch for local development

### DIFF
--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -148,7 +148,6 @@ impl<'a> Studio<'a> {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
-
         cmd.arg("studio");
         cmd.arg("build");
 


### PR DESCRIPTION
The local development environment uses the chroot studio for building packages in the worker.   This requires the HOME variable to be set. For production builder we clear the environment before creating the studio which includes clearing the HOME variable. This sets it to a hard-coded  path (the same as what is set by default in the config) only when we are in the development studio. 

The change here is a little awkward in shape,  but the job dispatch would likely need to be refactored to make supporting both the docker and chroot studio, along with windows builds, a little more ergonomic to set up. While this would be worthwhile taking on, it's a little out of scope for the scheduler work currently in flight, but we do need to be able to run the Worker in the studio as part of validating the scheduler changes.  

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>