### PR TITLE
Extend package build manifest to support existing build workers.

### DIFF
--- a/components/builder-graph/src/data_store.rs
+++ b/components/builder-graph/src/data_store.rs
@@ -18,8 +18,7 @@ use std::{collections::HashSet,
                Write},
           iter::FromIterator,
           path::Path,
-          str::FromStr,
-          sync::Arc};
+          str::FromStr};
 
 use crate::hab_core::package::{PackageIdent,
                                PackageTarget};
@@ -220,7 +219,7 @@ impl DataStore {
     }
 
     /// Create a new DataStore from a pre-existing pool; useful for testing the database.
-    pub fn from_pool(pool: DbPool, _: Arc<String>) -> Result<DataStore> { Ok(DataStore { pool }) }
+    pub fn from_pool(pool: DbPool) -> Result<DataStore> { Ok(DataStore { pool }) }
 
     /// Setup the datastore.
     ///

--- a/components/builder-graph/src/target_graph.rs
+++ b/components/builder-graph/src/target_graph.rs
@@ -62,6 +62,10 @@ impl TargetGraph {
         }
     }
 
+    pub fn graph_for_target(&self, target: PackageTarget) -> Option<&dyn PackageGraphTrait> {
+        self.graphs.get(&target).map(|x| x.as_ref())
+    }
+
     pub fn graph_mut(&mut self,
                      target_str: &str)
                      -> Option<&mut (dyn PackageGraphTrait + 'static)> {

--- a/components/builder-graph/src/util.rs
+++ b/components/builder-graph/src/util.rs
@@ -35,6 +35,7 @@ pub enum EdgeType {
     RuntimeDep,
     BuildDep,
     StrongBuildDep,
+    ExternalConstraint, // This comes from non dependency graph issues such as worker build limits
 }
 
 impl Default for EdgeType {


### PR DESCRIPTION
The build workers don't allow exact package resolution, but instead
resolve the latest from a channel. The execution ordering of the base
graph is specified only by the direct dependencies of the
package. This creates an antidependency (read before write) as it is
possible that we build the next iteration of a package before all of
the consumers of the last iteration have started; if that happens
those packages might pick up the wrong iteration. This is likely
harmless, except it makes the process + nondeterministic and hard to
debug. Constraining this will protect against this nondeterminism at
the cost of some parallelism.

Signed-off-by: Mark Anderson <mark@chef.io>
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>
Co-authored-by: Mark Anderson <mark@chef.io>
Co-authored-by: Scott Macfarlane <smacfarlane@chef.io>