### PR TITLE
allow an Access-Control-Allow-Origin header to be set for certain oauth providers like automate

### DIFF
--- a/components/builder-api-proxy/habitat/config/nginx.conf
+++ b/components/builder-api-proxy/habitat/config/nginx.conf
@@ -148,6 +148,29 @@ http {
     {{~/if}}
     error_log {{pkg.svc_path}}/logs/host.error.log error;
 
+    {{~#if cfg.nginx.allow_oauth_origin}}
+    location / {
+      # First attempt to serve request as file, then
+      # as directory, then fall back to displaying a 404.
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' '{{cfg.nginx.allow_oauth_origin}}';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        #
+        # Custom headers and headers various browsers *should* be OK with but aren't
+        #
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,skip';
+        #
+        # Tell client that this pre-flight info is valid for 20 days
+        #
+        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Content-Type' 'text/plain; charset=utf-8';
+        add_header 'Content-Length' 0;
+        return 204;
+      }
+      try_files $uri $uri/ /index.html;
+    }
+    {{~/if}}
+
     location = /health {
       return 200;
       access_log off;
@@ -168,6 +191,9 @@ http {
 
     location /index.html {
       add_header Cache-Control "private, no-cache, no-store";
+      {{~#if cfg.nginx.allow_oauth_origin}}
+      add_header 'Access-Control-Allow-Origin' '{{cfg.nginx.allow_oauth_origin}}' always;
+      {{~/if}}
       root {{pkg.svc_config_path}};
       break;
     }


### PR DESCRIPTION
This is really to compensate for recent changes in the automate oauth flow. If using a modern automate for oauth, the CORS headers need to be set. This introduces a new config setting: `allow_oauth_origin`. If a user is using automate as an oauth provider, they can set this setting to the domain of their automate server: `https://my.automate.server.com`.

We will update the `install.sh` of the on-prem builder to do this automatically.

Signed-off-by: Matt Wrock <matt@mattwrock.com>