### PR TITLE
Guard the creation of job_exec_state type

### DIFF
--- a/components/builder-db/src/migrations/2020-11-09-000001_job_graph_scheduler/up.sql
+++ b/components/builder-db/src/migrations/2020-11-09-000001_job_graph_scheduler/up.sql
@@ -1,14 +1,19 @@
-CREATE TYPE job_exec_state AS ENUM (
-  'pending',
-  'waiting_on_dependency',
-  'ready',
-  'running',
-  'complete',
-  'job_failed',
-  'dependency_failed',
-  'cancel_pending',
-  'cancel_complete'
-);
+DO $$ BEGIN
+  CREATE TYPE job_exec_state AS ENUM (
+    'pending',
+    'waiting_on_dependency',
+    'ready',
+    'running',
+    'complete',
+    'job_failed',
+    'dependency_failed',
+    'cancel_pending',
+    'cancel_complete'
+  );
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
 
 CREATE SEQUENCE IF NOT EXISTS job_graph_id_seq;
 


### PR DESCRIPTION
There's apparently no `IF NOT EXISTS` clause for this, so we have to
be a bit more verbose.

Signed-off-by: Christopher Maier <cmaier@chef.io>