### PR TITLE
minor fixes for functional tests

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -316,7 +316,7 @@ test-builder() {
   fi
 
   echo "Starting supervisor in test mode. Logs saved to ${logs}"
-  HAB_FUNC_TEST=1 RUST_LOG=debug HAB_NONINTERACTIVE=true HAB_NOCOLORING=true hab sup run --no-color > ${logs} 2>&1 &
+  HAB_FUNC_TEST=1 HAB_NONINTERACTIVE=true HAB_NOCOLORING=true hab sup run --no-color > ${logs} 2>&1 &
   sleep 8
 
   start-builder

--- a/test/builder-api/package.json
+++ b/test/builder-api/package.json
@@ -4,7 +4,7 @@
   "description": "Habitat API Tests",
   "main": "index.js",
   "scripts": {
-    "mocha": "mocha --require src/helpers --reporter spec src/api.js --bail",
+    "mocha": "./node_modules/mocha/bin/mocha --require src/helpers --reporter spec src/api.js --bail",
     "test": "./test.sh"
   },
   "author": "The Habitat Humans",


### PR DESCRIPTION
This seems to resolve 2 issues I was having running `test-builder`.

1. If you start the supervisor with `RUST_LOG` set to `debug`, there is a good chance that `hab-sup --version` will emit some debug output after the version which breaks the launcher's parsing logic. This is really a bug in the launcher that will be addressed separately and then we can add this back.
2. I noticed that the `mocha` test output was not printing to the screen which made me wonder if the tests were running at all. Oddly, the build-kite functional test runs to emit this output but I see nothing in a studio. Pointing to the path of the `mocha` binary seems to fix this.

Signed-off-by: Matt Wrock <matt@mattwrock.com>