### PR TITLE
Change default max json body size [jobsrv]

### DIFF
--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -198,7 +198,7 @@ pub async fn run(config: Config) -> Result<()> {
     HttpServer::new(move || {
         let app_state = AppState::new(&config, &datastore, db_pool.clone(), &graph_arc);
 
-        App::new().data(JsonConfig::default().limit(MAX_JSON_PAYLOAD))
+        App::new().app_data(JsonConfig::default().limit(MAX_JSON_PAYLOAD))
                   .data(app_state)
                   .wrap(Logger::default().exclude("/status"))
                   .service(web::resource("/status").route(web::get().to(status))


### PR DESCRIPTION
In some cases the manifest for a package can be larger than the maximum
default of 32k for the json body in rpc calls to jobsrv.  This was
previously corrected in #1366, but reappeared recently in our testing of
the scheduler.

Actix 2.0.0 added an `app_data` in addition to the `data` method that
makes the configuration available at the application level, rather than
the resource level.  Changing from the previously correct `data` to
`app_data` when setting the config value appears to again correctly set
the maximum payload size to 256K.

https://docs.rs/actix-web/2.0.0/actix_web/struct.Resource.html#method.app_data

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>