### PR TITLE
Handle package name mismatch in connection creation

### DIFF
--- a/components/builder-api/src/server/resources/projects.rs
+++ b/components/builder-api/src/server/resources/projects.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2018-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
 use std::{env,
           str::FromStr};
 
-use actix_web::{http::{self,
+use actix_web::{body::Body,
+                http::{self,
                        StatusCode},
                 web::{self,
                       Data,
@@ -59,6 +60,8 @@ pub struct ProjectCreateReq {
     pub repo_id:         u32,
     #[serde(default)]
     pub auto_build:      bool,
+    #[serde(default)]
+    pub name:            String,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -223,6 +226,15 @@ async fn create_project(req: HttpRequest,
     };
 
     let package_name = plan.name.trim_matches('"');
+    if package_name != body.name {
+        debug!("Package names mismatch, expected={}, found={}",
+               body.name, package_name);
+        return HttpResponse::with_body(StatusCode::UNPROCESSABLE_ENTITY,
+                                       Body::from_message(format!("Package name '{}' does not \
+                                                                   correspond to the plan file",
+                                                                  body.name)));
+    }
+
     let new_project = NewProject { owner_id: account_id as i64,
                                    origin: &origin.name,
                                    package_name,

--- a/components/builder-api/src/server/resources/projects.rs
+++ b/components/builder-api/src/server/resources/projects.rs
@@ -411,7 +411,12 @@ async fn update_project(req: HttpRequest,
                         Ok(plan) => {
                             debug!("plan = {:?}", &plan);
                             if plan.name != name {
-                                return HttpResponse::new(StatusCode::UNPROCESSABLE_ENTITY);
+                                debug!("Package names mismatch, expected={}, found={}",
+                                       name, plan.name);
+                                return HttpResponse::with_body(StatusCode::UNPROCESSABLE_ENTITY,
+                                       Body::from_message(format!("Package name '{}' does not \
+                                                                   correspond to the plan file",
+                                                                   name)));
                             }
                             plan
                         }

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -176,7 +176,9 @@ export class BuilderApiClient {
           if (response.ok) {
             resolve(response.json());
           } else {
-            reject(new Error(response.statusText));
+            response.text().then(message => {
+              reject(new Error(message || response.statusText));
+            }).catch(_ => reject(new Error(response.statusText)));
           }
         })
         .catch(error => this.handleError(error, reject));

--- a/components/builder-web/app/client/builder-api.ts
+++ b/components/builder-web/app/client/builder-api.ts
@@ -235,7 +235,9 @@ export class BuilderApiClient {
           if (response.ok) {
             resolve();
           } else {
-            reject(new Error(response.statusText));
+            response.text().then(message => {
+              reject(new Error(message || response.statusText));
+            }).catch(_ => reject(new Error(response.statusText)));
           }
         })
         .catch(error => this.handleError(error, reject));

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016-2021 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -430,8 +430,9 @@ export class ProjectSettingsComponent implements OnChanges, OnDestroy, AfterView
         this.handleSaved(result.success, origin, package_name, target);
       }));
     } else {
-      this.store.dispatch(addProject(this.planTemplate, this.token, (result) => {
-        const { origin, package_name, target } = result.response;
+      const project = { ...this.planTemplate, name: this.name};
+      this.store.dispatch(addProject(project, this.token, (result) => {
+        const { origin, package_name, target } = result.response || {};
         this.handleSaved(result.success, origin, package_name, target);
       }));
     }


### PR DESCRIPTION
closes #1602

When creating a new connection, if the package name does not match with the name in the plan file, it creates a record in the projects table but subsequently fails.

Upon updating the connection, it displays HTTP status text, which does not say what went wrong.

Along with handling the scenarios mentioned on the backend, this PR also handles displaying the message on UI.