### PR TITLE
Fix copy to clipboard functionality

### DIFF
--- a/components/builder-web/app/package/package-versions/package-versions.component.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.ts
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { fromJS }  from 'immutable';
+
 import { AppStore } from '../../app.store';
 import { packageString, parseDate, targetsFromPkgVersions } from '../../util';
 import { demotePackage, filterPackagesBy } from '../../actions/index';
 
 @Component({
-  template: require('./package-versions.component.html')
+  template: require('./package-versions.component.html'),
+  changeDetection: ChangeDetectionStrategy.Default
 })
 export class PackageVersionsComponent implements OnDestroy {
   origin: string;
@@ -144,14 +147,7 @@ export class PackageVersionsComponent implements OnDestroy {
           // Check the expanded list includes the current platform
           // This happens when there are two version nodes with separate platforms
           if (version.platforms.includes(platform)) {
-            pkgs.push({
-              origin: pkg.origin,
-              name: pkg.name,
-              version: pkg.version,
-              release: pkg.release,
-              channels: pkg.channels,
-              platforms: [platform]
-            });
+            pkgs.push(pkg);
           }
         });
       });

--- a/components/builder-web/app/package/package-versions/package-versions.component.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.ts
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { fromJS }  from 'immutable';
 
 import { AppStore } from '../../app.store';
 import { packageString, parseDate, targetsFromPkgVersions } from '../../util';
@@ -25,7 +24,6 @@ import { demotePackage, filterPackagesBy } from '../../actions/index';
 
 @Component({
   template: require('./package-versions.component.html'),
-  changeDetection: ChangeDetectionStrategy.Default
 })
 export class PackageVersionsComponent implements OnDestroy {
   origin: string;


### PR DESCRIPTION
The logic has a flaw in computing the expanded nodes. We are creating a list with new objects each time, and this keeps on updating the version nodes on hover. It prevents the other functionality to not working.

We should reuse the pkg object rather than create a new one each time a rerender is required.

Signed-off-by: Phani Sajja <psajja@progress.com>