### PR TITLE
Show builder event logs

### DIFF
--- a/components/builder-api-proxy/habitat/config/habitat.conf.js
+++ b/components/builder-api-proxy/habitat/config/habitat.conf.js
@@ -24,4 +24,6 @@ habitatConfig({
     use_gravatar: {{cfg.use_gravatar}},
     version: "{{pkg.ident}}",
     www_url: "{{cfg.www_url}}",
+    enable_builder_events: {{cfg.enable_builder_events}},
+    enable_builder_events_saas: {{cfg.enable_builder_events_saas}},
 });

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -13,6 +13,11 @@ status_url                = "https://status.habitat.sh/"
 tutorials_url             = "https://www.habitat.sh/learn"
 use_gravatar              = true
 www_url                   = "https://www.habitat.sh"
+# Enable/Disable the builder events
+enable_builder_events     = false
+# Enable/Disable the builder events from SaaS
+# The 'enable_builder_events' property also needs to be set to enable SaaS events.
+enable_builder_events_saas = false
 # How we connect to the proxied backend API service.
 #   When true, connect to all backend API services via their IPs provided
 #   via the bind

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -5,6 +5,7 @@ features_enabled = "jobsrv"
 targets = ["x86_64-linux", "x86_64-linux-kernel2", "x86_64-windows"]
 build_targets = ["x86_64-linux", "x86_64-linux-kernel2", "x86_64-windows"]
 build_on_upload = true
