### PR TITLE
turn off proxy request buffering to allow for better upload streaming and fix super large uploads

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -117,6 +117,7 @@ http {
     proxy_read_timeout {{cfg.nginx.proxy_read_timeout}};
     proxy_connect_timeout  {{cfg.nginx.proxy_connect_timeout}};
     proxy_http_version 1.1;
+    proxy_request_buffering off;
     proxy_set_header Connection "";
 
     {{~#if cfg.server.listen_tls}}


### PR DESCRIPTION
fixes #1663 

I noticed that the upload stream was hanging after a couple GB. Eventually the connection on the client or the nginx gateway would timeout which would close the stream leaving an incomplete temp file and ultimately resulting in a `premature eof` error while extracting the archive. I also observed that `builder-api` did not begin to read the stream until the client had sent the entire file. That seemed odd since the http 1.1 chunked encoding should allow for proper streaming. 

I eventually tried bypassing nginx and sending the upload strictly to builder-api. This resulted in a successful upload as well as proper streaming behavior.

I later discovered the [`proxy_request_buffering` setting in nginx](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering). By default this is on and causes nginx to buffer the entire body before sending it off to builder-api. By turning it off, I got proper streaming and successful uploads. I'm still not clear why the stream was hanging, but this appears to fix the problem.

Signed-off-by: Matt Wrock <matt@mattwrock.com>