### PR TITLE
Fix activating 'Build Jobs' on package page

### DIFF
--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -19,6 +19,7 @@
     <a
       mat-tab-link
       routerLink="./"
+      [routerLinkActiveOptions]="{exact: true}"
       routerLinkActive
       #versions="routerLinkActive"
       [active]="versions.isActive">


### PR DESCRIPTION
If we navigate to the 'Build Jobs' or 'Settings' page on the package page, the corresponding tab is not active. This change will fix the tab activation.

This 'routerLinkActiveOptions' was removed for the versions tab to be active even after selecting a particular version from the list. The same is true for Build Jobs.

We will investigate how to handle the child's routes to be active later.

Signed-off-by: Phani Sajja <psajja@progress.com>