### PR TITLE
Fix picking the pkg target for fully qualified ident

### DIFF
--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -1428,7 +1428,10 @@ async fn do_get_package(req: &HttpRequest,
 
     pkg_json["channels"] = json!(channels);
     pkg_json["is_a_service"] = json!(pkg.is_a_service());
-    let size = match req_state(req).packages.size_of(&pkg.ident, *pkg.target).await {
+    let size = match req_state(req).packages
+                                   .size_of(&pkg.ident, *pkg.target)
+                                   .await
+    {
         Ok(size) => size,
         Err(err) => {
             debug!("Could not get size for {:?}, {:?}", pkg.ident, err);

--- a/components/builder-api/src/server/resources/pkgs.rs
+++ b/components/builder-api/src/server/resources/pkgs.rs
@@ -1424,11 +1424,11 @@ async fn do_get_package(req: &HttpRequest,
     };
 
     let mut pkg_json = serde_json::to_value(pkg.clone()).unwrap();
-    let channels = channels_for_package_ident(req, &pkg.ident, target, &*conn)?;
+    let channels = channels_for_package_ident(req, &pkg.ident, *pkg.target, &*conn)?;
 
     pkg_json["channels"] = json!(channels);
     pkg_json["is_a_service"] = json!(pkg.is_a_service());
-    let size = match req_state(req).packages.size_of(&pkg.ident, target).await {
+    let size = match req_state(req).packages.size_of(&pkg.ident, *pkg.target).await {
         Ok(size) => size,
         Err(err) => {
             debug!("Could not get size for {:?}, {:?}", pkg.ident, err);


### PR DESCRIPTION
When we do not supply the target parameter for a package, it will default to X86_64_Linux. However, if the input ident is fully qualified, the builder determines the correct target when finding a package.

Sample route:
<builder-url>/v1/depot/pkgs/neurosis/testapp/0.1.4/20181115124506

After identifying the package, the target property from the newly found package should be used instead of the default.

Signed-off-by: Phani Sajja <psajja@progress.com>