### PR TITLE
correct description of connection_public_key tf variable

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -166,5 +166,5 @@ variable "enabled_features" {
 }
 
 variable "connection_public_key" {
-  description = "File path to the public key to use for SSH authentication to windows builder"
+  description = "Content of public key to use for SSH authentication to windows builder"
 }


### PR DESCRIPTION
closes #1614 

The variable should contain the actual value and not the file path of the public key. Running `make init` in the `cloud-environments` repo will pull the value from vault and set this variable.

Signed-off-by: Matt Wrock <matt@mattwrock.com>