### PR TITLE
Change the source for the connection public key

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -37,7 +37,7 @@ locals {
       bldr_url               = var.bldr_url
       worker_release_channel = var.worker_release_channel
       enabled_features       = var.enabled_features
-      authorized_keys        = file(var.connection_public_key)
+      authorized_keys        = var.connection_public_key
     })
 }
 


### PR DESCRIPTION
This aligns the Windows instances with our Linux instances in the
expectation that the public key is set to the value of the key rather
than the path to a file containing the key

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>