### PR TITLE
replace String return type for EventConsumer

### DIFF
--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -29,9 +29,9 @@ use diesel::{pg::PgConnection,
                               NotFound}}};
 
 use crate::{bldr_core::metrics::CounterMetric,
-            bldr_events::event::{BuilderEvent,
-                                 EventType,
-                                 RoutingKey::*},
+            bldr_events::event::{AffinityKey::*,
+                                 BuilderEvent,
+                                 EventType},
             hab_core::{package::{PackageIdent,
                                  PackageTarget},
                        ChannelIdent}};
@@ -444,7 +444,7 @@ async fn promote_package(req: HttpRequest,
                  debug!("Failed to save rank change to audit log: {}", e);
             };
 
-            BuilderEvent::new(EventType::PackageChannelMotion, NoKey, &auditevent)
+            BuilderEvent::new(EventType::PackageChannelMotion, NoAffinity, "builder_events".to_string(), &auditevent)
                 .publish(&state.event_producer).await;
 
             state

--- a/components/builder-events/src/connection.rs
+++ b/components/builder-events/src/connection.rs
@@ -117,7 +117,7 @@ pub trait EventConsumer {
     fn subscribe(&self, queues: &[&str]) -> Result<(), Error>;
     /// Poll the topic(s) for new messages. When a message exists, its payload will be returned.
     /// This is a synchronous call.
-    fn poll(&self) -> Option<Result<String, Error>>;
+    fn poll(&self) -> Option<Result<BuilderEvent, Error>>;
 
     // TODO (JM): Add an async stream consumer method, perhaps `consume_stream` or similar.
     // An example of a Kafka implementation of this is implemented via `StreamConsumer` [1].

--- a/components/builder-events/src/event.rs
+++ b/components/builder-events/src/event.rs
@@ -1,3 +1,4 @@
+use self::RoutingKey::*;
 use crate::connection::EventPublisher;
 use cloudevents::{event::Event,
                   EventBuilder,
@@ -99,6 +100,6 @@ impl BuilderEvent {
 impl From<Event> for BuilderEvent {
     fn from(event: Event) -> Self {
         BuilderEvent { inner:       event,
-                       routing_key: RoutingKey::NoKey, }
+                       routing_key: NoKey, }
     }
 }

--- a/components/builder-events/src/event.rs
+++ b/components/builder-events/src/event.rs
@@ -29,6 +29,7 @@ pub enum AffinityKey {
 
 #[derive(Debug)]
 pub struct EventEnvelope {
+    // topic or queue name
     pub destination:  String,
     pub affinity_key: AffinityKey,
 }

--- a/components/builder-events/src/event.rs
+++ b/components/builder-events/src/event.rs
@@ -29,10 +29,10 @@ pub enum AffinityKey {
     Key(String),
 }
 
-/// DeliveryTicket contains routing information about how to deliver the message such as the
+/// DeliveryTag contains routing information about how to deliver the message such as the
 /// destination and message affinity key.
 #[derive(Debug)]
-pub struct DeliveryTicket {
+pub struct DeliveryTag {
     // the Topic or Queue name
     pub destination:  String,
     pub affinity_key: AffinityKey,
@@ -42,7 +42,7 @@ pub struct DeliveryTicket {
 #[derive(Debug)]
 pub enum DispatchStatus {
     Delivered,
-    Undelivered(DeliveryTicket),
+    Undelivered(DeliveryTag),
 }
 
 /// An "event" expressing an action occurrence and its context in Builder. BuilderEvents are routed
@@ -100,8 +100,8 @@ impl BuilderEvent {
                                   .expect("This should always work because we control all the \
                                            inputs");
         BuilderEvent { inner:    event,
-                       tracking: Undelivered(DeliveryTicket { destination,
-                                                              affinity_key }), }
+                       tracking: Undelivered(DeliveryTag { destination,
+                                                           affinity_key }), }
     }
 
     // Function to return owned tuple consisting of the private fields in BuilderEvent

--- a/components/builder-events/src/event.rs
+++ b/components/builder-events/src/event.rs
@@ -95,3 +95,10 @@ impl BuilderEvent {
         }
     }
 }
+
+impl From<Event> for BuilderEvent {
+    fn from(event: Event) -> Self {
+        BuilderEvent { inner:       event,
+                       routing_key: RoutingKey::NoKey, }
+    }
+}

--- a/components/builder-events/src/kafka.rs
+++ b/components/builder-events/src/kafka.rs
@@ -150,11 +150,10 @@ impl EventPublisher for KafkaPublisher {
         let message_record =
             MessageRecord::from_event(event).expect("error while serializing the event");
         match tracking {
-            Undelivered(ticket) => {
-                let topic = ticket.destination;
+            Undelivered(tag) => {
                 let future_record = {
-                    let r = FutureRecord::to(&topic).message_record(&message_record);
-                    if let AffinityKey::Key(key) = &ticket.affinity_key {
+                    let r = FutureRecord::to(&tag.destination).message_record(&message_record);
+                    if let AffinityKey::Key(key) = &tag.affinity_key {
                         r.key(key)
                     } else {
                         r
@@ -165,7 +164,10 @@ impl EventPublisher for KafkaPublisher {
                         error!("KafkaPublisher failed to send message to a Broker: {:?}",
                                err)
                     }
-                    Ok(_) => trace!("KafkaPublisher published event to topic: {}", topic),
+                    Ok(_) => {
+                        trace!("KafkaPublisher published event to topic: {}",
+                               tag.destination)
+                    }
                 };
             }
             Delivered => error!("KafkaPublisher will not publish an already delivered Event."),

--- a/components/builder-events/src/kafka.rs
+++ b/components/builder-events/src/kafka.rs
@@ -160,11 +160,12 @@ impl EventPublisher for KafkaPublisher {
                         r
                     }
                 };
-                if let Err(err) = self.inner.send(future_record, 0).await {
-                    error!("KafkaPublisher failed to send message to a Broker: {:?}",
-                           err)
-                } else {
-                    trace!("KafkaPublisher published event to topic: {}", topic);
+                match self.inner.send(future_record, 0).await {
+                    Err(err) => {
+                        error!("KafkaPublisher failed to send message to a Broker: {:?}",
+                               err)
+                    }
+                    Ok(_) => trace!("KafkaPublisher published event to topic: {}", topic),
                 };
             }
             Delivered => error!("KafkaPublisher will not publish an already delivered Event."),


### PR DESCRIPTION
This change improves the `EventConsumer` trait's `.poll()` method by returning a `BuilderEvent` instead of `String` type. The `BuilderEvent` type now becomes the contract message implementation for the `EventConsumer` and `EventPublisher` APIs. The `BuilderEvent` struct includes an `event_type` field that we can match on to flexibly deserialize the JSON `payload` field into a downstream Type of our choosing. This should allow us to handle any sort of business logic we need with these libraries.

Signed-off-by: Jeremy J. Miller <jm@chef.io>