+saas_bldr_url = "https://bldr.habitat.sh"
 
 [http]
 listen = "0.0.0.0"

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -108,6 +108,7 @@ pub struct ApiCfg {
     pub features_enabled: Vec<String>,
     pub build_on_upload:  bool,
     pub private_max_age:  usize,
+    pub saas_bldr_url:    String,
 }
 
 mod deserialize_into_vec {
@@ -134,7 +135,8 @@ impl Default for ApiCfg {
                  build_targets:    vec![target::X86_64_LINUX, target::X86_64_WINDOWS],
                  features_enabled: vec!["jobsrv".to_string()],
                  build_on_upload:  true,
-                 private_max_age:  300, }
+                 private_max_age:  300,
+                 saas_bldr_url:    "https://bldr.habitat.sh".to_string(), }
     }
 }
 

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -9,6 +9,7 @@ pub mod services;
 use self::{framework::middleware::authentication_middleware,
            resources::{authenticate::Authenticate,
                        channels::Channels,
+                       events::Events,
                        ext::Ext,
                        jobs::Jobs,
                        notify::Notify,
@@ -170,6 +171,7 @@ pub async fn run(config: Config) -> error::Result<()> {
                     .configure(Projects::register)
                     .configure(Settings::register)
                     .configure(User::register)
+                    .configure(Events::register)
                     .service(
                         web::resource("/status")
                             .route(web::get().to(status))

--- a/components/builder-api/src/server/resources/events.rs
+++ b/components/builder-api/src/server/resources/events.rs
@@ -1,0 +1,187 @@
+use crate::{db::models::channel::{AuditPackage,
+                                  AuditPackageEvent,
+                                  ListEvents},
+            server::{authorize::authorize_session,
+                     error::{Error,
+                             Result},
+                     framework::headers,
+                     helpers::{self,
+                               req_state,
+                               DateRange,
+                               Pagination,
+                               SearchQuery,
+                               ToChannel},
+                     AppState}};
+use actix_web::{http,
+                web::{self,
+                      Data,
+                      Query,
+                      ServiceConfig},
+                HttpRequest,
+                HttpResponse};
+use builder_core::http_client::{HttpClient,
+                                USER_AGENT_BLDR};
+
+pub struct Events {}
+
+impl Events {
+    // Route registration
+    //
+    pub fn register(cfg: &mut ServiceConfig) {
+        cfg.route("/depot/events", web::get().to(get_events))
+           .route("/depot/events/saas", web::get().to(get_events_from_saas));
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+async fn get_events(req: HttpRequest,
+                    pagination: Query<Pagination>,
+                    channel: Query<ToChannel>,
+                    date_range: Query<DateRange>,
+                    search_query: Query<SearchQuery>)
+                    -> HttpResponse {
+    match do_get_events(&req, &pagination, &channel, &date_range, &search_query) {
+        Ok((events, count)) => postprocess_event_list(&req, &events, count, &pagination),
+        Err(err) => {
+            error!("{}", err);
+            err.into()
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+async fn get_events_from_saas(req: HttpRequest,
+                              pagination: Query<Pagination>,
+                              channel: Query<ToChannel>,
+                              date_range: Query<DateRange>,
+                              search_query: Query<SearchQuery>,
+                              state: Data<AppState>)
+                              -> HttpResponse {
+    let bldr_url = &state.config.api.saas_bldr_url;
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(USER_AGENT_BLDR.0.clone(), USER_AGENT_BLDR.1.clone());
+    if req.headers().contains_key(http::header::AUTHORIZATION) {
+        headers.insert(http::header::AUTHORIZATION,
+                       req.headers()
+                          .get(http::header::AUTHORIZATION)
+                          .unwrap()
+                          .clone());
+    }
+
+    let http_client = match HttpClient::new(bldr_url, headers) {
+        Ok(client) => client,
+        Err(err) => {
+            debug!("HttpClient Error: {:?}", err);
+            return HttpResponse::InternalServerError().body(err.to_string());
+        }
+    };
+
+    // We are expecting dates in YYYY-MM-DD format
+    let from_date = date_range.from_date.date().format("%Y-%m-%d").to_string();
+    let to_date = date_range.to_date.date().format("%Y-%m-%d").to_string();
+    let url = format!("{}/v1/depot/events?range={}&channel={}&from_date={}&to_date={}&query={}",
+                      bldr_url,
+                      pagination.range,
+                      channel.channel,
+                      from_date,
+                      to_date,
+                      search_query.query);
+    debug!("SaaS Url: {}", url);
+    match http_client.get(&url)
+                     .send()
+                     .await
+                     .map_err(Error::HttpClient)
+    {
+        Ok(response) => {
+            match response.text().await {
+                Ok(body) => {
+                    let mut http_response = HttpResponse::Ok();
+
+                    http_response.header(http::header::CONTENT_TYPE, headers::APPLICATION_JSON)
+                                 .header(http::header::CACHE_CONTROL, headers::NO_CACHE)
+                                 .body(body)
+                }
+                Err(err) => {
+                    let msg = format!("Error getting response text: {:?}", err);
+                    debug!("{}", msg);
+                    HttpResponse::InternalServerError().body(msg)
+                }
+            }
+        }
+        Err(err) => {
+            let msg = format!("Error sending request: {:?}", err);
+            debug!("{}", msg);
+            HttpResponse::InternalServerError().body(msg)
+        }
+    }
+}
+
+fn do_get_events(req: &HttpRequest,
+                 pagination: &Query<Pagination>,
+                 channel: &Query<ToChannel>,
+                 date_range: &Query<DateRange>,
+                 search_query: &Query<SearchQuery>)
+                 -> Result<(Vec<AuditPackageEvent>, i64)> {
+    let opt_session_id = match authorize_session(req, None, None) {
+        Ok(session) => Some(session.get_id() as i64),
+        Err(_) => None,
+    };
+    let (page, per_page) = helpers::extract_pagination_in_pages(pagination);
+
+    let conn = req_state(req).db.get_conn().map_err(Error::DbError)?;
+    let decoded_query =
+        match percent_encoding::percent_decode(search_query.query.as_bytes()).decode_utf8() {
+            Ok(q) => q.to_string().trim_end_matches('/').replace("/", " & "),
+            Err(err) => {
+                error!("{}", err);
+                return Err(Error::Unprocessable);
+            }
+        };
+
+    let el = ListEvents { page:       page as i64,
+                          limit:      per_page as i64,
+                          account_id: opt_session_id,
+                          channel:    channel.channel.trim().to_string(),
+                          from_date:  date_range.from_date,
+                          to_date:    date_range.to_date,
+                          query:      decoded_query, };
+    match AuditPackage::list(el, &*conn).map_err(Error::DieselError) {
+        Ok((packages, count)) => {
+            let pkg_events: Vec<AuditPackageEvent> =
+                packages.into_iter().map(|p| p.into()).collect();
+
+            Ok((pkg_events, count))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+pub fn postprocess_event_list(_req: &HttpRequest,
+                              events: &[AuditPackageEvent],
+                              count: i64,
+                              pagination: &Query<Pagination>)
+                              -> HttpResponse {
+    let (start, _) = helpers::extract_pagination(pagination);
+    let event_count = events.len() as isize;
+    let stop = match event_count {
+        0 => count,
+        _ => (start + event_count - 1) as i64,
+    };
+
+    debug!("postprocessing event list, start: {}, stop: {}, total_count: {}",
+           start, stop, count);
+
+    let body =
+        helpers::package_results_json(&events, count as isize, start as isize, stop as isize);
+
+    let mut response = if count as isize > (stop as isize + 1) {
+        HttpResponse::PartialContent()
+    } else {
+        HttpResponse::Ok()
+    };
+
+    response.header(http::header::CONTENT_TYPE, headers::APPLICATION_JSON)
+            .header(http::header::CACHE_CONTROL, headers::NO_CACHE)
+            .body(body)
+}

--- a/components/builder-api/src/server/resources/events.rs
+++ b/components/builder-api/src/server/resources/events.rs
@@ -173,7 +173,7 @@ pub fn postprocess_event_list(_req: &HttpRequest,
            start, stop, count);
 
     let body =
-        helpers::package_results_json(&events, count as isize, start as isize, stop as isize);
+        helpers::package_results_json(events, count as isize, start as isize, stop as isize);
 
     let mut response = if count as isize > (stop as isize + 1) {
         HttpResponse::PartialContent()

--- a/components/builder-api/src/server/resources/events.rs
+++ b/components/builder-api/src/server/resources/events.rs
@@ -98,8 +98,8 @@ async fn get_events_from_saas(req: HttpRequest,
                 Ok(body) => {
                     let mut http_response = HttpResponse::Ok();
 
-                    http_response.header(http::header::CONTENT_TYPE, headers::APPLICATION_JSON)
-                                 .header(http::header::CACHE_CONTROL, headers::NO_CACHE)
+                    http_response.append_header((http::header::CONTENT_TYPE, headers::APPLICATION_JSON))
+                                 .append_header((http::header::CACHE_CONTROL, headers::NO_CACHE))
                                  .body(body)
                 }
                 Err(err) => {
@@ -181,7 +181,7 @@ pub fn postprocess_event_list(_req: &HttpRequest,
         HttpResponse::Ok()
     };
 
-    response.header(http::header::CONTENT_TYPE, headers::APPLICATION_JSON)
-            .header(http::header::CACHE_CONTROL, headers::NO_CACHE)
+    response.append_header((http::header::CONTENT_TYPE, headers::APPLICATION_JSON))
+            .append_header((http::header::CACHE_CONTROL, headers::NO_CACHE))
             .body(body)
 }

--- a/components/builder-api/src/server/resources/events.rs
+++ b/components/builder-api/src/server/resources/events.rs
@@ -98,7 +98,8 @@ async fn get_events_from_saas(req: HttpRequest,
                 Ok(body) => {
                     let mut http_response = HttpResponse::Ok();
 
-                    http_response.append_header((http::header::CONTENT_TYPE, headers::APPLICATION_JSON))
+                    http_response.append_header((http::header::CONTENT_TYPE,
+                                                 headers::APPLICATION_JSON))
                                  .append_header((http::header::CACHE_CONTROL, headers::NO_CACHE))
                                  .body(body)
                 }
@@ -172,8 +173,7 @@ pub fn postprocess_event_list(_req: &HttpRequest,
     debug!("postprocessing event list, start: {}, stop: {}, total_count: {}",
            start, stop, count);
 
-    let body =
-        helpers::package_results_json(events, count as isize, start as isize, stop as isize);
+    let body = helpers::package_results_json(events, count as isize, start as isize, stop as isize);
 
     let mut response = if count as isize > (stop as isize + 1) {
         HttpResponse::PartialContent()

--- a/components/builder-api/src/server/resources/mod.rs
+++ b/components/builder-api/src/server/resources/mod.rs
@@ -1,5 +1,6 @@
 pub mod authenticate;
 pub mod channels;
+pub mod events;
 pub mod ext;
 pub mod jobs;
 pub mod notify;

--- a/components/builder-db/src/schema/audit.rs
+++ b/components/builder-db/src/schema/audit.rs
@@ -42,3 +42,11 @@ table! {
         created_at -> Nullable<Timestamptz>,
     }
 }
+
+use super::{member::origin_members,
+            origin::origins,
+            package::origin_packages};
+
+allow_tables_to_appear_in_same_query!(audit_package, origin_packages);
+allow_tables_to_appear_in_same_query!(audit_package, origins);
+allow_tables_to_appear_in_same_query!(audit_package, origin_members);

--- a/components/builder-web/.gitignore
+++ b/components/builder-web/.gitignore
@@ -14,3 +14,4 @@ npm-debug.log*
 /typings
 results/
 !app/search/results
+!app/events/results

--- a/components/builder-web/app/actions/events-saas.ts
+++ b/components/builder-web/app/actions/events-saas.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as depotApi from '../client/depot-api';
+
+export const CLEAR_SAAS_EVENTS = 'CLEAR_SAAS_EVENTS';
+export const SET_VISIBLE_SAAS_EVENTS = 'SET_VISIBLE_SAAS_EVENTS';
+export const SET_SAAS_EVENTS_TOTAL_COUNT = 'SET_SAAS_EVENTS_TOTAL_COUNT';
+export const SET_SAAS_EVENTS_NEXT_RANGE = 'SET_SAAS_EVENTS_NEXT_RANGE';
+export const SET_SAAS_EVENTS_SEARCH_QUERY = 'SET__SAAS_EVENTS_SEARCH_QUERY';
+export const SET_SAAS_EVENTS_DATE_FILTER = 'SET_SAAS_EVENTS_DATE_FILTER';
+
+export function fetchSaasEvents(nextRange: number = 0, fromDate: string, toDate: string, query: string = '') {
+  return dispatch => {
+    if (nextRange === 0) {
+      dispatch(clearEvents());
+    }
+
+    depotApi.getSaasEvents(nextRange, fromDate, toDate, query).then(response => {
+      dispatch(setVisibleEvents(response['results']));
+      dispatch(setEventsTotalCount(response['totalCount']));
+      dispatch(setEventsNextRange(response['nextRange']));
+    }).catch(error => {
+      dispatch(setVisibleEvents(undefined, error));
+    });
+  };
+}
+
+function clearEvents() {
+  return {
+    type: CLEAR_SAAS_EVENTS,
+  };
+}
+
+function setVisibleEvents(params, error = undefined) {
+  return {
+    type: SET_VISIBLE_SAAS_EVENTS,
+    payload: params,
+    error: error,
+  };
+}
+
+function setEventsTotalCount(payload: number) {
+  return {
+    type: SET_SAAS_EVENTS_TOTAL_COUNT,
+    payload,
+  };
+}
+
+function setEventsNextRange(payload: number) {
+  return {
+    type: SET_SAAS_EVENTS_NEXT_RANGE,
+    payload,
+  };
+}
+
+export function setSaasEventsSearchQuery(payload: string) {
+  return {
+    type: SET_SAAS_EVENTS_SEARCH_QUERY,
+    payload,
+  };
+}
+
+export function setSaasEventsDateFilter(payload: any) {
+  return {
+    type: SET_SAAS_EVENTS_DATE_FILTER,
+    payload,
+  };
+}

--- a/components/builder-web/app/actions/events.ts
+++ b/components/builder-web/app/actions/events.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as depotApi from '../client/depot-api';
+
+export const CLEAR_EVENTS = 'CLEAR_EVENTS';
+export const SET_VISIBLE_EVENTS = 'SET_VISIBLE_EVENTS';
+export const SET_EVENTS_TOTAL_COUNT = 'SET_EVENTS_TOTAL_COUNT';
+export const SET_EVENTS_NEXT_RANGE = 'SET_EVENTS_NEXT_RANGE';
+export const SET_EVENTS_SEARCH_QUERY = 'SET_EVENTS_SEARCH_QUERY';
+export const SET_EVENTS_DATE_FILTER = 'SET_EVENTS_DATE_FILTER';
+
+export function fetchEvents(nextRange: number = 0, fromDate: string, toDate: string, query: string = '') {
+  return dispatch => {
+    if (nextRange === 0) {
+      dispatch(clearEvents());
+    }
+
+    depotApi.getEvents(nextRange, fromDate, toDate, query).then(response => {
+      dispatch(setVisibleEvents(response['results']));
+      dispatch(setEventsTotalCount(response['totalCount']));
+      dispatch(setEventsNextRange(response['nextRange']));
+    }).catch(error => {
+      dispatch(setVisibleEvents(undefined, error));
+    });
+  };
+}
+
+function clearEvents() {
+  return {
+    type: CLEAR_EVENTS,
+  };
+}
+
+function setVisibleEvents(params, error = undefined) {
+  return {
+    type: SET_VISIBLE_EVENTS,
+    payload: params,
+    error: error,
+  };
+}
+
+function setEventsTotalCount(payload: number) {
+  return {
+    type: SET_EVENTS_TOTAL_COUNT,
+    payload,
+  };
+}
+
+function setEventsNextRange(payload: number) {
+  return {
+    type: SET_EVENTS_NEXT_RANGE,
+    payload,
+  };
+}
+
+export function setEventsSearchQuery(payload: string) {
+  return {
+    type: SET_EVENTS_SEARCH_QUERY,
+    payload,
+  };
+}
+
+export function setEventsDateFilter(payload: any) {
+  return {
+    type: SET_EVENTS_DATE_FILTER,
+    payload,
+  };
+}

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -242,6 +242,26 @@ export {
   TOGGLE_USER_NAV_MENU,
   toggleUserNavMenu
 } from './users';
+
+export {
+  CLEAR_EVENTS,
+  SET_VISIBLE_EVENTS,
+  SET_EVENTS_TOTAL_COUNT,
+  SET_EVENTS_NEXT_RANGE,
+  SET_EVENTS_SEARCH_QUERY,
+  SET_EVENTS_DATE_FILTER,
+  fetchEvents
+} from './events';
+
+export {
+  CLEAR_SAAS_EVENTS,
+  SET_VISIBLE_SAAS_EVENTS,
+  SET_SAAS_EVENTS_TOTAL_COUNT,
+  SET_SAAS_EVENTS_NEXT_RANGE,
+  SET_SAAS_EVENTS_SEARCH_QUERY,
+  SET_SAAS_EVENTS_DATE_FILTER,
+  fetchSaasEvents
+} from './events-saas';
 
 // Used by redux-reset to reset the app state
 export const RESET = 'RESET';

--- a/components/builder-web/app/app.component.html
+++ b/components/builder-web/app/app.component.html
@@ -7,7 +7,11 @@
 <div class="app {{ layout }}">
   <div class="wrapper">
     <nav class="menu" [class.open]="menuOpen">
-      <hab-side-nav [isSignedIn]="isSignedIn"></hab-side-nav>
+      <hab-side-nav
+        [isSignedIn]="isSignedIn"
+        [enabledEvents]="enabledEvents"
+        [enabledSaasEvents]="enabledSaasEvents">
+      </hab-side-nav>
     </nav>
     <main>
       <div class="menu-toggle" (click)="toggleMenu()"></div>

--- a/components/builder-web/app/app.component.ts
+++ b/components/builder-web/app/app.component.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ import { AppStore } from './app.store';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { URLSearchParams } from '@angular/http';
 import { ActivatedRoute, Router, NavigationEnd, NavigationStart } from '@angular/router';
-import { identifyUser, loadFeatures, removeNotification, exchangeOAuthCode,
-  routeChange, loadOAuthProvider, routeChangeEnd, setPackagesSearchQuery, signOut, toggleUserNavMenu } from './actions/index';
+import {
+  identifyUser, loadFeatures, removeNotification, exchangeOAuthCode,
+  routeChange, loadOAuthProvider, routeChangeEnd, setPackagesSearchQuery, signOut, toggleUserNavMenu
+} from './actions/index';
 
 const md5 = require('blueimp-md5');
 
@@ -119,6 +121,14 @@ export class AppComponent implements OnInit, OnDestroy {
 
   get username() {
     return this.state.users.current.profile.name;
+  }
+
+  get enabledEvents() {
+    return this.state.features.events;
+  }
+
+  get enabledSaasEvents() {
+    return this.state.features.saasEvents;
   }
 
   ngOnDestroy() {

--- a/components/builder-web/app/app.module.ts
+++ b/components/builder-web/app/app.module.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import { OriginModule } from './origin/origin.module';
 import { PackageModule } from './package/package.module';
 import { ProfileModule } from './profile/profile.module';
 import { SearchModule } from './search/search.module';
+import { EventsModule } from './events/events.module';
 import { SharedModule } from './shared/shared.module';
 
 @NgModule({
@@ -48,6 +49,7 @@ import { SharedModule } from './shared/shared.module';
     ReactiveFormsModule,
     RouterModule,
     SearchModule,
+    EventsModule,
     SharedModule,
     routing
   ],

--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -227,6 +227,8 @@ main {
 @import 'profile/profile.module';
 @import 'search/search.module';
 @import 'search/results/results.component';
+@import 'events/events.module';
+@import 'events/results/results.component';
 @import 'shared/shared.module';
 @import 'side-nav/side-nav.component';
 @import 'sign-in-page/sign-in-page.component';

--- a/components/builder-web/app/browser.ts
+++ b/components/builder-web/app/browser.ts
@@ -19,6 +19,10 @@ export class Browser {
     window.location.href = url;
   }
 
+  static openInTab(url) {
+    window.open(url, '_blank');
+  }
+
   static removeCookie(key) {
     cookies.remove(key, { domain: this.cookieDomain });
   }

--- a/components/builder-web/app/client/depot-api.ts
+++ b/components/builder-web/app/client/depot-api.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'whatwg-fetch';
-import config from '../config';
 import { packageString } from '../util';
 import { AppStore } from '../app.store';
 import { addNotification, signOut } from '../actions/index';
@@ -276,6 +275,68 @@ export function submitJob(origin: string, pkg: string, target: string, token: st
           resolve(true);
         } else {
           reject(new Error(response.statusText));
+        }
+      })
+      .catch(error => handleError(error, reject));
+  });
+}
+
+export function getEvents(nextRange: number = 0, fromDate: string, toDate: string, query: string = '') {
+  let url = `${urlPrefix}/depot/events` + `?range=${nextRange}&channel=stable&from_date=${fromDate}&to_date=${toDate}&query=${query}`;
+
+  return new Promise((resolve, reject) => {
+    fetch(url, opts())
+      .then(response => handleUnauthorized(response, reject))
+      .then(response => {
+        if (response.status >= 400) {
+          reject(new Error(response.statusText));
+        } else {
+          response.json().then(resultsObj => {
+            let results;
+
+            const endRange = parseInt(resultsObj.range_end, 10);
+            const totalCount = parseInt(resultsObj.total_count, 10);
+            const nextRange = totalCount > (endRange + 1) ? endRange + 1 : 0;
+
+            if (resultsObj['data']) {
+              results = resultsObj['data'];
+            } else {
+              results = resultsObj;
+            }
+
+            resolve({ results, totalCount, nextRange });
+          });
+        }
+      })
+      .catch(error => handleError(error, reject));
+  });
+}
+
+export function getSaasEvents(nextRange: number = 0, fromDate: string, toDate: string, query: string = '') {
+  let url = `${urlPrefix}/depot/events/saas` + `?range=${nextRange}&channel=stable&from_date=${fromDate}&to_date=${toDate}&query=${query}`;
+
+  return new Promise((resolve, reject) => {
+    fetch(url, opts())
+      .then(response => handleUnauthorized(response, reject))
+      .then(response => {
+        if (response.status >= 400) {
+          reject(new Error(response.statusText));
+        } else {
+          response.json().then(resultsObj => {
+            let results;
+
+            const endRange = parseInt(resultsObj.range_end, 10);
+            const totalCount = parseInt(resultsObj.total_count, 10);
+            const nextRange = totalCount > (endRange + 1) ? endRange + 1 : 0;
+
+            if (resultsObj['data']) {
+              results = resultsObj['data'];
+            } else {
+              results = resultsObj;
+            }
+
+            resolve({ results, totalCount, nextRange });
+          });
         }
       })
       .catch(error => handleError(error, reject));

--- a/components/builder-web/app/events/_events.module.scss
+++ b/components/builder-web/app/events/_events.module.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, Input } from '@angular/core';
-import config from '../config';
-
-@Component({
-  selector: 'hab-side-nav',
-  template: require('./side-nav.component.html')
-})
-export class SideNavComponent {
-  @Input() isSignedIn;
-  @Input() enabledEvents;
-  @Input() enabledSaasEvents;
-
-  get config() {
-    return config;
-  }
-}
+@import 'results/results.component';
+@import 'events/events.component';
+@import 'date-filter/date-filter.component';

--- a/components/builder-web/app/events/date-filter/_date-filter.component.scss
+++ b/components/builder-web/app/events/date-filter/_date-filter.component.scss
@@ -1,0 +1,104 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.event-filter {
+  width: 100%;
+
+  .date-filter {
+    float: right;
+    right: 0;
+
+    .show-label {
+      display: inline-block;
+      padding: 5px 0;
+      padding-right: $default-margin;
+      font-weight: 600;
+    }
+
+    .dropdown-toggle {
+      cursor: pointer; 
+      background: #fff;
+      border: $default-border; 
+    }
+
+    .calender-view {
+      @include shadow-panel;
+      display: inline-block;
+      color: $hab-text;
+      position: absolute;
+      right: $default-margin;
+      z-index: 100;
+      min-width: 38rem;
+      min-height: 25rem;
+      margin-top: 40px;
+
+      .close {
+        position: absolute;
+        right: 10px;
+        top: 10px;
+        width: 16px;
+        height: 16px;
+        opacity: 0.6;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+
+      .text-right {
+        text-align: right;
+      }
+
+      .date-range-head {
+        text-transform: uppercase; 
+        font-weight: 600; 
+        line-height: 1.2rem; 
+        margin-bottom: 10px; 
+        margin-left: 16px; 
+      }
+
+      .calendar-card {
+        width: 300px;
+      }
+      
+      .light-border {
+        border-right: 1px solid $light-gray;
+      }
+      
+      .float-right {
+        float: right;
+      }
+      
+      .float-left {
+        float: left;
+      }
+      
+      .date-txt {
+        margin-left: 16px; 
+        text-transform: uppercase;
+      }
+      
+      .button-cancel {
+        margin-right: 10px;
+      }
+      
+    }
+  }
+
+  .clearfix {
+    content: "";
+    clear: both;
+    display: table;
+  }
+}

--- a/components/builder-web/app/events/date-filter/date-filter.component.html
+++ b/components/builder-web/app/events/date-filter/date-filter.component.html
@@ -1,0 +1,53 @@
+<div class="event-filter">
+  <div class="date-filter">
+    <span class="show-label">Show</span>
+    <ng-container>
+      <button [disabled]="triggerDisabled()" mat-button mat-raised-button class="button dropdown-toggle" [matMenuTriggerFor]="menu">
+        <span>{{ getCurrentFilterLabel() }}</span>
+        <hab-icon symbol="drop-down"></hab-icon>
+      </button>
+      <mat-menu #menu="matMenu" [overlapTrigger]="false">
+        <ng-container *ngFor="let filter of filters;">
+          <button mat-menu-item (click)="filterChanged(filter)"> {{ filter.label }}
+          </button>
+          <mat-divider></mat-divider>
+        </ng-container>
+        <button mat-menu-item (click)="fromCalender()"> Select from calender... </button>
+      </mat-menu>
+      <ng-container *ngIf="showCalender">
+        <div class="calender-view">
+          <div class="text-right">
+            <a (click)="closeDateRange()" class="close">
+              <hab-icon symbol="close"></hab-icon>
+            </a>
+          </div>
+          <div class="date-range-head">Select a date range</div>
+          <div>
+            <div class="float-left">
+              <span class="date-txt">Start date: {{ getStartDate() }}</span>
+              <div class="calendar-card light-border">
+                <mat-calendar #fromDateCal [selected]="fromSelected" (selectedChange)="fromSelected = $event"
+                  [maxDate]="maxDate">
+                </mat-calendar>
+              </div>
+            </div>
+            <div class="float-right">
+              <span class="date-txt">End date: {{ getEndDate() }}</span>
+              <div class="calendar-card">
+                <mat-calendar [selected]="toSelected" (selectedChange)="toSelected = $event" [maxDate]="maxDate">
+                </mat-calendar>
+              </div>
+            </div>
+          </div>
+          <div class="clearfix"></div>
+          <div class="text-right">
+            <a (click)="cancel()" class="button-cancel">Cancel</a>
+            <button [disabled]="disabledApply()" mat-raised-button color="primary" (click)="apply()" type="submit"
+              class="button">Apply</button>
+          </div>
+        </div>
+      </ng-container>
+    </ng-container>
+  </div>
+  <div class="clearfix"></div>
+</div>

--- a/components/builder-web/app/events/date-filter/date-filter.component.spec.ts
+++ b/components/builder-web/app/events/date-filter/date-filter.component.spec.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DebugElement } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+
+import { AppStore } from '../../app.store';
+import { DateFilterComponent } from './date-filter.component';
+
+class MockAppStore {
+  static state;
+
+  getState() {
+    return MockAppStore.state;
+  }
+
+  dispatch() { }
+}
+
+class MockRoute {
+  get params() {
+    return of({});
+  }
+}
+
+describe('DateFilterComponent', () => {
+  let fixture: ComponentFixture<DateFilterComponent>;
+  let component: DateFilterComponent;
+  let element: DebugElement;
+  let store: AppStore;
+
+  beforeEach(() => {
+    MockAppStore.state = {
+      filters: []
+    };
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        MatInputModule,
+        NoopAnimationsModule
+      ],
+      declarations: [
+        DateFilterComponent
+      ],
+      providers: [
+        { provide: AppStore, useClass: MockAppStore },
+        { provide: ActivatedRoute, useClass: MockRoute }
+      ]
+    });
+
+    fixture = TestBed.createComponent(DateFilterComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+    store = TestBed.get(AppStore);
+  });
+
+  describe('given the events', () => {
+
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('show label', () => {
+      let heading = element.query(By.css('.show-label'));
+      expect(heading.nativeElement.textContent).toBe('Show');
+    });
+  });
+});

--- a/components/builder-web/app/events/date-filter/date-filter.component.ts
+++ b/components/builder-web/app/events/date-filter/date-filter.component.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, Input, ViewChild } from '@angular/core';
+import { MatCalendar } from '@angular/material';
+
+import { getDateRange, toDateString, toDate } from '../date-util';
+
+@Component({
+  selector: 'hab-events-date-filter',
+  template: require('./date-filter.component.html')
+})
+export class DateFilterComponent {
+
+  @ViewChild('fromDateCal') fromDateCal: MatCalendar<Date>;
+
+  @Input() dateFilterChanged: Function;
+  @Input() currentFilter: any;
+  @Input() filters: any;
+
+  maxDate: Date;
+  fromSelected: Date | null;
+  toSelected: Date | null;
+
+  public showCalender = false;
+
+  constructor() {
+    this.maxDate = new Date();
+  }
+
+  getCurrentFilterLabel() {
+    return this.currentFilter.label;
+  }
+
+  filterChanged(item: any) {
+    if (this.currentFilter.label === item.label)
+      return;
+
+    this.dateFilterChanged(item);
+  }
+
+  fromCalender() {
+    this.showCalender = true;
+    const dateRange = getDateRange(this.currentFilter);
+    this.fromSelected = toDate(dateRange.fromDate);
+    this.toSelected = toDate(dateRange.toDate);
+
+    setTimeout(() => {
+      this.fromDateCal.activeDate = this.fromSelected;
+    }, 500);
+  }
+
+  triggerDisabled() {
+    return this.showCalender;
+  }
+
+  closeDateRange() {
+    this.showCalender = false;
+  }
+
+  cancel() {
+    this.closeDateRange();
+  }
+
+  apply() {
+    const fromDateStr = toDateString(this.fromSelected);
+    const toDateStr = toDateString(this.toSelected);
+    const filter = {
+      label: `${fromDateStr} - ${toDateStr}`,
+      type: 'custom',
+      startDate: this.fromSelected,
+      endDate: this.toSelected
+    };
+
+    this.dateFilterChanged(filter);
+    this.closeDateRange();
+  }
+
+  disabledApply() {
+    if (this.fromSelected <= this.toSelected)
+      return false;
+
+    return true;
+  }
+
+  getStartDate() {
+    if (this.fromSelected)
+      return toDateString(this.fromSelected);
+
+    return '';
+  }
+
+  getEndDate() {
+    if (this.toSelected)
+      return toDateString(this.toSelected);
+
+    return '';
+  }
+}

--- a/components/builder-web/app/events/date-util.ts
+++ b/components/builder-web/app/events/date-util.ts
@@ -1,0 +1,58 @@
+import * as moment from 'moment';
+
+export const dateFilters = [
+    { label: 'Last 1 Week', type: 'days', interval: 7 },
+    { label: 'Last 2 Weeks', type: 'days', interval: 14 },
+    { label: 'Last 1 Month', type: 'months', interval: 1 },
+    { label: 'Last 3 Months', type: 'months', interval: 3 },
+    { label: 'Last 6 Months', type: 'months', interval: 6 },
+    { label: 'Last 1 Year', type: 'years', interval: 1 }
+];
+
+export function getDateRange(filter: any) {
+    switch (filter.type) {
+        case 'days':
+            return getRange('days', filter.interval);
+        case 'months':
+            return getRange('months', filter.interval);
+        case 'years':
+            return getRange('years', filter.interval);
+        case 'custom':
+            return getCustomRange(filter.startDate, filter.endDate);
+        default:
+            // Should not happen this
+            return getRange('days', 7);
+    }
+}
+
+function getRange(type, interval) {
+    const today = new Date();
+
+    const from_date = moment(today).subtract(interval, type).format('YYYY-MM-DD');
+    const to_date = moment(today).format('YYYY-MM-DD');
+
+    return {
+        fromDate: from_date,
+        toDate: to_date
+    };
+}
+
+function getCustomRange(fromDate: Date, toDate: Date) {
+    const from_date = moment(fromDate).format('YYYY-MM-DD');
+    const to_date = moment(toDate).format('YYYY-MM-DD');
+
+    return {
+        fromDate: from_date,
+        toDate: to_date
+    };
+}
+
+// Given a Date object, returns date in YYYY-MM-DD format
+export function toDateString(date: Date) {
+    return moment(date).format('YYYY-MM-DD');
+}
+
+// Given a date in string (YYYY-MM-DD), returns a Date object
+export function toDate(date: string) {
+    return moment(date).toDate();
+}

--- a/components/builder-web/app/events/events-routing.module.ts
+++ b/components/builder-web/app/events/events-routing.module.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { EventsComponent } from './events/events.component';
+import { EventsSaaSComponent } from './events-saas/events-saas.component';
+
+const routes: Routes = [
+  {
+    path: 'events',
+    component: EventsComponent,
+  },
+  {
+    path: 'events/saas',
+    component: EventsSaaSComponent,
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class EventsRoutingModule { }

--- a/components/builder-web/app/events/events-saas/events-saas.component.html
+++ b/components/builder-web/app/events/events-saas/events-saas.component.html
@@ -1,0 +1,34 @@
+<div class="events-component">
+  <header>
+    <h1>Builder Events (SaaS)</h1>
+    <h2 *ngIf="searchQuery">Search Results</h2>
+  </header>
+  <div class="body">
+    <div class="content">
+      <section class="events-filter">
+        <input
+          type="search"
+          #query autofocus
+          [formControl]="searchBox"
+          [value]="searchQuery"
+          placeholder="Search Events&hellip;">
+        <hab-events-date-filter [dateFilterChanged]="dateFilterChanged" [filters]="filters"
+          [currentFilter]="currentFilter"></hab-events-date-filter>
+      </section>
+      <section>
+        <hab-event-results
+          [noEvents]="(!ui.exists || events.size === 0) && !ui.loading"
+          [events]="events"
+          [errorMessage]="ui.errorMessage"
+          [fromSaas]="true">
+        </hab-event-results>
+      </section>
+      <section class="more" *ngIf="events.size < totalCount">
+        Showing {{events.size}} of {{totalCount}} events.
+        <a (click)="fetchMoreEvents()">
+          Load {{(totalCount - events.size) > perPage ? perPage : totalCount - events.size }} more.
+        </a>
+      </section>
+    </div>
+  </div>
+</div>

--- a/components/builder-web/app/events/events-saas/events-saas.component.spec.ts
+++ b/components/builder-web/app/events/events-saas/events-saas.component.spec.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DebugElement } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { List } from 'immutable';
+import { MockComponent } from 'ng2-mock-component';
+
+import { AppStore } from '../../app.store';
+import { EventsSaaSComponent } from './events-saas.component';
+
+class MockAppStore {
+  static state;
+
+  getState() {
+    return MockAppStore.state;
+  }
+
+  dispatch() { }
+}
+
+class MockRoute {
+  get params() {
+    return of({});
+  }
+}
+
+describe('EventsSaaSComponent', () => {
+  let fixture: ComponentFixture<EventsSaaSComponent>;
+  let component: EventsSaaSComponent;
+  let element: DebugElement;
+  let store: AppStore;
+
+  beforeEach(() => {
+    MockAppStore.state = {
+      events: {
+        visible: List(),
+        ui: {
+          visible: {}
+        }
+      },
+      app: {
+        name: 'Habitat'
+      }
+    };
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        MatInputModule,
+        NoopAnimationsModule
+      ],
+      declarations: [
+        MockComponent({
+          selector: 'hab-event-results',
+          inputs: ['errorMessage', 'noEvents', 'events']
+        }),
+        EventsSaaSComponent
+      ],
+      providers: [
+        { provide: AppStore, useClass: MockAppStore },
+        { provide: ActivatedRoute, useClass: MockRoute }
+      ]
+    });
+
+    fixture = TestBed.createComponent(EventsSaaSComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+    store = TestBed.get(AppStore);
+  });
+
+  describe('given the events', () => {
+
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('shows the Builder Events heading', () => {
+      let heading = element.query(By.css('.events-component h1'));
+      expect(heading.nativeElement.textContent).toBe('Builder Events (SaaS)');
+    });
+  });
+});

--- a/components/builder-web/app/events/events-saas/events-saas.component.ts
+++ b/components/builder-web/app/events/events-saas/events-saas.component.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FormControl } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+
+import { AppStore } from '../../app.store';
+import { fetchSaasEvents } from '../../actions/index';
+import { dateFilters, getDateRange } from '../date-util';
+import { setSaasEventsSearchQuery, setSaasEventsDateFilter } from '../../actions/events-saas';
+
+@Component({
+  template: require('./events-saas.component.html')
+})
+export class EventsSaaSComponent implements OnInit, OnDestroy {
+  dateFilterChanged: Function;
+  query: string = '';
+  searchBox: FormControl;
+
+  public filters: any;
+
+  private sub: Subscription;
+  private dateRange: any;
+
+  constructor(
+    private store: AppStore,
+    private route: ActivatedRoute,
+    private router: Router,
+    private title: Title
+  ) {
+    this.searchBox = new FormControl(this.searchQuery);
+    this.filters = dateFilters;
+    this.dateFilterChanged = function (item: any) {
+      this.currentFilter = item;
+      this.isOpen = !this.isOpen;
+      this.store.dispatch(setSaasEventsDateFilter(item));
+      this.fetchEvents(0);
+      return false;
+    }.bind(this);
+  }
+
+  ngOnInit() {
+    let state = this.store.getState();
+    // Ensure that the builder events are enabled
+    if (!(state.features.events && state.features.saasEvents)) {
+      this.router.navigate(['/pkgs']);
+      return;
+    }
+
+    this.sub = this.route.params.subscribe(_params => {
+      this.title.setTitle(`Events (SaaS) | ${this.store.getState().app.name}`);
+
+      this.fetchEvents(0);
+    });
+
+    this.searchBox.valueChanges
+      .pipe(
+        debounceTime(400),
+        distinctUntilChanged()
+      )
+      .subscribe(query => {
+        this.query = query;
+        this.store.dispatch(setSaasEventsSearchQuery(query));
+        this.fetchEvents(0);
+      });
+  }
+
+  ngOnDestroy() {
+    if (this.sub) {
+      this.sub.unsubscribe();
+    }
+  }
+
+  get events() {
+    return this.store.getState().eventsSaas.visible;
+  }
+
+  get perPage() {
+    return this.store.getState().eventsSaas.perPage;
+  }
+
+  get totalCount() {
+    return this.store.getState().eventsSaas.totalCount;
+  }
+
+  get ui() {
+    return this.store.getState().eventsSaas.ui.visible;
+  }
+
+  get searchQuery() {
+    return this.store.getState().eventsSaas.searchQuery;
+  }
+
+  get dateFilter() {
+    return this.store.getState().events.dateFilter;
+  }
+
+  get currentFilter() {
+    return this.dateFilter || this.filters[0];
+  }
+
+  fetchEvents(range) {
+    this.dateRange = getDateRange(this.currentFilter);
+    this.store.dispatch(fetchSaasEvents(range, this.dateRange.fromDate, this.dateRange.toDate, this.query));
+  }
+
+  fetchMoreEvents() {
+    this.store.dispatch(
+      fetchSaasEvents(this.store.getState().eventsSaas.nextRange, this.dateRange.fromDate, this.dateRange.toDate, this.query)
+    );
+  }
+}

--- a/components/builder-web/app/events/events.module.ts
+++ b/components/builder-web/app/events/events.module.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material';
+
+import { EventsComponent } from './events/events.component';
+import { EventsSaaSComponent } from './events-saas/events-saas.component';
+import { EventResultsComponent } from './results/results.component';
+import { DateFilterComponent } from './date-filter/date-filter.component';
+import { EventsRoutingModule } from './events-routing.module';
+import { SharedModule } from '../shared/shared.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatRippleModule,
+    MatDividerModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    EventsRoutingModule,
+    SharedModule
+  ],
+  declarations: [
+    EventsComponent,
+    EventsSaaSComponent,
+    EventResultsComponent,
+    DateFilterComponent
+  ]
+})
+export class EventsModule { }

--- a/components/builder-web/app/events/events/_events.component.scss
+++ b/components/builder-web/app/events/events/_events.component.scss
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.events-component {
+
+  .body {
+    .content {
+      width: 100%;
+      min-width: 100%;
+      padding-right: 0;
+
+      .events-filter {
+        display: flex;
+        justify-content: space-between;
+        flex-direction: row;
+
+        > input {
+          max-width: 65%;
+        }
+      }
+    }
+  }
+
+  header {
+    position: relative;
+  }
+
+  .more {
+    margin-top: $default-margin;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .events-filter {
+     align-items: start !important;
+     flex-direction: column !important;
+     justify-content: start !important;
+ }
+}

--- a/components/builder-web/app/events/events/events.component.html
+++ b/components/builder-web/app/events/events/events.component.html
@@ -1,0 +1,33 @@
+<div class="events-component">
+  <header>
+    <h1>Builder Events</h1>
+    <h2 *ngIf="searchQuery">Search Results</h2>
+  </header>
+  <div class="body">
+    <div class="content">
+      <section class="events-filter">
+        <input
+          type="search"
+          #query autofocus
+          [formControl]="searchBox"
+          [value]="searchQuery"
+          placeholder="Search Events&hellip;">
+        <hab-events-date-filter [dateFilterChanged]="dateFilterChanged" [filters]="filters"
+          [currentFilter]="currentFilter"></hab-events-date-filter>
+      </section>
+      <section>
+        <hab-event-results
+          [noEvents]="(!ui.exists || events.size === 0) && !ui.loading"
+          [events]="events"
+          [errorMessage]="ui.errorMessage">
+        </hab-event-results>
+      </section>
+      <section class="more" *ngIf="events.size < totalCount">
+        Showing {{events.size}} of {{totalCount}} events.
+        <a (click)="fetchMoreEvents()">
+          Load {{(totalCount - events.size) > perPage ? perPage : totalCount - events.size }} more.
+        </a>
+      </section>
+    </div>
+  </div>
+</div>

--- a/components/builder-web/app/events/events/events.component.spec.ts
+++ b/components/builder-web/app/events/events/events.component.spec.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DebugElement } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { List } from 'immutable';
+import { MockComponent } from 'ng2-mock-component';
+
+import { AppStore } from '../../app.store';
+import { EventsComponent } from './events.component';
+
+class MockAppStore {
+  static state;
+
+  getState() {
+    return MockAppStore.state;
+  }
+
+  dispatch() { }
+}
+
+class MockRoute {
+  get params() {
+    return of({});
+  }
+}
+
+describe('EventsComponent', () => {
+  let fixture: ComponentFixture<EventsComponent>;
+  let component: EventsComponent;
+  let element: DebugElement;
+  let store: AppStore;
+
+  beforeEach(() => {
+    MockAppStore.state = {
+      events: {
+        visible: List(),
+        ui: {
+          visible: {}
+        }
+      },
+      app: {
+        name: 'Habitat'
+      }
+    };
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        MatInputModule,
+        NoopAnimationsModule
+      ],
+      declarations: [
+        MockComponent({
+          selector: 'hab-event-results',
+          inputs: ['errorMessage', 'noEvents', 'events']
+        }),
+        EventsComponent
+      ],
+      providers: [
+        { provide: AppStore, useClass: MockAppStore },
+        { provide: ActivatedRoute, useClass: MockRoute }
+      ]
+    });
+
+    fixture = TestBed.createComponent(EventsComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+    store = TestBed.get(AppStore);
+  });
+
+  describe('given the events', () => {
+
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('shows the Builder Events heading', () => {
+      let heading = element.query(By.css('.events-component h1'));
+      expect(heading.nativeElement.textContent).toBe('Builder Events');
+    });
+  });
+});

--- a/components/builder-web/app/events/events/events.component.ts
+++ b/components/builder-web/app/events/events/events.component.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FormControl } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+
+import { AppStore } from '../../app.store';
+import { fetchEvents } from '../../actions/index';
+import { dateFilters, getDateRange } from '../date-util';
+import { setEventsSearchQuery, setEventsDateFilter } from '../../actions/events';
+
+@Component({
+  template: require('./events.component.html')
+})
+export class EventsComponent implements OnInit, OnDestroy {
+  dateFilterChanged: Function;
+  query: string = '';
+  searchBox: FormControl;
+
+  public filters: any;
+
+  private sub: Subscription;
+  private dateRange: any;
+
+  constructor(
+    private store: AppStore,
+    private route: ActivatedRoute,
+    private router: Router,
+    private title: Title
+  ) {
+    this.searchBox = new FormControl(this.searchQuery);
+    this.filters = dateFilters;
+    this.dateFilterChanged = function (item: any) {
+      this.isOpen = !this.isOpen;
+      this.store.dispatch(setEventsDateFilter(item));
+      this.fetchEvents(0);
+      return false;
+    }.bind(this);
+  }
+
+  ngOnInit() {
+    let state = this.store.getState();
+    // Ensure that the builder events are enabled
+    if (!state.features.events) {
+      this.router.navigate(['/pkgs']);
+      return;
+    }
+
+    this.sub = this.route.params.subscribe(_params => {
+      this.title.setTitle(`Events | ${this.store.getState().app.name}`);
+
+      this.fetchEvents(0);
+    });
+
+    this.searchBox.valueChanges
+      .pipe(
+        debounceTime(400),
+        distinctUntilChanged()
+      )
+      .subscribe(query => {
+        this.query = query;
+        this.store.dispatch(setEventsSearchQuery(query));
+        this.fetchEvents(0);
+      });
+  }
+
+  ngOnDestroy() {
+    if (this.sub) {
+      this.sub.unsubscribe();
+    }
+  }
+
+  get events() {
+    return this.store.getState().events.visible;
+  }
+
+  get perPage() {
+    return this.store.getState().events.perPage;
+  }
+
+  get totalCount() {
+    return this.store.getState().events.totalCount;
+  }
+
+  get ui() {
+    return this.store.getState().events.ui.visible;
+  }
+
+  get searchQuery() {
+    return this.store.getState().events.searchQuery;
+  }
+
+  get dateFilter() {
+    return this.store.getState().events.dateFilter;
+  }
+
+  get currentFilter() {
+    return this.dateFilter || this.filters[0];
+  }
+
+  fetchEvents(limit) {
+    this.dateRange = getDateRange(this.currentFilter);
+    this.store.dispatch(fetchEvents(limit, this.dateRange.fromDate, this.dateRange.toDate, this.query));
+  }
+
+  fetchMoreEvents() {
+    this.store.dispatch(
+      fetchEvents(this.store.getState().events.nextRange, this.dateRange.fromDate, this.dateRange.toDate, this.query)
+    );
+  }
+}

--- a/components/builder-web/app/events/results/_results.component.scss
+++ b/components/builder-web/app/events/results/_results.component.scss
@@ -1,0 +1,56 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.results-component {
+  display: block;
+
+  .none {
+    font-size: $base-font-size;
+    font-weight: normal;
+  }
+  
+  .item {
+    display: block;
+
+    .name {
+      font-size: 16px;
+    }
+
+    .pident {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .date {
+      text-align: right;
+    }
+  }
+
+  .heading h4:last-child {
+    text-align: right;
+  }
+
+  hab-icon {
+    @include icon-size(16);
+
+    &.status {
+      @each $status, $color in $status-colors {
+        &.#{$status} {
+          color: #{$color};
+        }
+      }
+    }
+  }
+}

--- a/components/builder-web/app/events/results/results.component.html
+++ b/components/builder-web/app/events/results/results.component.html
@@ -1,0 +1,33 @@
+<div class="results-component">
+  <ol class="nav-list">
+    <li class="heading">
+      <h4>Status</h4>
+      <h4>Origin</h4>
+      <h4>Channel</h4>
+      <h4>Package Ident</h4>
+      <h4 class="last-item">Created</h4>
+    </li>
+    <li class="none" *ngIf="noEvents">
+      <span>No events found.</span>
+    </li>
+    <li class="item" *ngFor="let event of events" (click)="onClick(event)">
+      <a>
+        <span class="column">
+          <hab-job-status-icon [status]="stateFor(event)"></hab-job-status-icon>
+        </span>
+        <span class="column origin">
+          {{ event.origin }}
+        </span>
+        <span class="column channel">
+          {{ event.channel }}
+        </span>
+        <span class="column pident">
+          {{ packageString(event) }}
+        </span>
+        <span class="column date">
+          {{ dateFor(event.created_at) }}
+        </span>
+      </a>
+    </li>
+  </ol>
+</div>

--- a/components/builder-web/app/events/results/results.component.spec.ts
+++ b/components/builder-web/app/events/results/results.component.spec.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { List } from 'immutable';
+import { MockComponent } from 'ng2-mock-component';
+
+import { EventResultsComponent } from './results.component';
+
+describe('EventResultsComponent', () => {
+  let fixture: ComponentFixture<EventResultsComponent>;
+  let component: EventResultsComponent;
+  let element: DebugElement;
+
+  beforeEach(() => {
+
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule
+      ],
+      declarations: [
+        EventResultsComponent,
+        MockComponent({ selector: 'hab-job-status-icon', inputs: ['status'] }),
+      ]
+    });
+
+    fixture = TestBed.createComponent(EventResultsComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+  });
+
+  beforeEach(() => {
+    component.events = List([
+      {
+        "operation": "Demote",
+        "created_at": "2021-05-18T15:02:33.095231",
+        "origin": "rcpd",
+        "channel": "stable",
+        "package_ident": {
+          "origin": "rcpd",
+          "name": "testapp",
+          "version": "0.1.0",
+          "release": "20200401202136"
+        }
+      }, {
+        "operation": "Promote",
+        "created_at": "2021-05-18T15:02:33.059659",
+        "origin": "rcpd",
+        "channel": "stable",
+        "package_ident": {
+          "origin": "rcpd",
+          "name": "testapp",
+          "version": "0.1.0",
+          "release": "20200401202136"
+        }
+      }, {
+        "operation": "Demote",
+        "created_at": "2021-05-18T15:02:29.212797",
+        "origin": "neurosis",
+        "channel": "foo",
+        "package_ident": {
+          "origin": "neurosis",
+          "name": "testapp",
+          "version": "0.1.3",
+          "release": "20171205003213"
+        }
+      }, {
+        "operation": "Promote",
+        "created_at": "2021-05-18T15:02:28.521932",
+        "origin": "neurosis",
+        "channel": "foo",
+        "package_ident": {
+          "origin": "neurosis",
+          "name": "testapp",
+          "version": "0.1.3",
+          "release": "20171205003213"
+        }
+      }
+    ]);
+    fixture.detectChanges();
+  });
+
+  it('renders a list of events', () => {
+    let items = element.queryAll(By.css('.results-component ol li.item'));
+    expect(items.length).toBe(4);
+
+    function text(item, selector) {
+      return item.query(By.css(selector)).nativeElement.textContent;
+    }
+
+    expect(text(items[0], '.origin')).toContain('rcpd');
+    expect(text(items[0], '.channel')).toContain('stable');
+    expect(text(items[0], '.pident')).toContain('rcpd/testapp/0.1.0/20200401202136');
+
+    expect(text(items[1], '.origin')).toContain('rcpd');
+    expect(text(items[1], '.channel')).toContain('stable');
+    expect(text(items[1], '.pident')).toContain('rcpd/testapp/0.1.0/20200401202136');
+
+    expect(text(items[2], '.origin')).toContain('neurosis');
+    expect(text(items[2], '.channel')).toContain('foo');
+    expect(text(items[2], '.pident')).toContain('neurosis/testapp/0.1.3/20171205003213');
+
+    expect(text(items[3], '.origin')).toContain('neurosis');
+    expect(text(items[3], '.channel')).toContain('foo');
+    expect(text(items[3], '.pident')).toContain('neurosis/testapp/0.1.3/20171205003213');
+  });
+
+  describe('given an empty list of events', () => {
+
+    beforeEach(() => {
+      component.events = List();
+      fixture.detectChanges();
+    });
+
+    it('hides the list', () => {
+      let el = element.query(By.css('.results-component ol li.item'));
+      expect(el).toBeNull();
+    });
+
+    it('renders an appropriate message', () => {
+      let el = element.query(By.css('.results-component ol li.none'));
+      expect(el.nativeElement.textContent).toContain('No events found.');
+    });
+  });
+});

--- a/components/builder-web/app/events/results/results.component.ts
+++ b/components/builder-web/app/events/results/results.component.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
+import { List } from 'immutable';
+import * as moment from 'moment';
+
+import { packageString } from '../../util';
+import { Browser } from '../../browser';
+
+const BLDR_SAAS = 'https://bldr.habitat.sh';
+
+@Component({
+  selector: 'hab-event-results',
+  template: require('./results.component.html')
+})
+export class EventResultsComponent {
+  @Input() errorMessage: string;
+  @Input() noEvents: boolean;
+  @Input() events: List<Object>;
+  @Input() fromSaas: boolean;
+
+  constructor(
+    private router: Router
+  ) {
+  }
+
+  onClick(event: any) {
+    if (this.fromSaas) {
+      const url = `${BLDR_SAAS}/#pkgs/${event.origin}/${event.package_ident.name}/${event.package_ident.version}/${event.package_ident.release}`;
+      Browser.openInTab(url);
+    } else {
+      this.router.navigate(['/pkgs', event.origin, event.package_ident.name, event.package_ident.version, event.package_ident.release]);
+    }
+  }
+
+  packageString(event) {
+    return packageString(event.package_ident);
+  }
+
+  dateFor(timestamp) {
+    return moment(timestamp, 'YYYY-MM-DDTHH:mm:ss').fromNow();
+  }
+
+  stateFor(event) {
+    return event.operation;
+  }
+}

--- a/components/builder-web/app/initial-state.ts
+++ b/components/builder-web/app/initial-state.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 import { List, Record } from 'immutable';
 import { BehaviorSubject } from 'rxjs';
+
 import { Origin } from './records/Origin';
 import { Package } from './records/Package';
 import { Project } from './records/Project';
@@ -93,7 +94,9 @@ export default Record({
       azure: false,
       docker: false
     })(),
-    builder: false
+    builder: false,
+    events: false,
+    saasEvents: false
   })(),
   notifications: Record({
     all: List(),
@@ -259,5 +262,35 @@ export default Record({
         })()
       })()
     })()
