### PR TITLE
warning: panic message is not a string literal

### DIFF
--- a/components/builder-core/src/job.rs
+++ b/components/builder-core/src/job.rs
@@ -32,8 +32,8 @@ impl Job {
                         .split('/')
                         .collect::<Vec<&str>>();
         assert!(items.len() == 2,
-                format!("Invalid project identifier - {}",
-                        self.0.get_project().get_id()));
+                "Invalid project identifier - {}",
+                self.0.get_project().get_id());
         items[0]
     }
 }


### PR DESCRIPTION
In Rust 2021, the assert macro can also accept expressions, format! is no longer needed to pass a string literal.

Signed-off-by: Phani Sajja <psajja@progress.com>