### PR TITLE
Enable package search by prefix match

### DIFF
--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -769,6 +769,10 @@ fn search_packages(req: HttpRequest,
     // search across all origins, similar to how the "distinct" search works now, but returning all
     // the details instead of just names.
     let decoded_query = match percent_encoding::percent_decode(query.as_bytes()).decode_utf8() {
+        // TODO There might be a case where there is a package with the same name as the origin.
+        // And the search with the query 'origin/' could end up finding the matches in 'origin' and
+        // the package names. Ideally, it should filter the matches to match the 'origin'
+        // only in this case.
         Ok(q) => q.to_string().trim_end_matches('/').replace("/", " & "),
         Err(err) => {
             debug!("{}", err);

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -782,13 +782,13 @@ fn search_packages(req: HttpRequest,
 
     debug!("search_packages called with: {}", decoded_query);
 
+    let search_packages = SearchPackages { query:      decoded_query,
+                                           page:       page as i64,
+                                           limit:      per_page as i64,
+                                           account_id: opt_session_id, };
+
     if pagination.distinct {
-        return match Package::search_distinct(SearchPackages { query:      decoded_query,
-                                                               page:       page as i64,
-                                                               limit:      per_page as i64,
-                                                               account_id: opt_session_id, },
-                                              &*conn)
-        {
+        return match Package::search_distinct(&search_packages, &*conn) {
             Ok((packages, count)) => postprocess_package_list(&req, &packages, count, &pagination),
             Err(err) => {
                 debug!("{}", err);
@@ -797,12 +797,7 @@ fn search_packages(req: HttpRequest,
         };
     }
 
-    match Package::search(SearchPackages { query:      decoded_query,
-                                           page:       page as i64,
-                                           limit:      per_page as i64,
-                                           account_id: opt_session_id, },
-                          &*conn)
-    {
+    match Package::search(&search_packages, &*conn) {
         Ok((packages, count)) => postprocess_package_list(&req, &packages, count, &pagination),
         Err(err) => {
             debug!("{}", err);

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -765,7 +765,7 @@ impl Package {
         result
     }
 
-    pub fn search(sp: SearchPackages,
+    pub fn search(sp: &SearchPackages,
                   conn: &PgConnection)
                   -> QueryResult<(Vec<BuilderPackageIdent>, i64)> {
         Counter::DBCall.increment();
@@ -802,7 +802,7 @@ impl Package {
     }
 
     // This is me giving up on fighting the typechecker and just duplicating a bunch of code
-    pub fn search_distinct(sp: SearchPackages,
+    pub fn search_distinct(sp: &SearchPackages,
                            conn: &PgConnection)
                            -> QueryResult<(Vec<BuilderPackageIdent>, i64)> {
         Counter::DBCall.increment();

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -773,7 +773,7 @@ impl Package {
 
         let mut query = origin_packages::table
             .select(origin_packages::ident)
-            .filter(to_tsquery(sp.query).matches(origin_packages::ident_vector))
+            .filter(to_tsquery(format!("{}:*", sp.query)).matches(origin_packages::ident_vector))
             .order(origin_packages::ident.asc())
             .into_boxed();
 
@@ -811,7 +811,7 @@ impl Package {
         let mut query = origin_packages::table
             .inner_join(origins::table)
             .select(sql("concat_ws('/', origins.name, origin_packages.name)"))
-            .filter(to_tsquery(sp.query).matches(origin_packages::ident_vector))
+            .filter(to_tsquery(format!("{}:*", sp.query)).matches(origin_packages::ident_vector))
             .order(origin_packages::name.asc())
             .into_boxed();
 

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -348,15 +348,37 @@ describe('Working with packages', function () {
 
   describe('Finding packages', function () {
     it('allows me to search for packages', function (done) {
-      request.get('/depot/pkgs/search/testapp')
+      request.get('/depot/pkgs/search/testapp2')
         .type('application/json')
         .accept('application/json')
         .expect(200)
         .end(function (err, res) {
           expect(res.body.range_start).to.equal(0);
-          expect(res.body.range_end).to.equal(6);
-          expect(res.body.total_count).to.equal(7);
-          expect(res.body.data.length).to.equal(7);
+          expect(res.body.range_end).to.equal(1);
+          expect(res.body.total_count).to.equal(2);
+          expect(res.body.data.length).to.equal(2);
+          expect(res.body.data[0].origin).to.equal('neurosis');
+          expect(res.body.data[0].name).to.equal('testapp2');
+          expect(res.body.data[0].version).to.equal('v1.2.3-aaster');
+          expect(res.body.data[0].release).to.equal(release6);
+          expect(res.body.data[1].origin).to.equal('neurosis');
+          expect(res.body.data[1].name).to.equal('testapp2');
+          expect(res.body.data[1].version).to.equal('v1.2.3-master');
+          expect(res.body.data[1].release).to.equal(release5);
+          done(err);
+        });
+    });
+
+    it('allows me to search for packages by partial name', function (done) {
+      request.get('/depot/pkgs/search/testa')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.range_start).to.equal(0);
+          expect(res.body.range_end).to.equal(8);
+          expect(res.body.total_count).to.equal(9);
+          expect(res.body.data.length).to.equal(9);
           expect(res.body.data[0].origin).to.equal('neurosis');
           expect(res.body.data[0].name).to.equal('testapp');
           expect(res.body.data[0].version).to.equal('0.1.13');
@@ -371,16 +393,84 @@ describe('Working with packages', function () {
           expect(res.body.data[3].name).to.equal('testapp');
           expect(res.body.data[3].version).to.equal('0.1.3');
           expect(res.body.data[3].release).to.equal(release8);
-          expect(res.body.data[6].origin).to.equal('xmen');
-          expect(res.body.data[6].name).to.equal('testapp');
-          expect(res.body.data[6].version).to.equal('0.1.4');
-          expect(res.body.data[6].release).to.equal(release4);
+          expect(res.body.data[8].origin).to.equal('xmen');
+          expect(res.body.data[8].name).to.equal('testapp');
+          expect(res.body.data[8].version).to.equal('0.1.4');
+          expect(res.body.data[8].release).to.equal(release4);
+          done(err);
+        });
+    });
+
+    it('allows me to search for packages by origin/name', function (done) {
+      request.get('/depot/pkgs/search/neurosis%2Ftestapp')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.range_start).to.equal(0);
+          expect(res.body.range_end).to.equal(7);
+          expect(res.body.total_count).to.equal(8);
+          expect(res.body.data.length).to.equal(8);
+          expect(res.body.data[0].origin).to.equal('neurosis');
+          expect(res.body.data[0].name).to.equal('testapp');
+          expect(res.body.data[0].version).to.equal('0.1.13');
+          expect(res.body.data[0].release).to.equal(release10);
+          expect(res.body.data[1].version).to.equal('0.1.3');
+          expect(res.body.data[1].release).to.equal(release1);
+          expect(res.body.data[2].origin).to.equal('neurosis');
+          expect(res.body.data[2].name).to.equal('testapp');
+          expect(res.body.data[2].version).to.equal('0.1.3');
+          expect(res.body.data[2].release).to.equal(release2);
+          expect(res.body.data[6].origin).to.equal('neurosis');
+          expect(res.body.data[6].name).to.equal('testapp2');
+          expect(res.body.data[6].version).to.equal('v1.2.3-aaster');
+          expect(res.body.data[6].release).to.equal(release6);
+          expect(res.body.data[7].origin).to.equal('neurosis');
+          expect(res.body.data[7].name).to.equal('testapp2');
+          expect(res.body.data[7].version).to.equal('v1.2.3-master');
+          expect(res.body.data[7].release).to.equal(release5);
           done(err);
         });
     });
 
     it('allows me to search for distinct packages', function (done) {
-      request.get('/depot/pkgs/search/testapp?distinct=true')
+      request.get('/depot/pkgs/search/testapp2?distinct=true')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.range_start).to.equal(0);
+          expect(res.body.range_end).to.equal(0);
+          expect(res.body.total_count).to.equal(1);
+          expect(res.body.data.length).to.equal(1);
+          expect(res.body.data[0].origin).to.equal('neurosis');
+          expect(res.body.data[0].name).to.equal('testapp2');
+          done(err);
+        });
+    });
+
+    it('allows me to search for distinct packages by partial name', function (done) {
+      request.get('/depot/pkgs/search/testa?distinct=true')
+        .type('application/json')
+        .accept('application/json')
+        .expect(200)
+        .end(function (err, res) {
+          expect(res.body.range_start).to.equal(0);
+          expect(res.body.range_end).to.equal(2);
+          expect(res.body.total_count).to.equal(3);
+          expect(res.body.data.length).to.equal(3);
+          expect(res.body.data[0].origin).to.equal('neurosis');
+          expect(res.body.data[0].name).to.equal('testapp');
+          expect(res.body.data[1].origin).to.equal('xmen');
+          expect(res.body.data[1].name).to.equal('testapp');
+          expect(res.body.data[2].origin).to.equal('neurosis');
+          expect(res.body.data[2].name).to.equal('testapp2');
+          done(err);
+        });
+    });
+
+    it('allows me to search for distinct packages by origin/name', function (done) {
+      request.get('/depot/pkgs/search/neurosis%2Ftestapp?distinct=true')
         .type('application/json')
         .accept('application/json')
         .expect(200)
@@ -391,8 +481,8 @@ describe('Working with packages', function () {
           expect(res.body.data.length).to.equal(2);
           expect(res.body.data[0].origin).to.equal('neurosis');
           expect(res.body.data[0].name).to.equal('testapp');
-          expect(res.body.data[1].origin).to.equal('xmen');
-          expect(res.body.data[1].name).to.equal('testapp');
+          expect(res.body.data[1].origin).to.equal('neurosis');
+          expect(res.body.data[1].name).to.equal('testapp2');
           done(err);
         });
     });


### PR DESCRIPTION
The current search functionality in builder will only search for packages when their org/package name matches. The problem with this is that the user has to know the origin/package name upfront to search for packages. It does not allow to search for packages that can start with an origin or package name.

 Postgress [full text search](https://www.postgresql.org/docs/9.6/textsearch-intro.html) supports [prefix matching](https://www.postgresql.org/docs/9.6/textsearch-controls.html).

With this fix, the search can support the following prefix cases:
cor
core
core/rust

The limitation of the current search is restricted to prefix match only. It does not support trigram matches.

Signed-off-by: Phani Sajja <psajja@progress.com>