-  })()
+  })(),
+  events: Record({
+    visible: List(),
+    nextRange: 0,
+    perPage: 50,
+    totalCount: 0,
+    searchQuery: '',
+    dateFilter: undefined,
+    ui: Record({
+      visible: Record({
+        errorMessage: undefined,
+        exists: false,
+        loading: true,
+      })(),
+    })(),
+  })(),
+  eventsSaas: Record({
+    visible: List(),
+    nextRange: 0,
+    perPage: 50,
+    totalCount: 0,
+    searchQuery: '',
+    dateFilter: undefined,
+    ui: Record({
+      visible: Record({
+        errorMessage: undefined,
+        exists: false,
+        loading: true,
+      })(),
+    })(),
+  })(),
 })();

--- a/components/builder-web/app/reducers/events-saas.ts
+++ b/components/builder-web/app/reducers/events-saas.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { List } from 'immutable';
+
+import * as actionTypes from '../actions/index';
+import initialState from '../initial-state';
+
+export default function eventsSaas(state = initialState['eventsSaas'], action) {
+  switch (action.type) {
+
+    case actionTypes.CLEAR_SAAS_EVENTS:
+      return state.set('nextRange', 0).
+        set('visible', List()).
+        set('totalCount', 0).
+        setIn(['ui', 'visible', 'loading'], true).
+        setIn(['ui', 'visible', 'exists'], false);
+
+    case actionTypes.SET_SAAS_EVENTS_NEXT_RANGE:
+      return state.set('nextRange', action.payload);
+
+    case actionTypes.SET_SAAS_EVENTS_TOTAL_COUNT:
+      return state.set('totalCount', action.payload);
+
+    case actionTypes.SET_SAAS_EVENTS_SEARCH_QUERY:
+      return state.set('searchQuery', action.payload);
+
+    case actionTypes.SET_SAAS_EVENTS_DATE_FILTER:
+      return state.set('dateFilter', action.payload);
+
+    case actionTypes.SET_VISIBLE_SAAS_EVENTS:
+      if (action.error) {
+        return state.set('visible', List()).
+          setIn(['ui', 'visible', 'errorMessage'], action.error.message).
+          setIn(['ui', 'visible', 'exists'], false).
+          setIn(['ui', 'visible', 'loading'], false);
+      } else {
+        return state.set('visible', state.get('visible').concat(List(action.payload))).
+          setIn(['ui', 'visible', 'errorMessage'], undefined).
+          setIn(['ui', 'visible', 'exists'], true).
+          setIn(['ui', 'visible', 'loading'], false);
+      }
+
+    default:
+      return state;
+  }
+}

