### PR TITLE
Event log fixes on the SaaS events page

### DIFF
--- a/components/builder-web/app/client/depot-api.ts
+++ b/components/builder-web/app/client/depot-api.ts
@@ -313,10 +313,10 @@ export function getEvents(nextRange: number = 0, fromDate: string, toDate: strin
 }
 
 export function getSaasEvents(nextRange: number = 0, fromDate: string, toDate: string, query: string = '') {
-  let url = `${urlPrefix}/depot/events/saas` + `?range=${nextRange}&channel=stable&from_date=${fromDate}&to_date=${toDate}&query=${query}`;
+  let url = `${urlPrefix}/depot/events/saas?range=${nextRange}&channel=stable&from_date=${fromDate}&to_date=${toDate}&query=${query}`;
 
   return new Promise((resolve, reject) => {
-    fetch(url, opts())
+    fetch(url)
       .then(response => handleUnauthorized(response, reject))
       .then(response => {
         if (response.status >= 400) {

--- a/components/builder-web/app/events/events-saas/events-saas.component.ts
+++ b/components/builder-web/app/events/events-saas/events-saas.component.ts
@@ -46,7 +46,6 @@ export class EventsSaaSComponent implements OnInit, OnDestroy {
     this.searchBox = new FormControl(this.searchQuery);
     this.filters = dateFilters;
     this.dateFilterChanged = function (item: any) {
-      this.currentFilter = item;
       this.isOpen = !this.isOpen;
       this.store.dispatch(setSaasEventsDateFilter(item));
       this.fetchEvents(0);
@@ -107,7 +106,7 @@ export class EventsSaaSComponent implements OnInit, OnDestroy {
   }
 
   get dateFilter() {
-    return this.store.getState().events.dateFilter;
+    return this.store.getState().eventsSaas.dateFilter;
   }
 
   get currentFilter() {


### PR DESCRIPTION
Case 1: When the date filter changed on the Events (SaaS), results in console errors.
Fixes the dropdown change on the Events (SaaS) page.

Case 2: When the user logged in and tried to access Events (SaaS), results in console errors.
This is occurring because the user is logged into a different environment (acceptance/on-prem) and the auth same token is used for the production instance. Currently, we can only show events that are publicly accessible. 

We need to handle the login case separately. Below are the possible options:
1. Use separate auth credentials when accessing Events (SaaS) - may not be the right choice.
2. Support multi-login (on-prem and SaaS), use the token based on the context.
3. Any other options?
