### PR TITLE
Update actix-web crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,25 +4,26 @@ version = 3
 
 [[package]]
 name = "actix-codec"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5dbeb2d9e51344cb83ca7cc170f1217f9fe25bfc50160e6e200b5c31c1019a"
+checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
 dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-sink",
  "log 0.4.14",
+ "memchr 2.4.1",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]
 name = "actix-http"
-version = "3.0.0-beta.11"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b510d35f13987537289f38bf136e7e702a5c87cc28760310cc459544f40afd"
+checksum = "a5885cb81a0d4d0d322864bea1bb6c2a8144626b4fdc625d4c51eba197e7797a"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -37,24 +38,20 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.1",
  "language-tags",
  "local-channel",
  "log 0.4.14",
  "mime",
- "once_cell",
  "percent-encoding",
- "pin-project",
  "pin-project-lite",
  "rand",
  "sha-1",
  "smallvec",
- "tokio",
 ]
 
 [[package]]
@@ -69,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.5.0-beta.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b95ce0d76d1aa2f98b681702807475ade0f99bd4552546a6843a966d42ea3d"
+checksum = "eb60846b52c118f2f04a56cc90880a274271c489b2498623d58176f8ca21fa80"
 dependencies = [
  "bytestring",
  "firestorm",
@@ -83,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.3.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea360596a50aa9af459850737f99293e5cb9114ae831118cb6026b3bbc7583ad"
+checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -94,18 +91,20 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.0.0-beta.6"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7367665785765b066ad16e1086d26a087f696bc7c42b6f93004ced6cfcf1eeca"
+checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
 dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
  "futures-core",
- "log 0.4.14",
- "mio",
+ "futures-util",
+ "mio 0.8.3",
  "num_cpus",
+ "socket2",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -121,21 +120,20 @@ dependencies = [
 
 [[package]]
 name = "actix-tls"
-version = "3.0.0-beta.7"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4af84e13e4600829858a3e68079be710d1ada461431e1e4c5ae663479ea0a3c"
+checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "derive_more",
  "futures-core",
- "http",
  "log 0.4.14",
  "openssl",
+ "pin-project-lite",
  "tokio-openssl",
- "tokio-util",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]
@@ -150,35 +148,32 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.0.0-beta.10"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a4b9d00991d8da308070a5cea7f1bbaa153a91c3fb5567937d99b9f46d601e"
+checksum = "f4e5ebffd51d50df56a3ae0de0e59487340ca456f05dd0b90c0a7a6dd6a74d31"
 dependencies = [
  "actix-codec",
  "actix-http",
- "actix-macros",
  "actix-router",
  "actix-rt",
  "actix-server",
  "actix-service",
  "actix-tls",
  "actix-utils",
- "actix-web-codegen",
  "ahash 0.7.6",
  "bytes",
+ "bytestring",
  "cfg-if",
  "derive_more",
- "either",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "itoa",
+ "itoa 1.0.1",
  "language-tags",
  "log 0.4.14",
  "mime",
  "once_cell",
- "paste",
- "pin-project",
+ "pin-project-lite",
  "regex",
  "serde",
  "serde_json",
@@ -187,18 +182,6 @@ dependencies = [
  "socket2",
  "time 0.3.4",
  "url",
-]
-
-[[package]]
-name = "actix-web-codegen"
-version = "0.5.0-beta.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe80a8828fa88a0420dc8fdd4c16b8207326c917f17701881b063eadc2a8d3b"
-dependencies = [
- "actix-router",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -304,7 +287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc 0.2.106",
+ "libc 0.2.125",
  "winapi",
 ]
 
@@ -323,7 +306,7 @@ dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
- "libc 0.2.106",
+ "libc 0.2.125",
  "miniz_oxide",
  "object",
  "rustc-demangle",
@@ -372,6 +355,15 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
@@ -448,7 +440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61bf7211aad104ce2769ec05efcdfabf85ee84ac92461d142f22cf8badd0e54c"
 dependencies = [
  "errno",
- "libc 0.2.106",
+ "libc 0.2.125",
  "thiserror",
 ]
 
@@ -483,7 +475,7 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "num-integer",
  "num-traits",
  "serde",
@@ -538,7 +530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -553,7 +545,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -607,6 +599,16 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -709,6 +711,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,7 +745,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "redox_users",
  "winapi",
 ]
@@ -744,7 +756,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "redox_users",
  "winapi",
 ]
