### PR TITLE
Fix size computing for packages with /latest route

### DIFF
--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -1428,10 +1428,10 @@ async fn do_get_package(req: &HttpRequest,
 
     pkg_json["channels"] = json!(channels);
     pkg_json["is_a_service"] = json!(pkg.is_a_service());
-    let size = match req_state(req).packages.size_of(ident, target).await {
+    let size = match req_state(req).packages.size_of(&pkg.ident, target).await {
         Ok(size) => size,
         Err(err) => {
-            debug!("Could not get size for {:?}, {:?}", ident, err);
+            debug!("Could not get size for {:?}, {:?}", pkg.ident, err);
             0
         }
     };

--- a/test/builder-api/src/packages.js
+++ b/test/builder-api/src/packages.js
@@ -646,6 +646,7 @@ describe('Working with packages', function () {
           expect(res.body.ident.name).to.equal('testapp');
           expect(res.body.ident.version).to.equal('0.1.13');
           expect(res.body.ident.release).to.equal(release10);
+          expect(res.body.size).to.equal(1633);
           done(err);
         });
     });
@@ -743,6 +744,7 @@ describe('Working with packages', function () {
           expect(res.body.ident.name).to.equal('testapp');
           expect(res.body.ident.version).to.equal('0.1.3');
           expect(res.body.ident.release).to.equal(release2);
+          expect(res.body.size).to.equal(1569);
           done(err);
         });
     });
@@ -757,6 +759,7 @@ describe('Working with packages', function () {
           expect(res.body.ident.name).to.equal('testapp');
           expect(res.body.ident.version).to.equal('0.1.3');
           expect(res.body.ident.release).to.equal(release2);
+          expect(res.body.size).to.equal(1569);
           done(err);
         });
     });


### PR DESCRIPTION
We can get the package metadata with the /latest route with the omission of the version and or release options.
This PR fixes getting package HART size as part of package metadata in those situations.

It also updates a few functional tests to check the size attribute in the response JSON.


Signed-off-by: Phani Sajja <psajja@progress.com>