### PR TITLE
get commit count from HEAD not master

### DIFF
--- a/components/builder-api-proxy/habitat/plan.sh
+++ b/components/builder-api-proxy/habitat/plan.sh
@@ -31,7 +31,7 @@ pkg_exposes=(port ssl-port)
 pkg_version() {
   # TED: After migrating the builder repo we needed to add to
   # the rev-count to keep version sorting working
-  echo "$(($(git rev-list master --count) + 5000))"
+  echo "$(($(git rev-list HEAD --count) + 5000))"
 }
 
 do_before() {

--- a/components/builder-datastore/plan.sh
+++ b/components/builder-datastore/plan.sh
@@ -36,7 +36,7 @@ pkg_exposes=(port)
 pkg_version() {
   # TED: After migrating the builder repo we needed to add to
   # the rev-count to keep version sorting working
-  echo "$(($(git rev-list master --count) + 5000))"
+  echo "$(($(git rev-list HEAD --count) + 5000))"
 }
 
 ext_semver_version=0.17.0

--- a/components/builder-memcached/plan.sh
+++ b/components/builder-memcached/plan.sh
@@ -11,7 +11,7 @@ pkg_exposes=(port)
 pkg_version() {
   # TED: After migrating the builder repo we needed to add to
   # the rev-count to keep version sorting working
-  echo "$(($(git rev-list master --count) + 5000))"
+  echo "$(($(git rev-list HEAD --count) + 5000))"
 }
 do_before() {
   update_pkg_version

--- a/components/builder-minio/habitat/plan.sh
+++ b/components/builder-minio/habitat/plan.sh
@@ -17,7 +17,7 @@ pkg_exports=(
 pkg_version() {
   # TED: After migrating the builder repo we needed to add to
   # the rev-count to keep version sorting working
-  echo "$(($(git rev-list master --count) + 5000))"
+  echo "$(($(git rev-list HEAD --count) + 5000))"
 }
 
 do_before() {

--- a/components/builder-worker/habitat/x86_64-windows/plan.ps1
+++ b/components/builder-worker/habitat/x86_64-windows/plan.ps1
@@ -29,7 +29,7 @@ $bin = "bldr-worker"
 function pkg_version {
     # TED: After migrating the builder repo we needed to add to
     # the rev-count to keep version sorting working
-    5000 + (git rev-list master --count)
+    5000 + (git rev-list HEAD --count)
 }
 
 function Invoke-Before {


### PR DESCRIPTION
Some of our plans produce a version based on commit count of HEAD but others get the count from master. Head is better since that will give a reproducible version for any given checkout.

Signed-off-by: mwrock <matt@mattwrock.com>