### PR TITLE
emit errors with http_client certificate processing to stderr

### DIFF
--- a/components/builder-core/src/http_client.rs
+++ b/components/builder-core/src/http_client.rs
@@ -115,13 +115,13 @@ fn process_cache_dir<P>(cache_path: P, mut certificates: &mut Vec<Certificate>)
                             process_cert_file(&mut certificates, &path);
                         }
                     }
-                    Err(err) => debug!("Unable to read cache entry, err = {:?}", err),
+                    Err(err) => error!("Unable to read cache entry, err = {:?}", err),
                 }
             }
         }
         Err(err) => {
             if err.kind() != std::io::ErrorKind::NotFound {
-                debug!("Unable to read cache directory, err = {:?}", err)
+                error!("Unable to read cache directory, err = {:?}", err)
             }
         }
     }
@@ -133,7 +133,7 @@ fn process_cert_file(certificates: &mut Vec<Certificate>, file_path: &Path) {
     match cert_from_file(file_path) {
         Ok(cert) => certificates.push(cert),
         Err(err) => {
-            debug!("Unable to process cert file: {}, err={:?}",
+            error!("Unable to process cert file: {}, err={:?}",
                    file_path.display(),
                    err)
         }


### PR DESCRIPTION
Related to #1640. If there are errors when processing certificate files stored in `/hab/cache/ssl`, we currently emit the errors to the debug logs. If a customer runs into problems with custom certificates in `/hab/cache/ssl/` then these errors are hidden and support has to coach the customer to turn on debug logging. This PR will always emit these errors to standard error so that debug level logging does not need to be enables to see them.

Signed-off-by: Matt Wrock <matt@mattwrock.com>