### PR TITLE
Revert unnecessary schema changes

### DIFF
--- a/components/builder-db/src/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/components/builder-db/src/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -16,17 +16,10 @@
 --
 -- SELECT diesel_manage_updated_at('users');
 -- ```
-CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl information_schema.sql_identifier) RETURNS VOID AS $$
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
 BEGIN
-  IF NOT EXISTS (SELECT *
-    FROM information_schema.triggers
-    WHERE event_object_table = _tbl
-    AND trigger_name = 'set_updated_at'
-  )
-  THEN
     EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
                     FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
-  END IF;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/components/builder-db/src/migrations/2020-11-09-000001_job_graph_scheduler/up.sql
+++ b/components/builder-db/src/migrations/2020-11-09-000001_job_graph_scheduler/up.sql
@@ -1,19 +1,14 @@
-DO $$ BEGIN
-  CREATE TYPE job_exec_state AS ENUM (
-    'pending',
-    'waiting_on_dependency',
-    'ready',
-    'running',
-    'complete',
-    'job_failed',
-    'dependency_failed',
-    'cancel_pending',
-    'cancel_complete'
-  );
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
-
+CREATE TYPE job_exec_state AS ENUM (
+  'pending',
+  'waiting_on_dependency',
+  'ready',
+  'running',
+  'complete',
+  'job_failed',
+  'dependency_failed',
+  'cancel_pending',
+  'cancel_complete'
+);
 
 CREATE SEQUENCE IF NOT EXISTS job_graph_id_seq;
 

--- a/components/builder-db/src/migrations/2020-11-09-000001_job_graph_scheduler/up.sql
+++ b/components/builder-db/src/migrations/2020-11-09-000001_job_graph_scheduler/up.sql
@@ -45,11 +45,11 @@ SELECT diesel_manage_updated_at('job_graph');
 -- This is required for fast search inside the array
 -- It might get large, maybe we should create partial index
 -- either filtered on job state or a separate active/archived flag
-CREATE EXTENSION IF NOT EXISTS intarray;
-CREATE INDEX IF NOT EXISTS job_graph_dependencies_idx ON job_graph USING GIN(dependencies);
+CREATE EXTENSION intarray;
+CREATE INDEX ON job_graph USING GIN(dependencies);
 
 -- This index might be combined with another field (maybe group_id?)
-CREATE INDEX IF NOT EXISTS state ON job_graph (job_state);
+CREATE INDEX state ON job_graph (job_state);
 
 -- TODO Possible index
 -- target, job_exec_state for count_ready_by_target
@@ -64,7 +64,7 @@ CREATE INDEX IF NOT EXISTS state ON job_graph (job_state);
 -- the gin index doesn't supprt that function, and is hella slow.
 -- Using @> is vastly faster. (e.g. 30k entries, 7000 ms becomes 15ms)
 --
--- needs gin index on dependencies
+-- needs gin index on dependencies 
 CREATE OR REPLACE FUNCTION t_rdeps_for_id(job_graph_id BIGINT)
 RETURNS SETOF BIGINT
 AS $$


### PR DESCRIPTION
This effectively undoes #1565 and #1566, as we now believe them to have been unnecessary.

The problem they were attempting to solve was a failure to apply migrations in our acceptance environment. Initially, we added the idempotency guards from those two PRs to address apparent failures in the migration. Ultimately, we were able to get the migration applied in our acceptance environment, thanks to their help. Further inspection revealed that an earlier version of the migration, identified by a different, earlier timestamp had been applied in the acceptance environment (we have not been able to find this migration in version control history, leading us to suspect some manner of "out-of-band" application, perhaps as some kind of manual validation). As a result, the migration script ended up effectively "re-applying" a migration, which failed because some objects were not created with idempotency guards. The migration infrastructure itself should guard against this in the future, provided migrations are applied consistently, and in the proper order. As a result (and because our production environment does not have this earlier migration applied), we can safely remove the changes of the previous two PRs.