@@ -756,7 +768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
 dependencies = [
  "cfg-if",
- "libc 0.2.106",
+ "libc 0.2.125",
  "socket2",
  "winapi",
 ]
@@ -900,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
- "libc 0.2.106",
+ "libc 0.2.125",
  "winapi",
 ]
 
@@ -911,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -958,16 +970,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if",
- "libc 0.2.106",
+ "libc 0.2.125",
  "redox_syscall",
  "winapi",
 ]
 
 [[package]]
 name = "firestorm"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31586bda1b136406162e381a3185a506cdfc1631708dd40cba2f6628d8634499"
+checksum = "4d3d6188b8804df28032815ea256b6955c9625c24da7525f387a7af02fbb8f01"
 
 [[package]]
 name = "fixedbitset"
@@ -1129,8 +1141,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
- "libc 0.2.106",
- "wasi",
+ "libc 0.2.125",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1146,7 +1158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a8057932925d3a9d9e4434ea016570d37420ddb1ceed45a174d577f24ed6700"
 dependencies = [
  "bitflags 1.3.2",
- "libc 0.2.106",
+ "libc 0.2.125",
  "libgit2-sys",
  "log 0.4.14",
  "openssl-probe",
@@ -1180,9 +1192,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.7"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -1193,7 +1205,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -1424,7 +1436,7 @@ dependencies = [
  "habitat_win_users",
  "hex 0.4.3",
  "lazy_static",
- "libc 0.2.106",
+ "libc 0.2.125",
  "log 0.4.14",
  "native-tls",
  "nix 0.23.0",
@@ -1497,7 +1509,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -1519,7 +1531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1530,7 +1542,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1577,7 +1589,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1661,12 +1673,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -1697,7 +1715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da06b22cd19af338a40f5d44a0aa6352ae43839d0855a049881cbc7e1b9c914"
 dependencies = [
  "libarchive3-sys",
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -1706,7 +1724,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd3beae8f59a4c7a806523269b5392037577c150446e88d684dfa6de6031ca7"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "pkg-config",
 ]
 
@@ -1718,9 +1736,9 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libgit2-sys"
@@ -1729,7 +1747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddbd6021eef06fb289a8f54b3c2acfdd85ff2a585dfbb24b8576325373d2152c"
 dependencies = [
  "cc",
- "libc 0.2.106",
+ "libc 0.2.125",
  "libssh2-sys",
  "libz-sys",
  "openssl-sys",
@@ -1743,7 +1761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
 dependencies = [
  "cc",
- "libc 0.2.106",
+ "libc 0.2.125",
  "pkg-config",
  "walkdir",
 ]
@@ -1755,7 +1773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
 dependencies = [
  "cc",
- "libc 0.2.106",
+ "libc 0.2.125",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1769,7 +1787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
- "libc 0.2.106",
+ "libc 0.2.125",
  "pkg-config",
  "vcpkg",
 ]
@@ -1832,7 +1850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdb4b7c3eddad11d3af9e86c487607d2d2442d185d848575365c4856ba96d619"
 dependencies = [
  "cc",
- "libc 0.2.106",
+ "libc 0.2.125",
  "pkg-config",
 ]
 
@@ -1848,8 +1866,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -1879,7 +1897,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -1951,11 +1969,23 @@ version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "log 0.4.14",
  "miow",
  "ntapi",
  "winapi",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+dependencies = [
+ "libc 0.2.125",
+ "log 0.4.14",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1974,7 +2004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
- "libc 0.2.106",
+ "libc 0.2.125",
  "log 0.4.14",
  "openssl",
  "openssl-probe",
@@ -2004,7 +2034,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cc",
  "cfg-if",
- "libc 0.2.106",
+ "libc 0.2.125",
  "memoffset",
 ]
 
@@ -2065,7 +2095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -2112,7 +2142,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
- "libc 0.2.106",
+ "libc 0.2.125",
  "once_cell",
  "openssl-sys",
 ]
@@ -2140,7 +2170,7 @@ checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg",
  "cc",
- "libc 0.2.106",
+ "libc 0.2.125",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -2176,7 +2206,7 @@ checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if",
  "instant",
- "libc 0.2.106",
+ "libc 0.2.125",
  "redox_syscall",
  "smallvec",
  "winapi",
@@ -2500,7 +2530,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "rand_chacha",
  "rand_core",
  "rand_hc",
@@ -2622,7 +2652,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "log 0.4.14",
  "num_cpus",
  "rayon",
@@ -2680,7 +2710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
- "libc 0.2.106",
+ "libc 0.2.125",
  "once_cell",
  "spin",
  "untrusted",
@@ -2753,7 +2783,7 @@ dependencies = [
  "base64 0.13.0",
  "bytes",
  "chrono 0.4.19",
- "digest",
+ "digest 0.9.0",
  "futures",
  "hex 0.4.3",
  "hmac",
@@ -2866,7 +2896,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
- "libc 0.2.106",
+ "libc 0.2.125",
  "security-framework-sys",
 ]
 
@@ -2877,7 +2907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -2931,7 +2961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "indexmap",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -2943,22 +2973,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "sha-1"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "block-buffer",
  "cfg-if",
  "cpufeatures",
- "digest",
- "opaque-debug",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2967,10 +2995,10 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -2995,7 +3023,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -3034,7 +3062,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "winapi",
 ]
 