--- a/components/builder-web/app/reducers/events.ts
+++ b/components/builder-web/app/reducers/events.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { List } from 'immutable';
+
+import * as actionTypes from '../actions/index';
+import initialState from '../initial-state';
+
+export default function events(state = initialState['events'], action) {
+  switch (action.type) {
+
+    case actionTypes.CLEAR_EVENTS:
+      return state.set('nextRange', 0).
+        set('visible', List()).
+        set('totalCount', 0).
+        setIn(['ui', 'visible', 'loading'], true).
+        setIn(['ui', 'visible', 'exists'], false);
+
+    case actionTypes.SET_EVENTS_NEXT_RANGE:
+      return state.set('nextRange', action.payload);
+
+    case actionTypes.SET_EVENTS_TOTAL_COUNT:
+      return state.set('totalCount', action.payload);
+
+    case actionTypes.SET_EVENTS_SEARCH_QUERY:
+      return state.set('searchQuery', action.payload);
+
+    case actionTypes.SET_EVENTS_DATE_FILTER:
+      return state.set('dateFilter', action.payload);
+
+    case actionTypes.SET_VISIBLE_EVENTS:
+      if (action.error) {
+        return state.set('visible', List()).
+          setIn(['ui', 'visible', 'errorMessage'], action.error.message).
+          setIn(['ui', 'visible', 'exists'], false).
+          setIn(['ui', 'visible', 'loading'], false);
+      } else {
+        return state.set('visible', state.get('visible').concat(List(action.payload))).
+          setIn(['ui', 'visible', 'errorMessage'], undefined).
+          setIn(['ui', 'visible', 'exists'], true).
+          setIn(['ui', 'visible', 'loading'], false);
+      }
+
+    default:
+      return state;
+  }
+}

