### PR TITLE
Expose worker zmq poll interval as config object

### DIFF
--- a/components/builder-worker/habitat/_common/config.toml
+++ b/components/builder-worker/habitat/_common/config.toml
@@ -5,6 +5,7 @@ log_path = '{{pkg.svc_path}}/logs'
 bldr_channel = "{{cfg.bldr_channel}}"
 features_enabled = "{{cfg.features_enabled}}"
 target = "{{cfg.target}}"
+work_poll_interval_secs = {{cfg.work_poll_interval_secs}}
 
 {{~#eachAlive bind.depot.members as |member|}}
 {{~#if @first}}

--- a/components/builder-worker/habitat/_common/default.toml
+++ b/components/builder-worker/habitat/_common/default.toml
@@ -6,6 +6,7 @@ features_enabled = ""
 airlock_enabled = false
 recreate_ns_dir = false
 target = "x86_64-linux"
+work_poll_interval = 60
 
 [github]
 api_url = "https://api.github.com"

--- a/components/builder-worker/habitat/_common/default.toml
+++ b/components/builder-worker/habitat/_common/default.toml
@@ -6,7 +6,7 @@ features_enabled = ""
 airlock_enabled = false
 recreate_ns_dir = false
 target = "x86_64-linux"
-work_poll_interval = 60
+work_poll_interval_secs = 60
 
 [github]
 api_url = "https://api.github.com"

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -18,25 +18,27 @@ pub type JobSrvCfg = Vec<JobSrvAddr>;
 #[serde(default)]
 pub struct Config {
     /// Enable automatic publishing for all builds by default
-    pub auto_publish:     bool,
+    pub auto_publish:       bool,
     /// Filepath where persistent application data is stored
-    pub data_path:        PathBuf,
+    pub data_path:          PathBuf,
     /// Location of Builder encryption keys
-    pub key_dir:          KeyCache,
+    pub key_dir:            KeyCache,
     /// Path to worker event logs
-    pub log_path:         PathBuf,
+    pub log_path:           PathBuf,
     /// Default channel name for Publish post-processor to use to determine which channel to
     /// publish artifacts to
-    pub bldr_channel:     ChannelIdent,
+    pub bldr_channel:       ChannelIdent,
     /// Default URL for Publish post-processor to use to determine which Builder to use
     /// for retrieving signing keys and publishing artifacts
-    pub bldr_url:         String,
+    pub bldr_url:           String,
     /// List of Job Servers to connect to
-    pub jobsrv:           JobSrvCfg,
-    pub features_enabled: String,
+    pub jobsrv:             JobSrvCfg,
+    pub features_enabled:   String,
     /// Github application id to use for private repo access
-    pub github:           GitHubCfg,
-    pub target:           PackageTarget,
+    pub github:             GitHubCfg,
+    pub target:             PackageTarget,
+    /// The frequency to poll the zmq socket for messages from jobsrv, in seconds
+    pub work_poll_interval: usize,
 }
 
 impl Config {
@@ -54,16 +56,17 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Config { auto_publish:     true,
-                 data_path:        PathBuf::from("/tmp"),
-                 log_path:         PathBuf::from("/tmp"),
-                 key_dir:          KeyCache::new("/hab/svc/builder-worker/files"),
-                 bldr_channel:     ChannelIdent::unstable(),
-                 bldr_url:         url::default_bldr_url(),
-                 jobsrv:           vec![JobSrvAddr::default()],
-                 features_enabled: "".to_string(),
-                 github:           GitHubCfg::default(),
-                 target:           PackageTarget::from_str("x86_64-linux").unwrap(), }
+        Config { auto_publish:       true,
+                 data_path:          PathBuf::from("/tmp"),
+                 log_path:           PathBuf::from("/tmp"),
+                 key_dir:            KeyCache::new("/hab/svc/builder-worker/files"),
+                 bldr_channel:       ChannelIdent::unstable(),
+                 bldr_url:           url::default_bldr_url(),
+                 jobsrv:             vec![JobSrvAddr::default()],
+                 features_enabled:   "".to_string(),
+                 github:             GitHubCfg::default(),
+                 target:             PackageTarget::from_str("x86_64-linux").unwrap(),
+                 work_poll_interval: 60, }
     }
 }
 
@@ -101,6 +104,7 @@ mod tests {
         key_dir = "/path/to/key"
         features_enabled = "FOO,BAR"
         target = "x86_64-linux-kernel2"
+        work_poll_interval = 10
 
         [[jobsrv]]
         host = "1:1:1:1:1:1:1:1"
@@ -127,5 +131,6 @@ mod tests {
         assert_eq!(&config.features_enabled, "FOO,BAR");
         assert_eq!(config.target,
                    PackageTarget::from_str("x86_64-linux-kernel2").unwrap());
+        assert_eq!(config.work_poll_interval, 10);
     }
 }

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -110,7 +110,7 @@ fn deserialize_work_poll_interval<'de, D>(duration: D) -> Result<Duration, D::Er
             1
         }
         d @ 1..=60 => d,
-        d @ _ => {
+        d => {
             warn!("WorkerPollInterval is {} seconds; This may adversely impact job throughput",
                   d);
             d

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -7,10 +7,12 @@ use habitat_core::{config::ConfigFile,
                    package::PackageTarget,
                    url,
                    ChannelIdent};
+use serde::Deserializer;
 use std::{net::{IpAddr,
                 Ipv4Addr},
           path::PathBuf,
-          str::FromStr};
+          str::FromStr,
+          time::Duration};
 
 pub type JobSrvCfg = Vec<JobSrvAddr>;
 
@@ -18,27 +20,28 @@ pub type JobSrvCfg = Vec<JobSrvAddr>;
 #[serde(default)]
 pub struct Config {
     /// Enable automatic publishing for all builds by default
-    pub auto_publish:       bool,
+    pub auto_publish:            bool,
     /// Filepath where persistent application data is stored
-    pub data_path:          PathBuf,
+    pub data_path:               PathBuf,
     /// Location of Builder encryption keys
-    pub key_dir:            KeyCache,
+    pub key_dir:                 KeyCache,
     /// Path to worker event logs
-    pub log_path:           PathBuf,
+    pub log_path:                PathBuf,
     /// Default channel name for Publish post-processor to use to determine which channel to
     /// publish artifacts to
-    pub bldr_channel:       ChannelIdent,
+    pub bldr_channel:            ChannelIdent,
     /// Default URL for Publish post-processor to use to determine which Builder to use
     /// for retrieving signing keys and publishing artifacts
-    pub bldr_url:           String,
+    pub bldr_url:                String,
     /// List of Job Servers to connect to
-    pub jobsrv:             JobSrvCfg,
-    pub features_enabled:   String,
+    pub jobsrv:                  JobSrvCfg,
+    pub features_enabled:        String,
     /// Github application id to use for private repo access
-    pub github:             GitHubCfg,
-    pub target:             PackageTarget,
+    pub github:                  GitHubCfg,
+    pub target:                  PackageTarget,
     /// The frequency to poll the zmq socket for messages from jobsrv, in seconds
-    pub work_poll_interval: usize,
+    #[serde(deserialize_with = "deserialize_work_poll_interval")]
+    pub work_poll_interval_secs: Duration,
 }
 
 impl Config {
@@ -56,17 +59,17 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Config { auto_publish:       true,
-                 data_path:          PathBuf::from("/tmp"),
-                 log_path:           PathBuf::from("/tmp"),
-                 key_dir:            KeyCache::new("/hab/svc/builder-worker/files"),
-                 bldr_channel:       ChannelIdent::unstable(),
-                 bldr_url:           url::default_bldr_url(),
-                 jobsrv:             vec![JobSrvAddr::default()],
-                 features_enabled:   "".to_string(),
-                 github:             GitHubCfg::default(),
-                 target:             PackageTarget::from_str("x86_64-linux").unwrap(),
-                 work_poll_interval: 60, }
+        Config { auto_publish:            true,
+                 data_path:               PathBuf::from("/tmp"),
+                 log_path:                PathBuf::from("/tmp"),
+                 key_dir:                 KeyCache::new("/hab/svc/builder-worker/files"),
+                 bldr_channel:            ChannelIdent::unstable(),
+                 bldr_url:                url::default_bldr_url(),
+                 jobsrv:                  vec![JobSrvAddr::default()],
+                 features_enabled:        "".to_string(),
+                 github:                  GitHubCfg::default(),
+                 target:                  PackageTarget::from_str("x86_64-linux").unwrap(),
+                 work_poll_interval_secs: Duration::from_secs(60), }
     }
 }
 
@@ -92,6 +95,28 @@ impl Default for JobSrvAddr {
     }
 }
 
+// Ideally we'd bake this validation into a new type to used by work_poll_interval_secs.
+// Since the value is only intended to be changed as part of development work via the
+// config file and we hope to remove the zmq use in the future, we'll do the validation
+// here in the deserialization for now. If we end up expanding on the use of the poll
+// interval, it may be worth revisiting this to make it more robust
+fn deserialize_work_poll_interval<'de, D>(duration: D) -> Result<Duration, D::Error>
+    where D: Deserializer<'de>
+{
+    let duration: u64 = serde::Deserialize::deserialize(duration)?;
+
+    if duration == 0 {
+        warn!("WorkerPollInterval is 0 seconds; zmq::poll will return immediately");
+    }
+
+    if duration > 60 {
+        warn!("WorkerPollInterval is {} seconds; This may adversely impact job throughput",
+              duration);
+    }
+
+    Ok(Duration::from_secs(duration))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,7 +129,7 @@ mod tests {
         key_dir = "/path/to/key"
         features_enabled = "FOO,BAR"
         target = "x86_64-linux-kernel2"
-        work_poll_interval = 10
+        work_poll_interval_secs = 10
 
         [[jobsrv]]
         host = "1:1:1:1:1:1:1:1"
@@ -131,6 +156,6 @@ mod tests {
         assert_eq!(&config.features_enabled, "FOO,BAR");
         assert_eq!(config.target,
                    PackageTarget::from_str("x86_64-linux-kernel2").unwrap());
-        assert_eq!(config.work_poll_interval, 10);
+        assert_eq!(config.work_poll_interval_secs.as_secs(), 10);
     }
 }

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -714,7 +714,7 @@ impl RunnerMgr {
 
         let mut srv_msg = false;
         let (tx, mut rx): (_, async_mpsc::UnboundedReceiver<Job>) = async_mpsc::unbounded();
-        let work_poll_interval = (self.config.work_poll_interval * 1000) as i64;
+        let work_poll_interval = self.config.work_poll_interval_secs.as_millis() as i64;
 
         loop {
             {

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -20,14 +20,14 @@ else
   exit 1
 fi
 
-mkdir -p /hab/svc/builder-minio
-cat <<EOT > /hab/svc/builder-minio/user.toml
+mkdir -p /hab/user/builder-minio/config
+cat <<EOT > /hab/user/builder-minio/config/user.toml
 key_id = "depot"
 secret_key = "password"
 EOT
 
-mkdir -p /hab/svc/builder-api
-cat <<EOT > /hab/svc/builder-api/user.toml
+mkdir -p /hab/user/builder-api/config
+cat <<EOT > /hab/user/builder-api/config/user.toml
 log_level = "debug,tokio_core=error,tokio_reactor=error,zmq=error,hyper=error"
 
 [http]
@@ -50,8 +50,8 @@ password = "$PGPASSWORD"
 port = 5433
 EOT
 
-mkdir -p /hab/svc/builder-api-proxy
-cat <<EOT > /hab/svc/builder-api-proxy/user.toml
+mkdir -p /hab/user/builder-api-proxy/config
+cat <<EOT > /hab/user/builder-api-proxy/config/user.toml
 log_level = "info"
 enable_builder = true
 enable_publisher_docker = true
@@ -79,8 +79,8 @@ proxy_read_timeout = 180
 keepalive_timeout = "180s"
 EOT
 
-mkdir -p /hab/svc/builder-jobsrv
-cat <<EOT > /hab/svc/builder-jobsrv/user.toml
+mkdir -p /hab/user/builder-jobsrv/config/
+cat <<EOT > /hab/user/builder-jobsrv/config/user.toml
 log_level = "debug,tokio_core=error,tokio_reactor=error,zmq=error,postgres=error"
 
 [http]
@@ -94,8 +94,8 @@ port = 5433
 backend = "local"
 EOT
 
-mkdir -p /hab/svc/builder-worker
-cat <<EOT > /hab/svc/builder-worker/user.toml
+mkdir -p /hab/user/builder-worker/config
+cat <<EOT > /hab/user/builder-worker/config/user.toml
 log_level = "info"
 
 key_dir = "/hab/svc/builder-worker/files"
@@ -103,6 +103,7 @@ auto_publish = true
 airlock_enabled = false
 data_path = "/hab/svc/builder-worker/data"
 bldr_url = "http://localhost:9636"
+work_poll_interval = 5
 
 [github]
 api_url = "$GITHUB_API_URL"

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -103,7 +103,7 @@ auto_publish = true
 airlock_enabled = false
 data_path = "/hab/svc/builder-worker/data"
 bldr_url = "http://localhost:9636"
-work_poll_interval = 5
+work_poll_interval_secs = 5
 
 [github]
 api_url = "$GITHUB_API_URL"


### PR DESCRIPTION
The builder-worker currently blocks its main run loop for up to 60 seconds, or until a message from jobsrv arrives.  This has a side effect of blocking job completion until the polling times out, as the jobserv in normal operation won't send a message to a busy worker.   The blocking occurs because we use an mspc channel to signal back to the main loop that work has completed, which is only read after the zmq poll finishes. https://github.com/habitat-sh/builder/blob/master/components/builder-worker/src/runner/mod.rs#L715-L755

This PR exposes that value as a config object, with the default of its current value 60 seconds (converted to ms for zmq).  It also sets the default for the studio dev environment to 5 seconds, so that we can tighten up our feedback loop while iterating on the scheduler.   

A side effect of this change, is that our `user.toml` files we lay down as part of `start-builder` are now written to the `/hab/user/<svc>` path, getting rid of the deprecation warnings. 
