### PR TITLE
Adds feature-flagged POC for kafka producer to builder api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudevents-sdk"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c814591b300c224c5705c7579a4c80d68aa3472c0d9f0da8c20a74ce40b4bed"
+dependencies = [
+ "base64 0.12.3",
+ "chrono",
+ "delegate",
+ "hostname",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "snafu",
+ "url",
+ "uuid",
+ "web-sys",
+]
+
+[[package]]
+name = "cloudevents-sdk-rdkafka"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84a2a1f07370760f4fd6128acbb0c9d9d4dbe627de3ccc321153b709d9c4908"
+dependencies = [
+ "bytes 0.5.6",
+ "cloudevents-sdk",
+ "lazy_static",
+ "rdkafka",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +853,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e531288b600a8bea48baff926d2f16a3f68fda1cd2d59240279907ba727332"
+dependencies = [
+ "proc-macro2 1.0.20",
+ "quote 1.0.7",
+ "syn 1.0.40",
+]
+
+[[package]]
+name = "derivative"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
+dependencies = [
+ "proc-macro2 1.0.20",
+ "quote 1.0.7",
+ "syn 1.0.40",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1027,12 @@ dependencies = [
  "socket2",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dogstatsd"
@@ -1438,6 +1497,7 @@ dependencies = [
  "cfg-if",
  "libc 0.2.76",
  "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1552,6 +1612,8 @@ dependencies = [
  "bytes 0.5.6",
  "chrono",
  "clap",
+ "cloudevents-sdk",
+ "cloudevents-sdk-rdkafka",
  "diesel",
  "diesel-derive-enum",
  "diesel_full_text_search",
@@ -1573,6 +1635,7 @@ dependencies = [
  "protobuf",
  "r2d2",
  "rand 0.7.3",
+ "rdkafka",
  "regex",
  "reqwest",
  "rusoto_core 0.45.0",
@@ -1582,6 +1645,7 @@ dependencies = [
  "serde_json",
  "sha2 0.9.1",
  "tempfile",
+ "tokio 0.1.22",
  "toml 0.5.6",
  "url",
  "uuid",
@@ -2535,6 +2599,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.20",
+ "quote 1.0.7",
+ "syn 1.0.40",
+]
+
+[[package]]
 name = "oauth-client"
 version = "0.0.0"
 dependencies = [
@@ -2603,6 +2689,15 @@ dependencies = [
  "libc 0.2.76",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2818,6 +2913,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml 0.5.6",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3110,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d455ac2a07a27d87b4f0e321dfd8d9a5b574bd96f55e42e6c594712a08051222"
+dependencies = [
+ "futures 0.3.5",
+ "libc 0.2.76",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d770343fbbc6089c750000711a17a906e8b3f7831afcd752d9667d38833e578"
+dependencies = [
+ "libc 0.2.76",
+ "libz-sys",
+ "num_enum",
+ "openssl-sys",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3421,6 +3553,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3540,6 +3682,27 @@ name = "smallvec"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+
+[[package]]
+name = "snafu"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5aed652511f5c9123cf2afbe9c244c29db6effa2abb05c866e965c82405ce"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf8f7d5720104a9df0f7076a8682024e958bba0fe9848767bb44f251f3648e9"
+dependencies = [
+ "proc-macro2 1.0.20",
+ "quote 1.0.7",
+ "syn 1.0.40",
+]
 
 [[package]]
 name = "socket2"
@@ -4391,6 +4554,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -18,6 +18,8 @@ bytes = "*"
 base64 = "*"
 bitflags = "1"
 chrono = { version = "*", features = ["serde"] }
+cloudevents-sdk = "0.2.0"
+cloudevents-sdk-rdkafka = "*"
 diesel = { version = "*", features = ["postgres", "chrono", "serde_json", "r2d2"] }
 diesel-derive-enum = { version = "*", features = ["postgres"] }
 diesel_full_text_search = "*"
@@ -36,6 +38,7 @@ serde = "*"
 serde_derive = "*"
 serde_json = "*"
 sha2 = "*"
+tokio = "*"
 toml = { version = "*", default-features = false }
 futures = "*"
 rand = "*"
@@ -46,6 +49,10 @@ rusoto_s3 = "*"
 tempfile = "*"
 url = "*"
 uuid = { version = "*", features = ["v4"] }
+
+[dependencies.rdkafka]
+version = "*"
+features = ["ssl"]
 
 [dependencies.memcache]
 version = "*"

--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -41,3 +41,6 @@ port = {{member.cfg.rpc_port}}
 
 [datastore]
 {{toToml cfg.datastore}}
+
+[kafka]
+{{toToml cfg.kafka}}

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -49,6 +49,6 @@ host = "127.0.0.1"
 port = 5432
 
 [kafka]
-bootstrap_nodes = "localhost:9092"
+bootstrap_nodes = ["localhost:9092"]
 client_id = "http://localhost"
 connection_retry_ms = 300

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -47,3 +47,8 @@ connection_timeout_sec = 3600
 db_workers = 4
 host = "127.0.0.1"
 port = 5432
+
+[kafka]
+bootstrap_nodes = "localhost:9092"
+client_id = "http://localhost"
+connection_retry_ms = 300

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -7,7 +7,7 @@ pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/coreutils core/gcc-libs core/zeromq core/libsodium
 core/libarchive core/curl core/postgresql)
 pkg_build_deps=(core/protobuf-cpp core/protobuf-rust core/coreutils core/cacerts
-core/rust core/gcc core/git core/pkg-config)
+core/rust core/gcc core/git core/pkg-config core/bash core/make)
 pkg_exports=(
   [port]=http.port
 )

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -17,7 +17,8 @@ use std::{env,
                 SocketAddr,
                 ToSocketAddrs},
           option::IntoIter,
-          path::PathBuf};
+          path::PathBuf,
+          time::Duration};
 
 pub trait GatewayCfg {
     /// Default number of worker threads to simultaneously handle HTTP requests.
@@ -31,7 +32,7 @@ pub trait GatewayCfg {
     fn listen_port(&self) -> u16;
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub api:         ApiCfg,
@@ -44,21 +45,7 @@ pub struct Config {
     pub memcache:    MemcacheCfg,
     pub jobsrv:      JobsrvCfg,
     pub datastore:   DataStoreCfg,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Config { api:         ApiCfg::default(),
-                 artifactory: ArtifactoryCfg::default(),
-                 github:      GitHubCfg::default(),
-                 http:        HttpCfg::default(),
-                 oauth:       OAuth2Cfg::default(),
-                 s3:          S3Cfg::default(),
-                 ui:          UiCfg::default(),
-                 memcache:    MemcacheCfg::default(),
-                 jobsrv:      JobsrvCfg::default(),
-                 datastore:   DataStoreCfg::default(), }
-    }
+    pub kafka:       KafkaCfg,
 }
 
 #[derive(Debug)]
@@ -207,6 +194,28 @@ impl ToSocketAddrs for HttpCfg {
             IpAddr::V4(ref a) => (*a, self.port).to_socket_addrs(),
             IpAddr::V6(ref a) => (*a, self.port).to_socket_addrs(),
         }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct KafkaCfg {
+    pub bootstrap_nodes:     Vec<String>,
+    pub client_id:           String,
+    pub connection_retry_ms: Duration,
+    pub message_timeout:     String,
+    pub api_key:             String,
+    pub api_secret_key:      String,
+}
+
+impl Default for KafkaCfg {
+    fn default() -> Self {
+        KafkaCfg { bootstrap_nodes:     vec![String::from("localhost:9092")],
+                   client_id:           String::from("http://localhost"),
+                   api_key:             String::from("CHANGEME"),
+                   api_secret_key:      String::from("CHANGEMETOO"),
+                   message_timeout:     String::from("3000"),
+                   connection_retry_ms: Duration::from_millis(300), }
     }
 }
 

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -116,9 +116,7 @@ mod deserialize_into_vec {
         where D: Deserializer<'de>
     {
         let list = String::deserialize(deserializer)?;
-        let features = list.split(',')
-                           .map(|f| f.trim().to_uppercase().to_owned())
-                           .collect();
+        let features = list.split(',').map(|f| f.trim().to_uppercase()).collect();
         Ok(features)
     }
 }
@@ -440,7 +438,8 @@ mod tests {
         assert_eq!(config.api.build_targets.len(), 1);
         assert_eq!(config.api.build_targets[0], target::X86_64_LINUX);
 
-        assert_eq!(&config.api.features_enabled, "foo, bar");
+        assert_eq!(&config.api.features_enabled,
+                   &["foo".to_string(), "bar".to_string()]);
         assert_eq!(config.api.build_on_upload, false);
         assert_eq!(config.api.private_max_age, 400);
 

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -200,22 +200,36 @@ impl ToSocketAddrs for HttpCfg {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct KafkaCfg {
-    pub bootstrap_nodes:     Vec<String>,
-    pub client_id:           String,
-    pub connection_retry_ms: Duration,
-    pub message_timeout:     String,
-    pub api_key:             String,
-    pub api_secret_key:      String,
+    pub bootstrap_nodes:        Vec<String>,
+    pub client_id:              String,
+    #[serde(with = "deserialize_into_duration")]
+    pub connection_retry_delay: Duration,
+    pub message_timeout:        String,
+    pub api_key:                String,
+    pub api_secret_key:         String,
 }
 
 impl Default for KafkaCfg {
     fn default() -> Self {
-        KafkaCfg { bootstrap_nodes:     vec![String::from("localhost:9092")],
-                   client_id:           String::from("http://localhost"),
-                   api_key:             String::from("CHANGEME"),
-                   api_secret_key:      String::from("CHANGEMETOO"),
-                   message_timeout:     String::from("3000"),
-                   connection_retry_ms: Duration::from_millis(300), }
+        KafkaCfg { bootstrap_nodes:        vec![String::from("localhost:9092")],
+                   client_id:              String::from("http://localhost"),
+                   api_key:                String::from("CHANGEME"),
+                   api_secret_key:         String::from("CHANGEMETOO"),
+                   message_timeout:        String::from("3000"),
+                   connection_retry_delay: Duration::from_secs(3), }
+    }
+}
+
+mod deserialize_into_duration {
+    use serde::{self,
+                Deserialize,
+                Deserializer};
+    use std::time::Duration;
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+        where D: Deserializer<'de>
+    {
+        let s = u64::deserialize(deserializer)?;
+        Ok(Duration::from_secs(s))
     }
 }
 

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -439,7 +439,7 @@ mod tests {
         assert_eq!(config.api.build_targets[0], target::X86_64_LINUX);
 
         assert_eq!(&config.api.features_enabled,
-                   &["foo".to_string(), "bar".to_string()]);
+                   &["FOO".to_string(), "BAR".to_string()]);
         assert_eq!(config.api.build_on_upload, false);
         assert_eq!(config.api.private_max_age, 400);
 

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -102,9 +102,25 @@ pub struct ApiCfg {
     pub key_path:         KeyCache,
     pub targets:          Vec<PackageTarget>,
     pub build_targets:    Vec<PackageTarget>,
-    pub features_enabled: String,
+    #[serde(with = "deserialize_into_vec")]
+    pub features_enabled: Vec<String>,
     pub build_on_upload:  bool,
     pub private_max_age:  usize,
+}
+
+mod deserialize_into_vec {
+    use serde::{self,
+                Deserialize,
+                Deserializer};
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+        where D: Deserializer<'de>
+    {
+        let list = String::deserialize(deserializer)?;
+        let features = list.split(',')
+                           .map(|f| f.trim().to_uppercase().to_owned())
+                           .collect();
+        Ok(features)
+    }
 }
 
 impl Default for ApiCfg {
@@ -116,7 +132,7 @@ impl Default for ApiCfg {
                                         target::X86_64_LINUX_KERNEL2,
                                         target::X86_64_WINDOWS,],
                  build_targets:    vec![target::X86_64_LINUX, target::X86_64_WINDOWS],
-                 features_enabled: String::from("jobsrv"),
+                 features_enabled: vec!["jobsrv".to_string()],
                  build_on_upload:  true,
                  private_max_age:  300, }
     }

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -204,7 +204,7 @@ pub struct KafkaCfg {
     pub client_id:              String,
     #[serde(with = "deserialize_into_duration")]
     pub connection_retry_delay: Duration,
-    pub message_timeout:        String,
+    pub message_timeout_ms:     u64,
     pub api_key:                String,
     pub api_secret_key:         String,
 }
@@ -215,7 +215,7 @@ impl Default for KafkaCfg {
                    client_id:              String::from("http://localhost"),
                    api_key:                String::from("CHANGEME"),
                    api_secret_key:         String::from("CHANGEMETOO"),
-                   message_timeout:        String::from("3000"),
+                   message_timeout_ms:     3000,
                    connection_retry_delay: Duration::from_secs(3), }
     }
 }

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -107,7 +107,7 @@ impl AppState {
                         break;
                     }
                     Err(_) => {
-                        thread::sleep(config.kafka.connection_retry_ms);
+                        thread::sleep(config.kafka.connection_retry_delay);
                         continue;
                     }
                 }

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -127,11 +127,7 @@ fn enable_features(config: &Config) {
                                                           ("ARTIFACTORY", feat::Artifactory),
                                                           ("BUILDDEPS", feat::BuildDeps),
                                                           ("EVENTBUS", feat::EventBus)]);
-    let features_enabled = config.api
-                                 .features_enabled
-                                 .split(',')
-                                 .map(|f| f.trim().to_uppercase());
-    for key in features_enabled {
+    for key in &config.api.features_enabled {
         if features.contains_key(key.as_str()) {
             info!("Enabling feature: {}", key);
             feat::enable(features[key.as_str()]);

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -69,7 +69,7 @@ features! {
         const LegacyProject = 0b0000_0011,
         const Artifactory = 0b0000_0100,
         const BuildDeps = 0b0000_1000,
-        const EventBus = 0b0000_0110
+        const EventBus = 0b0001_0000
     }
 }
 

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -18,7 +18,8 @@ use self::{framework::middleware::authentication_middleware,
                        projects::Projects,
                        settings::Settings,
                        user::User},
-           services::{memcache::MemcacheClient,
+           services::{events::KafkaProducer,
+                      memcache::MemcacheClient,
                       s3::S3Handler}};
 use crate::{bldr_core::rpc::RpcClient,
             config::{Config,
@@ -42,8 +43,10 @@ use rand::{self,
            Rng};
 use std::{cell::RefCell,
           collections::HashMap,
+          convert::TryFrom,
           iter::FromIterator,
-          sync::Arc};
+          sync::Arc,
+          thread};
 
 // This cipher list corresponds to the "intermediate" configuration
 // recommended by Mozilla:
@@ -65,7 +68,8 @@ features! {
         const Jobsrv = 0b0000_0010,
         const LegacyProject = 0b0000_0011,
         const Artifactory = 0b0000_0100,
-        const BuildDeps = 0b0000_1000
+        const BuildDeps = 0b0000_1000,
+        const EventBus = 0b0000_0110
     }
 }
 
@@ -79,18 +83,38 @@ pub struct AppState {
     memcache:    RefCell<MemcacheClient>,
     artifactory: ArtifactoryClient,
     db:          DbPool,
+    kafka:       Option<KafkaProducer>,
 }
 
 impl AppState {
     pub fn new(config: &Config, db: DbPool) -> error::Result<AppState> {
-        Ok(AppState { config: config.clone(),
-                      packages: S3Handler::new(config.s3.clone()),
-                      github: GitHubClient::new(config.github.clone())?,
-                      jobsrv: RpcClient::new(&format!("{}", config.jobsrv)),
-                      oauth: OAuth2Client::new(config.oauth.clone())?,
-                      memcache: RefCell::new(MemcacheClient::new(&config.memcache.clone())),
-                      artifactory: ArtifactoryClient::new(config.artifactory.clone())?,
-                      db })
+        let mut app_state =
+            AppState { config: config.clone(),
+                       packages: S3Handler::new(config.s3.clone()),
+                       github: GitHubClient::new(config.github.clone())?,
+                       jobsrv: RpcClient::new(&format!("{}", config.jobsrv)),
+                       oauth: OAuth2Client::new(config.oauth.clone())?,
+                       memcache: RefCell::new(MemcacheClient::new(&config.memcache.clone())),
+                       artifactory: ArtifactoryClient::new(config.artifactory.clone())?,
+                       db,
+                       kafka: None };
+
+        if feat::is_enabled(feat::EventBus) {
+            loop {
+                match KafkaProducer::try_from(&config.kafka.clone()) {
+                    Ok(producer) => {
+                        app_state.kafka = Some(producer);
+                        break;
+                    }
+                    Err(_) => {
+                        thread::sleep(config.kafka.connection_retry_ms);
+                        continue;
+                    }
+                }
+            }
+        };
+
+        Ok(app_state)
     }
 }
 
@@ -99,7 +123,8 @@ fn enable_features(config: &Config) {
                                                           ("JOBSRV", feat::Jobsrv),
                                                           ("LEGACYPROJECT", feat::LegacyProject),
                                                           ("ARTIFACTORY", feat::Artifactory),
-                                                          ("BUILDDEPS", feat::BuildDeps)]);
+                                                          ("BUILDDEPS", feat::BuildDeps),
+                                                          ("EVENTBUS", feat::EventBus)]);
     let features_enabled = config.api
                                  .features_enabled
                                  .split(',')

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -104,9 +104,11 @@ impl AppState {
                 match KafkaProducer::try_from(&config.kafka.clone()) {
                     Ok(producer) => {
                         app_state.kafka = Some(producer);
+                        info!("EventBus ready to go.");
                         break;
                     }
-                    Err(_) => {
+                    Err(e) => {
+                        warn!("Unable to load EventBus: {}", e);
                         thread::sleep(config.kafka.connection_retry_delay);
                         continue;
                     }

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -451,9 +451,9 @@ async fn promote_package(req: HttpRequest,
                 Err(err) => debug!("Failed to save rank change to audit log: {}", err),
             };
 
-            if feat::is_enabled(feat::EventBus) {
+            if feat::is_enabled(feat::EventBus) && state.kafka.as_ref().is_some() {
                 let msgkey = session.get_id() as i64;
-                let kafkaconn = state.kafka.as_ref().expect("Failed to return kafka config from actix AppState");
+                let kafkaconn = state.kafka.as_ref().unwrap(); // safe, we check .is_some() above
 
                 match EventBuilderV10::new()
                     .id(format!("{:?}", Uuid::new_v4()))

--- a/components/builder-api/src/server/services/events.rs
+++ b/components/builder-api/src/server/services/events.rs
@@ -21,7 +21,7 @@ impl TryFrom<&KafkaCfg> for KafkaProducer {
     fn try_from(config: &KafkaCfg) -> Result<Self, KafkaError> {
         let bootstrap_list = config.bootstrap_nodes.join(",");
         match ClientConfig::new().set("bootstrap.servers", &bootstrap_list)
-                                 .set("message.timeout.ms", &config.message_timeout)
+                                 .set("message.timeout.ms", &config.message_timeout_ms.to_string())
                                  .set("client.id", &config.client_id)
                                  .set("sasl.username", &config.api_key)
                                  .set("sasl.password", &config.api_secret_key)

--- a/components/builder-api/src/server/services/events.rs
+++ b/components/builder-api/src/server/services/events.rs
@@ -1,0 +1,53 @@
+use std::convert::TryFrom;
+
+use crate::config::KafkaCfg;
+
+use cloudevents::Event;
+use cloudevents_sdk_rdkafka::{FutureRecordExt,
+                              MessageRecord};
+
+use rdkafka::{config::ClientConfig,
+              error::KafkaError,
+              producer::{FutureProducer,
+                         FutureRecord}};
+
+pub const KAFKA_DEFAULT_TOPIC_NAME: &str = "bldr_event_init";
+
+pub struct KafkaProducer(pub FutureProducer);
+
+impl TryFrom<&KafkaCfg> for KafkaProducer {
+    type Error = KafkaError;
+
+    fn try_from(config: &KafkaCfg) -> Result<Self, KafkaError> {
+        let bootstrap_list = config.bootstrap_nodes.join(",");
+        match ClientConfig::new().set("bootstrap.servers", &bootstrap_list)
+                                 .set("message.timeout.ms", &config.message_timeout)
+                                 .set("client.id", &config.client_id)
+                                 .set("sasl.username", &config.api_key)
+                                 .set("sasl.password", &config.api_secret_key)
+                                 .set("security.protocol", "SASL_SSL")
+                                 .set("sasl.mechanisms", "PLAIN")
+                                 .create()
+        {
+            Ok(iprodr) => Ok(KafkaProducer(iprodr)),
+            Err(err) => {
+                error!("Error initializing kafka producer, will retry: {:?}", err);
+                Err(err)
+            }
+        }
+    }
+}
+
+pub async fn produce(msgkey: i64, event: Event, conn: &FutureProducer, topic_name: &str) {
+    let message_record =
+        MessageRecord::from_event(event).expect("error while serializing the event");
+
+    if let Err(err) = conn.send(FutureRecord::to(topic_name).message_record(&message_record)
+                                                            .key(&format!("Key {}", msgkey)),
+                                0)
+                          .await
+    {
+        error!("Event producer failed to send message to event bus: {:?}",
+               err)
+    };
+}

--- a/components/builder-api/src/server/services/mod.rs
+++ b/components/builder-api/src/server/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod events;
 pub mod github;
 pub mod memcache;
 pub mod metrics;

--- a/support/ci/builder-base-plan.sh
+++ b/support/ci/builder-base-plan.sh
@@ -65,4 +65,13 @@ do_builder_prepare() {
   # Used to set the active package target for the binaries at build time
   export PLAN_PACKAGE_TARGET="$pkg_target"
   build_line "Setting PLAN_PACKAGE_TARGET=$PLAN_PACKAGE_TARGET"
+
+  # Used to allow librdkafka build scripts to execute successfully
+
+  if test -f /usr/bin/env; then
+    build_line "/usr/bin/env exists skipping symlink"
+  else
+    ln -s "$(hab pkg path core/coreutils)/bin/env" /usr/bin/env
+    build_line "Setting symlink to binary env for librdkafka"
+  fi
 }


### PR DESCRIPTION
This PR adds all the required bits for the initial piece of confluent cloud integration for the builder API hidden behind a feature flag. It only generates an event on individual package promotions. Getting this merged means we can start to investigate more interesting levels of kafka interaction in the SaaS services and serves as a model for event production and submission to confluent as an event bus. It should have no impact on live/acceptance whatsoever.

Signed-off-by: Ian Henry <ianjhenry00@gmail.com>