--- a/components/builder-web/app/reducers/features.ts
+++ b/components/builder-web/app/reducers/features.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,8 +24,9 @@ export default function builds(state = initialState['features'], action) {
         .setIn(['publishers', 'amazon'], !!config['enable_publisher_amazon'])
         .setIn(['publishers', 'azure'], !!config['enable_publisher_azure'])
         .setIn(['publishers', 'docker'], !!config['enable_publisher_docker'])
-        .set('builder', !!config['enable_builder']);
-
+        .set('builder', !!config['enable_builder'])
+        .set('events', !!config['enable_builder_events'])
+        .set('saasEvents', !!config['enable_builder_events_saas']);
     default:
       return state;
   }

--- a/components/builder-web/app/reducers/index.ts
+++ b/components/builder-web/app/reducers/index.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import router from './router';
 import session from './sessions';
 import users from './users';
 import ui from './ui';
+import events from './events';
+import eventsSaas from './events-saas';
 
 export default combineReducers({
   app,
@@ -42,5 +44,7 @@ export default combineReducers({
   router,
   session,
   ui,
-  users
+  users,
+  events,
+  eventsSaas
 });

--- a/components/builder-web/app/shared/shared.module.ts
+++ b/components/builder-web/app/shared/shared.module.ts
@@ -94,6 +94,7 @@ import { JobNoticeComponent } from './job-notice/job-notice.component';
     SimpleConfirmDialog
   ],
   exports: [
+    MatMenuModule,
     BreadcrumbsComponent,
     ChannelsComponent,
     CheckingInputComponent,

--- a/components/builder-web/app/side-nav/side-nav.component.html
+++ b/components/builder-web/app/side-nav/side-nav.component.html
@@ -18,6 +18,18 @@
         Search Packages
       </a>
     </li>
+    <li>
+      <a [routerLink]="['/events']" *ngIf="enabledEvents">
+        <hab-icon symbol="event"></hab-icon>
+        Events
+      </a>
+    </li>
+    <li>
+      <a [routerLink]="['/events/saas']" *ngIf="enabledEvents && enabledSaasEvents">
+        <hab-icon symbol="cloud"></hab-icon>
+        Events (SaaS)
+      </a>
+    </li>
   </ul>
   <h3>Quick Links</h3>
   <ul>

--- a/components/builder-web/app/user-nav/_user-nav.component.scss
+++ b/components/builder-web/app/user-nav/_user-nav.component.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 .user-nav-component {
-  display: block;
+  display: inline-block;
   border-radius: 50%;
   padding: 2px;
   cursor: pointer;
@@ -23,7 +23,7 @@
   }
 
   img {
-    display: block;
+    // display: block;
     border: solid 2px $white;
     border-radius: 50%;
     height: 40px;
@@ -68,5 +68,17 @@
   .cta {
     background-color: $hab-orange;
     color: $white;
+  }
+
+  hab-icon[symbol="notifications"] {
+    width: 2em;
+  }
+
+  .notif-link {
+    vertical-align: top;
+    margin-right: 5px;
+    margin-top: 5px;
+    height: 42px;
+    display: inline-block;
   }
 }

--- a/components/builder-web/app/user-nav/user-nav.component.ts
+++ b/components/builder-web/app/user-nav/user-nav.component.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/builder-web/app/util.ts
+++ b/components/builder-web/app/util.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 import * as moment from 'moment';
+import { find } from 'lodash';
+
 import { Project } from './records/Project';
 import { AppStore } from './app.store';
 import { FeatureFlags } from './privilege';
-import { find } from 'lodash';
 
 // Pretty print a time
 // Print a number of seconds as minutes and seconds
@@ -182,7 +183,9 @@ export function iconForJobState(state) {
     processing: 'loading',
     queued: 'pending',
     rejected: 'alert',
-    skipped: 'no'
+    skipped: 'no',
+    demote: 'no',
+    promote: 'check',
   }[state.toLowerCase()];
 }
 
@@ -205,6 +208,8 @@ export function labelForJobState(state) {
     processing: 'Processing',
     queued: 'Queued',
     rejected: 'Rejected',
-    skipped: 'Skipped'
+    skipped: 'Skipped',
+    demote: 'Demote',
+    promote: 'Promote',
   }[state.toLowerCase()];
 }

