### PR TITLE
Add API endpoint to jobsrv to return graph 

### DIFF
--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -70,6 +70,7 @@ use bytes::Bytes;
 use diesel::result::Error::NotFound;
 use futures::{channel::mpsc,
               StreamExt};
+use protobuf::Message;
 use serde::ser::Serialize;
 use std::{fs::{self,
                remove_file,
@@ -1196,6 +1197,7 @@ async fn do_upload_package_finish(req: &HttpRequest,
                 let mut job_graph_package = jobsrv::JobGraphPackageCreate::new();
                 job_graph_package.set_package(pkg.into());
 
+                let msg_size = job_graph_package.compute_size();
                 match route_message::<jobsrv::JobGraphPackageCreate, originsrv::OriginPackage>(
                     &req,
                     &job_graph_package,
@@ -1210,7 +1212,8 @@ async fn do_upload_package_finish(req: &HttpRequest,
                         );
                     }
                     Err(err) => {
-                        warn!("Failed to create job graph package, err={:?}", err);
+                        warn!("Failed to create job graph package, (msg_size {}) err={:?}", msg_size, err);
+                        debug!("Message: {:?}", job_graph_package);
                         return err.into();
                     }
                 }

--- a/components/builder-graph/src/acyclic_package_graph.rs
+++ b/components/builder-graph/src/acyclic_package_graph.rs
@@ -395,6 +395,12 @@ impl PackageGraphTrait for AcyclicPackageGraph {
                                   external_dependencies: all_external_dependencies,
                                   unbuildable_reasons:   unbuildable_map, })
     }
