### PR TITLE
Fix the tags which are used in datadog dashboard OPS-1909

### DIFF
--- a/terraform/files/nginx.yaml
+++ b/terraform/files/nginx.yaml
@@ -1,6 +1,8 @@
 init_config:
 instances:
   - nginx_status_url: http://localhost/nginx_status/
+    tags:
+      - instance:api
 logs:
   - type: file
     path: /hab/svc/builder-api-proxy/logs/host.*.log


### PR DESCRIPTION
restore previously removed tag

Signed-off-by: Riju VV <riju.vv@progress.com>