--- a/components/builder-web/assets/images/icons/all.svg
+++ b/components/builder-web/assets/images/icons/all.svg
@@ -248,5 +248,21 @@
       <!-- https://material.io/icons/#web_asset -->
       <path d="M19 4H5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.89-2-2-2zm0 14H5V8h14v10z"/>
     </g>
+    <g id="icon-notifications">
+      <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Acircle_notifications -->
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 16.5c-.83 0-1.5-.67-1.5-1.5h3c0 .83-.67 1.5-1.5 1.5zm5-2.5H7v-1l1-1v-2.61C8 9.27 9.03 7.47 11 7v-.5c0-.57.43-1 1-1s1 .43 1 1V7c1.97.47 3 2.28 3 4.39V14l1 1v1z"/>
+    </g>
+    <g id="icon-event">
+      <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Aevent -->
+      <path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/>
+    </g>
+    <g id="icon-cloud">
+      <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Acloud_done -->
+      <path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM10 17l-3.5-3.5 1.41-1.41L10 14.17 15.18 9l1.41 1.41L10 17z"/>
+    </g>
+    <g id="icon-close">
+      <!-- https://fonts.google.com/icons?selected=Material%20Icons%20Outlined%3Aclear -->
+      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
+    </g>
   </defs>
 </svg>

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -66,5 +66,12 @@ habitatConfig({
     version: "",
 
     // The main website URL
-    www_url: "https://www.habitat.sh"
+    www_url: "https://www.habitat.sh",
+
+     // Enable/Disable builder events
+    enable_builder_events: false,
+
+     // Enable/Disable builder events from SaaS
+     // The 'enable_builder_events' property also needs to be set to enable SaaS events.
+     enable_builder_events_saas: false
 });