+
+    //  maybe look to implement this as part of serialization
+    fn as_json(&self, _origin_filter: Option<&str>) -> String {
+        unimplemented!() // we expect that we will rip this code out rather than need to implement
+                         // this..
+    }
 }
 
 impl AcyclicPackageGraph {

--- a/components/builder-graph/src/cyclic_package_graph.rs
+++ b/components/builder-graph/src/cyclic_package_graph.rs
@@ -87,4 +87,7 @@ impl PackageGraphTrait for CyclicPackageGraph {
                      -> Result<PackageBuildManifest> {
         Ok(self.graph.compute_build(touched, unbuildable))
     }
+
+    //  maybe look to implement this as part of serialization
+    fn as_json(&self, origin_filter: Option<&str>) -> String { self.graph.as_json(origin_filter) }
 }

--- a/components/builder-graph/src/graph_helpers.rs
+++ b/components/builder-graph/src/graph_helpers.rs
@@ -111,6 +111,7 @@ pub fn count_edges_filtered(graph: &DiGraphMap<PackageIdentIntern, EdgeType>,
     (in_count, out_count)
 }
 
+#[tracing::instrument(skip(graph))]
 pub fn changed_edges_for_type(graph: &DiGraphMap<PackageIdentIntern, EdgeType>,
                               node: PackageIdentIntern,
                               deps: &[PackageIdentIntern],
@@ -129,6 +130,7 @@ pub fn changed_edges_for_type(graph: &DiGraphMap<PackageIdentIntern, EdgeType>,
     (added, removed)
 }
 
+#[tracing::instrument(skip(graph))]
 pub fn update_edges_for_type(graph: &mut DiGraphMap<PackageIdentIntern, EdgeType>,
                              node: PackageIdentIntern,
                              added: &[PackageIdentIntern],
@@ -142,6 +144,7 @@ pub fn update_edges_for_type(graph: &mut DiGraphMap<PackageIdentIntern, EdgeType
     }
 }
 
+#[tracing::instrument(skip(graph))]
 pub fn revise_edges_for_type(graph: &mut DiGraphMap<PackageIdentIntern, EdgeType>,
                              node: PackageIdentIntern,
                              deps: &[PackageIdentIntern],
@@ -238,6 +241,59 @@ pub fn dump_graph_raw(graph: &DiGraphMap<PackageIdentIntern, EdgeType>,
                      node_name, in_count, out_count, rdeps_join, bdeps_join, sdeps_join).unwrap();
         }
     }
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Tooling around emitting the graph as JSON/serializing it
+// This resembles the PackageBuild structure and probably has room for consolidation
+// Also look at consolidation with dump_graph_raw above
+#[derive(Debug, Default, Serialize)]
+pub struct GraphNodeWithEdges {
+    pub name:         PackageIdentIntern,
+    pub runtime_deps: Vec<PackageIdentIntern>,
+    pub build_deps:   Vec<PackageIdentIntern>,
+    pub strong_deps:  Vec<PackageIdentIntern>,
+}
+
+pub fn dump_graph_structured(graph: &DiGraphMap<PackageIdentIntern, EdgeType>,
+                             origin_filter: Option<&str>,
+                             drop_orphaned: bool)
+                             -> Vec<GraphNodeWithEdges> {
+    let mut result = Vec::new();
+
+    // iterate through nodes
+    for node in graph.nodes().sorted() {
+        let (in_count, out_count) = count_edges(&graph, node);
+        let orphaned = (in_count == 0) && (out_count == 0);
+        let keep = !orphaned || !drop_orphaned;
+        if filter_match(&node, origin_filter) && keep {
+            let mut bdeps = Vec::new();
+            let mut rdeps = Vec::new();
+            let mut sdeps = Vec::new();
+            for succ in graph.neighbors_directed(node, Direction::Outgoing) {
+                let edge_weight = graph.edge_weight(node, succ).unwrap();
+                match edge_weight {
+                    EdgeType::BuildDep => bdeps.push(succ),
+                    EdgeType::RuntimeDep => rdeps.push(succ),
+                    EdgeType::StrongBuildDep => sdeps.push(succ),
+                    EdgeType::ExternalConstraint => {
+                        warn!("External Constraints should not appear here {:?}",
+                              edge_weight)
+                    }
+                }
+            }
+            bdeps.sort();
+            rdeps.sort();
+            sdeps.sort();
+
+            let element = GraphNodeWithEdges { name:         node,
+                                               runtime_deps: rdeps,
+                                               build_deps:   bdeps,
+                                               strong_deps:  sdeps, };
+            result.push(element)
+        }
+    }
+    result
 }
 
 pub fn emit_graph_as_dot(graph: &DiGraphMap<PackageIdentIntern, EdgeType>,

--- a/components/builder-graph/src/package_graph_target.rs
+++ b/components/builder-graph/src/package_graph_target.rs
@@ -108,6 +108,7 @@ impl PackageGraphForTarget {
     // Incrementally adds a node to the graph, rejecting it and doing nothing
     // if it returns a cycle.
     // Returns current node, edge count of graph.
+    #[tracing::instrument(skip(self))]
     pub fn extend(&mut self, package_info: &PackageInfo, use_build_deps: bool) -> (usize, usize) {
         debug!("Extend: {} {} N:{} E:{} P:{}",
                package_info.ident,
@@ -128,6 +129,8 @@ impl PackageGraphForTarget {
         if !self.latest_map.contains_key(&short_ident)
            || self.latest_map[&short_ident] <= package_ident
         {
+            let msg = format!("Updating plan ident {} with {}", short_ident, package_ident);
+            tracing::info!("{}", msg);
             // we will need to be checking for cycles here...
             // List current node in graph outgoing runtime (rt) deps
             // Compare to new package rt deps
@@ -219,6 +222,7 @@ impl PackageGraphForTarget {
     // The embarassing levels of parallel construction between the two should be cleaned up and
     // unified
     // Returns true if we can add this w/o a cycle
+    #[tracing::instrument(skip(self))]
     pub fn check_extend(&self, package_info: &PackageInfo, _use_build_deps: bool) -> bool {
         // TODO make plan for removing package_info structs from package table when they are no
         // longer part of graph Right now we keep them forever, which is unnecessary.
@@ -265,6 +269,17 @@ impl PackageGraphForTarget {
         }
 
         true
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub fn as_json(&self, origin_filter: Option<&str>) -> String {
+        let graph = graph_helpers::dump_graph_structured(&self.latest_graph, origin_filter, false);
+        debug!("Dump Graph Structured for (N:{} E:{} {}) {} elements",
+               self.latest_graph.node_count(),
+               self.latest_graph.edge_count(),
+               self.target,
+               graph.len());
+        serde_json::to_string(&graph).unwrap()
     }
 
     pub fn write_packages_json(&self, filename: &str, filter: Option<&str>) {

--- a/components/builder-graph/src/package_graph_target.rs
+++ b/components/builder-graph/src/package_graph_target.rs
@@ -129,8 +129,8 @@ impl PackageGraphForTarget {
         if !self.latest_map.contains_key(&short_ident)
            || self.latest_map[&short_ident] <= package_ident
         {
-            let msg = format!("Updating plan ident {} with {}", short_ident, package_ident);
-            tracing::info!("{}", msg);
+            // This should be event, but hitting https://github.com/tokio-rs/tracing/issues/792
+            tracing::info!("Updating plan ident {} with {}", short_ident, package_ident);
             // we will need to be checking for cycles here...
             // List current node in graph outgoing runtime (rt) deps
             // Compare to new package rt deps

--- a/components/builder-graph/src/package_graph_trait.rs
+++ b/components/builder-graph/src/package_graph_trait.rs
@@ -62,4 +62,7 @@ pub trait PackageGraphTrait: Send + Sync {
                      touched: &[PackageIdentIntern],
                      unbuildable: &dyn Unbuildable)
                      -> Result<PackageBuildManifest>;
+
+    //  maybe look to implement this as part of serialization
+    fn as_json(&self, origin_filter: Option<&str>) -> String;
 }

--- a/components/builder-graph/src/package_ident_intern.rs
+++ b/components/builder-graph/src/package_ident_intern.rs
@@ -19,6 +19,9 @@ use std::{cmp::{Ordering,
           result,
           str::FromStr};
 
+use serde::ser::{Serialize,
+                 Serializer};
+
 use crate::hab_core::{error as herror,
                       package::{ident::{version_sort,
                                         Identifiable},
@@ -134,6 +137,14 @@ impl fmt::Debug for PackageIdentIntern {
         } else {
             write!(f, "{}/{}", self.origin, self.name)
         }
+    }
+}
+
+impl Serialize for PackageIdentIntern {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -45,7 +45,8 @@ use actix_web::{dev::Body,
                 web::{self,
                       Data,
                       Json,
-                      JsonConfig},
+                      JsonConfig,
+                      Query},
                 App,
                 HttpResponse,
                 HttpServer};
@@ -55,6 +56,7 @@ use std::{collections::{HashMap,
           iter::{FromIterator,
                  Iterator},
           panic,
+          str::FromStr,
           sync::{Arc,
                  RwLock},
           time::Instant};
@@ -99,6 +101,15 @@ impl AppState {
     }
 }
 
+// Patterned after helpers in the api
+#[derive(Deserialize)]
+pub struct OriginTarget {
+    #[serde(default)]
+    pub origin: Option<String>,
+    #[serde(default)]
+    pub target: Option<String>,
+}
+
 /// Endpoint for determining availability of builder-jobsrv components.
 ///
 /// Returns a status 200 on success. Any non-200 responses are an outage or a partial outage.
@@ -106,7 +117,7 @@ fn status() -> HttpResponse { HttpResponse::new(StatusCode::OK) }
 
 #[allow(clippy::needless_pass_by_value)]
 fn handle_rpc(msg: Json<RpcMessage>, state: Data<AppState>) -> HttpResponse {
-    debug!("Got RPC message, body =\n{:?}", msg);
+    debug!("Got RPC message, id {} body =\n{:?}", msg.id.as_str(), msg);
 
     let result = match msg.id.as_str() {
         "JobGet" => handlers::job_get(&msg, &state),
@@ -136,6 +147,32 @@ fn handle_rpc(msg: Json<RpcMessage>, state: Data<AppState>) -> HttpResponse {
         Ok(m) => HttpResponse::Ok().json(m),
         Err(e) => e.into(),
     }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_graph(state: Data<AppState>, query: Query<OriginTarget>) -> HttpResponse {
+    let origin_filter = query.origin.as_deref(); //
+    let target = query.target.as_deref().unwrap_or("x86_64-linux");
+
+    match fetch_graph_for_target(state, &target, origin_filter) {
+        Ok(body) => HttpResponse::with_body(StatusCode::OK, Body::from(body)),
+        Err(err) => {
+            HttpResponse::with_body(StatusCode::INTERNAL_SERVER_ERROR,
+                                    Body::from_message(err.to_string()))
+        } // maybe we do 401 ill formed instead?
+    }
+}
+
+#[tracing::instrument(skip(state))]
+fn fetch_graph_for_target(state: Data<AppState>,
+                          target_string: &str,
+                          origin_filter: Option<&str>)
+                          -> Result<String> {
+    let target = PackageTarget::from_str(target_string)?;
+    let target_graph = state.graph.read().map_err(|_| Error::System)?; // Should rethink this error
+    let graph = target_graph.graph_for_target(target).ok_or(Error::System)?;
+    let body = graph.as_json(origin_filter);
+    Ok(body)
 }
 
 fn enable_features_from_config(cfg: &Config) {
@@ -224,6 +261,7 @@ pub async fn run(config: Config) -> Result<()> {
                     .service(web::resource("/status").route(web::get().to(status))
                                                     .route(web::head().to(status)))
                     .route("/rpc", web::post().to(handle_rpc))
+                    .route("/graph", web::get().to(handle_graph))
                         }).workers(cfg.handler_count())
                           .keep_alive(cfg.http.keep_alive)
                           .bind(cfg.http.clone())


### PR DESCRIPTION
Add API endpoint to jobsrv to return graph

Adds a resource in the form: /graph?target=TARGET&origin=ORIGIN to return a json dump of the graph.

If origin is not provided gives full graph
If target is not provided chooses x86_64-linux

Also add a bit more tracing to help track api calls

Signed-off-by: Mark Anderson <mark@chef.io>