### PR TITLE
Add makefile target for installing MacOS prerequisite packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ ifeq ($(UNAME_S),Darwin)
 endif
 .PHONY: linux
 
+prereq:  ## Invoke "make prereq" to install MacOS prerequisite packages
+	sudo apt-get update
+	sudo apt-get install -y --no-install-recommends build-essential libarchive-dev pkg-config cmake
+.PHONY: prereq
+
 build: build-bin build-lib build-srv ## builds all the components
 build-all: build
 .PHONY: build build-all


### PR DESCRIPTION
Makefile target can be invoked with:
$ make prereq
Target will refresh apt-get, and install packages preventing clean installation on MacOS workstation