--- a/components/builder-web/stylesheets/base/_colors.scss
+++ b/components/builder-web/stylesheets/base/_colors.scss
@@ -62,7 +62,9 @@ $status-colors: (
   queued: $pending,
   rejected: $error,
   skipped: $disabled,
-  success: $success
+  success: $success,
+  promote: $success,
+  demote: $error
 );
 
 $form-colors: (

--- a/test/builder-api/src/util.js
+++ b/test/builder-api/src/util.js
@@ -1,0 +1,24 @@
+function getLast1WeekDateRange() {
+    // to_date is inclusive
+    const toDate = new Date();
+
+    // from_date is inclusive
+    let fromDate = new Date();
+    fromDate = new Date(fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate() - 7);
+
+    const toDateStr = toDate.getFullYear() + '-' + (toDate.getMonth() + 1) + '-' + toDate.getDate();
+    const fromDateStr = fromDate.getFullYear() + '-' + (fromDate.getMonth() + 1) + '-' + fromDate.getDate();
+
+    return {
+        fromDate: fromDateStr,
+        toDate: toDateStr
+    };
+}
+
+// Given a URI/URL append the last one week date range query parameters
+function appendDateRange(url) {
+    const dateRange = getLast1WeekDateRange();
+    return `${url}?from_date=${dateRange.fromDate}&to_date=${dateRange.toDate}`;
+}
+
+module.exports.appendDateRange = appendDateRange;


### PR DESCRIPTION
The builder generates package-level promotion/demotion events and are persisted as event logs. There are two different sets of events generated by 1: on-prem builder, 2: SaaS builder. 

A new API endpoint is added to fetch these event logs. The builder events from the SaaS builder can be accessed from the on-prem environment through the API call, which routed to the SaaS instance.

To view the event logs from the on-prem builder, set the following property on the 'builder-API-proxy' service.

enable_builder_events: true

Furthermore, the on-prem builder can also enable to see the events from the SaaS builder. To view the events from the SaaS builder, set the following property on the 'builder-api-proxy' service.

enable_builder_events_saas: true

Note: It is also important to set the 'enable_builder_events' property to view the events from SaaS.

The following configuration properties set in the 'builder-api-proxy' service will show events from on-prem and SaaS builders.

enable_builder_events: true
enable_builder_events_saas: true