@@ -3045,7 +3073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
 dependencies = [
  "ed25519",
- "libc 0.2.106",
+ "libc 0.2.125",
  "libsodium-sys",
  "serde",
 ]
@@ -3114,7 +3142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
- "libc 0.2.106",
+ "libc 0.2.125",
  "xattr",
 ]
 
@@ -3125,7 +3153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
- "libc 0.2.106",
+ "libc 0.2.125",
  "rand",
  "redox_syscall",
  "remove_dir_all 0.5.3",
@@ -3194,7 +3222,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "winapi",
 ]
 
@@ -3204,8 +3232,8 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
 dependencies = [
- "itoa",
- "libc 0.2.106",
+ "itoa 0.4.8",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -3225,15 +3253,14 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
- "autocfg",
  "bytes",
- "libc 0.2.106",
+ "libc 0.2.125",
  "memchr 2.4.1",
- "mio",
+ "mio 0.7.14",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -3245,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3296,7 +3323,7 @@ dependencies = [
  "postgres-types",
  "socket2",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -3325,6 +3352,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,11 +3389,12 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if",
+ "log 0.4.14",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3360,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3371,11 +3413,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -3522,6 +3565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3565,6 +3614,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3670,7 +3725,7 @@ checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
 dependencies = [
  "either",
  "lazy_static",
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -3723,10 +3778,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "177b1723986bcb4c606058e77f6e8614b51c7f9ad2face6f6fd63dd5c8b3cec3"
 dependencies = [
  "field-offset",
- "libc 0.2.106",
+ "libc 0.2.125",
  "widestring 0.4.3",
  "winapi",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"
@@ -3743,7 +3841,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
 ]
 
 [[package]]
@@ -3783,7 +3881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aad98a7a617d608cd9e1127147f630d24af07c7cd95ba1533246d96cbdd76c66"
 dependencies = [
  "bitflags 1.3.2",
- "libc 0.2.106",
+ "libc 0.2.125",
  "log 0.4.14",
  "zmq-sys",
 ]
@@ -3794,6 +3892,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d33a2c51dde24d5b451a2ed4b488266df221a5eaee2ee519933dc46b9a9b3648"
 dependencies = [
- "libc 0.2.106",
+ "libc 0.2.125",
  "metadeps",
 ]

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "*", features = ["v4"] }
 zmq = "*"
 
 [dependencies.actix-web]
-version = "4.0.0-beta.8"
+version = "4.0.1"
 default-features = false
 features = [ "openssl" ]
 

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "*", features = ["v4"] }
 zmq = "*"
 
 [dependencies.actix-web]
-version = "4.0.1"
+version = "*"
 default-features = false
 features = [ "openssl" ]
 

--- a/components/builder-api/src/server/authorize.rs
+++ b/components/builder-api/src/server/authorize.rs
@@ -14,7 +14,8 @@
 
 use std::str::FromStr;
 
-use actix_web::HttpRequest;
+use actix_web::{HttpMessage,
+                HttpRequest};
 
 use crate::{bldr_core::{access_token::BUILDER_ACCOUNT_ID,
                         metrics::CounterMetric,

--- a/components/builder-api/src/server/framework/middleware.rs
+++ b/components/builder-api/src/server/framework/middleware.rs
@@ -45,7 +45,7 @@ pub async fn route_message<R, T>(req: &HttpRequest, msg: &R) -> error::Result<T>
 // Optional Authentication - this middleware does not enforce authentication,
 // but will insert a Session if a valid Bearer token is received
 pub fn authentication_middleware<S>(
-    mut req: ServiceRequest,
+    req: ServiceRequest,
     srv: &S)
     -> impl Future<Output = Result<ServiceResponse<BoxBody>, Error>>
     where S: Service<ServiceRequest, Response = ServiceResponse<BoxBody>, Error = Error>

--- a/components/builder-api/src/server/framework/middleware.rs
+++ b/components/builder-api/src/server/framework/middleware.rs
@@ -10,13 +10,14 @@ use crate::{bldr_core::{access_token::{AccessToken,
                      helpers::req_state,
                      services::metrics::Counter,
                      AppState}};
-use actix_web::{dev::{Body,
-                      Service,
+use actix_web::{body::BoxBody,
+                dev::{Service,
                       ServiceRequest,
                       ServiceResponse},
                 http,
                 web::Data,
                 Error,
+                HttpMessage,
                 HttpRequest,
                 HttpResponse};
 use futures::future::{ok,
@@ -43,10 +44,11 @@ pub async fn route_message<R, T>(req: &HttpRequest, msg: &R) -> error::Result<T>
 
 // Optional Authentication - this middleware does not enforce authentication,
 // but will insert a Session if a valid Bearer token is received
-pub fn authentication_middleware<S>(mut req: ServiceRequest,
-                                    srv: &S)
-                                    -> impl Future<Output = Result<ServiceResponse<Body>, Error>>
-    where S: Service<ServiceRequest, Response = ServiceResponse<Body>, Error = Error>
+pub fn authentication_middleware<S>(
+    mut req: ServiceRequest,
+    srv: &S)
+    -> impl Future<Output = Result<ServiceResponse<BoxBody>, Error>>
+    where S: Service<ServiceRequest, Response = ServiceResponse<BoxBody>, Error = Error>
 {
     let hdr = match req.headers().get(http::header::AUTHORIZATION) {
         Some(hdr) => hdr.to_str().unwrap(), // unwrap Ok
@@ -68,9 +70,7 @@ pub fn authentication_middleware<S>(mut req: ServiceRequest,
         }
     };
 
-    req.head_mut()
-       .extensions_mut()
-       .insert::<originsrv::Session>(session);
+    req.extensions_mut().insert::<originsrv::Session>(session);
     Either::Left(srv.call(req))
 }
 

--- a/components/builder-api/src/server/resources/channels.rs
+++ b/components/builder-api/src/server/resources/channels.rs
@@ -99,10 +99,10 @@ impl Channels {
 // Route handlers - these functions can return any Responder trait
 //
 #[allow(clippy::needless_pass_by_value)]
-fn get_channels(path: Path<String>,
-                sandbox: Query<SandboxBool>,
-                state: Data<AppState>)
-                -> HttpResponse {
+async fn get_channels(path: Path<String>,
+                      sandbox: Query<SandboxBool>,
+                      state: Data<AppState>)
+                      -> HttpResponse {
     let origin = path.into_inner();
 
     let conn = match state.db.get_conn().map_err(Error::DbError) {
@@ -134,10 +134,10 @@ fn get_channels(path: Path<String>,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn create_channel(req: HttpRequest,
-                  path: Path<(String, String)>,
-                  state: Data<AppState>)
-                  -> HttpResponse {
+async fn create_channel(req: HttpRequest,
+                        path: Path<(String, String)>,
+                        state: Data<AppState>)
+                        -> HttpResponse {
     let (origin, channel) = path.into_inner();
 
     let session_id =
@@ -168,10 +168,10 @@ fn create_channel(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn delete_channel(req: HttpRequest,
-                  path: Path<(String, String)>,
-                  state: Data<AppState>)
-                  -> HttpResponse {
+async fn delete_channel(req: HttpRequest,
+                        path: Path<(String, String)>,
+                        state: Data<AppState>)
+                        -> HttpResponse {
     let (origin, channel) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 
@@ -202,11 +202,11 @@ fn delete_channel(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn promote_channel_packages(req: HttpRequest,
-                            path: Path<(String, String)>,
-                            state: Data<AppState>,
-                            to_channel: Query<ToChannel>)
-                            -> HttpResponse {
+async fn promote_channel_packages(req: HttpRequest,
+                                  path: Path<(String, String)>,
+                                  state: Data<AppState>,
+                                  to_channel: Query<ToChannel>)
+                                  -> HttpResponse {
     let (origin, channel) = path.into_inner();
 
     let session = match authorize_session(&req, Some(&origin), Some(OriginMemberRole::Maintainer)) {
@@ -256,11 +256,11 @@ fn promote_channel_packages(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn demote_channel_packages(req: HttpRequest,
-                           path: Path<(String, String)>,
-                           state: Data<AppState>,
-                           to_channel: Query<ToChannel>)
-                           -> HttpResponse {
+async fn demote_channel_packages(req: HttpRequest,
+                                 path: Path<(String, String)>,
+                                 state: Data<AppState>,
+                                 to_channel: Query<ToChannel>)
+                                 -> HttpResponse {
     let (origin, channel) = path.into_inner();
     let conn = match state.db.get_conn().map_err(Error::DbError) {
         Ok(conn_ref) => conn_ref,
@@ -459,11 +459,11 @@ async fn promote_package(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn demote_package(req: HttpRequest,
-                  path: Path<(String, String, String, String, String)>,
-                  qtarget: Query<Target>,
-                  state: Data<AppState>)
-                  -> HttpResponse {
+async fn demote_package(req: HttpRequest,
+                        path: Path<(String, String, String, String, String)>,
+                        qtarget: Query<Target>,
+                        state: Data<AppState>)
+                        -> HttpResponse {
     let (origin, channel, pkg, version, release) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 
@@ -537,10 +537,13 @@ fn demote_package(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_packages_for_origin_channel_package_version(req: HttpRequest,
-                                                   path: Path<(String, String, String, String)>,
-                                                   pagination: Query<Pagination>)
-                                                   -> HttpResponse {
+async fn get_packages_for_origin_channel_package_version(req: HttpRequest,
+                                                         path: Path<(String,
+                                                               String,
+                                                               String,
+                                                               String)>,
+                                                         pagination: Query<Pagination>)
+                                                         -> HttpResponse {
     let (origin, channel, pkg, version) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 
@@ -559,10 +562,10 @@ fn get_packages_for_origin_channel_package_version(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_packages_for_origin_channel_package(req: HttpRequest,
-                                           path: Path<(String, String, String)>,
-                                           pagination: Query<Pagination>)
-                                           -> HttpResponse {
+async fn get_packages_for_origin_channel_package(req: HttpRequest,
+                                                 path: Path<(String, String, String)>,
+                                                 pagination: Query<Pagination>)
+                                                 -> HttpResponse {
     let (origin, channel, pkg) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 
@@ -581,10 +584,10 @@ fn get_packages_for_origin_channel_package(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_packages_for_origin_channel(req: HttpRequest,
-                                   path: Path<(String, String)>,
-                                   pagination: Query<Pagination>)
-                                   -> HttpResponse {
+async fn get_packages_for_origin_channel(req: HttpRequest,
+                                         path: Path<(String, String)>,
+                                         pagination: Query<Pagination>)
+                                         -> HttpResponse {
     let (origin, channel) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 
@@ -604,10 +607,10 @@ fn get_packages_for_origin_channel(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_latest_package_for_origin_channel_package(req: HttpRequest,
-                                                 path: Path<(String, String, String)>,
-                                                 qtarget: Query<Target>)
-                                                 -> HttpResponse {
+async fn get_latest_package_for_origin_channel_package(req: HttpRequest,
+                                                       path: Path<(String, String, String)>,
+                                                       qtarget: Query<Target>)
+                                                       -> HttpResponse {
     let (origin, channel, pkg) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 
@@ -630,13 +633,13 @@ fn get_latest_package_for_origin_channel_package(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_latest_package_for_origin_channel_package_version(req: HttpRequest,
-                                                         path: Path<(String,
-                                                               String,
-                                                               String,
-                                                               String)>,
-                                                         qtarget: Query<Target>)
-                                                         -> HttpResponse {
+async fn get_latest_package_for_origin_channel_package_version(req: HttpRequest,
+                                                               path: Path<(String,
+                                                                     String,
+                                                                     String,
+                                                                     String)>,
+                                                               qtarget: Query<Target>)
+                                                               -> HttpResponse {
     let (origin, channel, pkg, version) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 
@@ -659,10 +662,10 @@ fn get_latest_package_for_origin_channel_package_version(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_package_fully_qualified(req: HttpRequest,
-                               path: Path<(String, String, String, String, String)>,
-                               qtarget: Query<Target>)
-                               -> HttpResponse {
+async fn get_package_fully_qualified(req: HttpRequest,
+                                     path: Path<(String, String, String, String, String)>,
+                                     qtarget: Query<Target>)
+                                     -> HttpResponse {
     let (origin, channel, pkg, version, release) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 
@@ -685,10 +688,10 @@ fn get_package_fully_qualified(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_latest_packages_for_origin_channel(req: HttpRequest,
-                                          path: Path<(String, String)>,
-                                          qtarget: Query<Target>)
-                                          -> HttpResponse {
+async fn get_latest_packages_for_origin_channel(req: HttpRequest,
+                                                path: Path<(String, String)>,
+                                                qtarget: Query<Target>)
+                                                -> HttpResponse {
     let (origin, channel) = path.into_inner();
     let channel = ChannelIdent::from(channel);
 

--- a/components/builder-api/src/server/resources/jobs.rs
+++ b/components/builder-api/src/server/resources/jobs.rs
@@ -268,7 +268,7 @@ fn filtered_group_rdeps(req: &HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_job(req: HttpRequest, path: Path<String>) -> HttpResponse {
+async fn get_job(req: HttpRequest, path: Path<String>) -> HttpResponse {
     let id_str = path.into_inner();
 
     let job_id = match id_str.parse::<u64>() {

--- a/components/builder-api/src/server/resources/profile.rs
+++ b/components/builder-api/src/server/resources/profile.rs
@@ -14,6 +14,7 @@ use actix_web::{http::{self,
                       Json,
                       Path,
                       ServiceConfig},
+                HttpMessage,
                 HttpRequest,
                 HttpResponse};
 use bldr_core::access_token::AccessToken as CoreAccessToken;
@@ -50,7 +51,7 @@ pub fn do_get_access_tokens(req: &HttpRequest, account_id: u64) -> Result<Vec<Ac
 // Route handlers - these functions can return any Responder trait
 //
 #[allow(clippy::needless_pass_by_value)]
-fn get_account(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
+async fn get_account(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
     let account_id = match authorize_session(&req, None, None) {
         Ok(session) => session.get_id() as i64,
         Err(_err) => return HttpResponse::new(StatusCode::UNAUTHORIZED),
@@ -71,7 +72,7 @@ fn get_account(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_access_tokens(req: HttpRequest) -> HttpResponse {
+async fn get_access_tokens(req: HttpRequest) -> HttpResponse {
     let account_id = match authorize_session(&req, None, None) {
         Ok(session) => session.get_id(),
         Err(err) => return err.into(),
@@ -94,7 +95,7 @@ fn get_access_tokens(req: HttpRequest) -> HttpResponse {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn generate_access_token(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
+async fn generate_access_token(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
     let account_id = match authorize_session(&req, None, None) {
         Ok(session) => session.get_id(),
         Err(err) => return err.into(),
@@ -149,10 +150,10 @@ fn generate_access_token(req: HttpRequest, state: Data<AppState>) -> HttpRespons
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn revoke_access_token(req: HttpRequest,
-                       path: Path<String>,
-                       state: Data<AppState>)
-                       -> HttpResponse {
+async fn revoke_access_token(req: HttpRequest,
+                             path: Path<String>,
+                             state: Data<AppState>)
+                             -> HttpResponse {
     let token_id_str = path.into_inner();
     let token_id = match token_id_str.parse::<u64>() {
         Ok(id) => id,
@@ -193,10 +194,10 @@ fn revoke_access_token(req: HttpRequest,
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn update_account(req: HttpRequest,
-                  body: Json<UserUpdateReq>,
-                  state: Data<AppState>)
-                  -> HttpResponse {
+async fn update_account(req: HttpRequest,
+                        body: Json<UserUpdateReq>,
+                        state: Data<AppState>)
+                        -> HttpResponse {
     let account_id = match authorize_session(&req, None, None) {
         Ok(session) => session.get_id(),
         Err(_err) => return HttpResponse::new(StatusCode::UNAUTHORIZED),

--- a/components/builder-api/src/server/resources/user.rs
+++ b/components/builder-api/src/server/resources/user.rs
@@ -39,7 +39,7 @@ impl User {
 // Route handlers - these functions can return any Responder trait
 //
 #[allow(clippy::needless_pass_by_value)]
-fn get_invitations(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
+async fn get_invitations(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
     let account_id = match authorize_session(&req, None, None) {
         Ok(session) => session.get_id(),
         Err(err) => return err.into(),
@@ -60,7 +60,7 @@ fn get_invitations(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn get_origins(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
+async fn get_origins(req: HttpRequest, state: Data<AppState>) -> HttpResponse {
     let account_id = match authorize_session(&req, None, None) {
         Ok(session) => session.get_id() as i64,
         Err(err) => return err.into(),

--- a/components/builder-core/src/access_token.rs
+++ b/components/builder-core/src/access_token.rs
@@ -427,7 +427,7 @@ mod tests {
             //
             // This is the best we can do with `std::str::FromStr`, though.
             let encrypted: SignedBox = key.encrypt("supersecretstuff");
-            let b64 = base64::encode(encrypted.to_string());
+            let b64 = base64::encode(&encrypted.to_string());
             let token = format!("_{}", b64);
             let parsed = token.parse::<AccessToken>();
             assert!(parsed.is_ok(), "It should parse because it's encrypted");

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -55,7 +55,7 @@ tracing-futures = "*"
 zmq = "*"
 
 [dependencies.actix-web]
-version = "4.0.0-beta.8"
+version = "4.0.1"
 default-features = false
 
 [dependencies.clap]

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -55,7 +55,7 @@ tracing-futures = "*"
 zmq = "*"
 
 [dependencies.actix-web]
-version = "4.0.1"
+version = "*"
 default-features = false
 
 [dependencies.clap]


### PR DESCRIPTION
This PR updates the actix-web crate to the latest (4.0.1).

Below are the steps followed to update the crate:

- Update actix-web to 4.0.1 in Cargo.toml (builder-api, and builder-jobsrv)
- run **cargo update -p actix-web**
- Manually update the crate versions in the package section of Cargo.lock (This might happen when the update command moves the crates to a lower version)
- Address the API/other breaking changes one after the other.

Tips:

1. Observe the failed crates, and check the crate versions in Cargo.lock to fix them. For example, for the error below, we need to check the package section with the name **habitat_builder_api**.
Caused by:
  process didn't exit successfully: `rustc --crate-name habitat_builder_api --ed