### PR TITLE
CHEF-6081: Added production version of OneTrust script.

### DIFF
--- a/components/builder-api-proxy/habitat/config/index.html
+++ b/components/builder-api-proxy/habitat/config/index.html
@@ -28,7 +28,7 @@
         })();
       </script>
       <!-- OneTrust Cookies Consent Notice start for bldr.habitat.sh -->
-      <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" onerror="oneTrustHelper.gtmFallback()"  type="text/javascript" charset="UTF-8" data-domain-script="56349530-b58d-4008-8d3b-f953100c27d3-test" ></script>
+      <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" onerror="oneTrustHelper.gtmFallback()" data-language="en" type="text/javascript" charset="UTF-8" data-domain-script="56349530-b58d-4008-8d3b-f953100c27d3" ></script>
       <script type="text/javascript">
         function OptanonWrapper() { }
       </script>


### PR DESCRIPTION
Added the production version of One Trust script in deployment file(components/builder-api-proxy/habitat/config/index.html). Have used the same parameter 'cfg.hosted' to load One Trust and GTM tags, if its set, so that these scripts are only run if it is a SAS deployment.

We will need to host these changes in our acceptance environment ( https://bldr.acceptance.habitat.sh/#/pkgs/core ) and share it with relevant stakeholders for testing. Once the testing is completed, we can do the deployment in the production environment.

https://chefio.atlassian.net/browse/CHEF-6081

PS: I was not able to test the deployment file changes on local.

<img width="1792" alt="Screenshot 2023-12-06 at 7 46 17 PM" src="https://github.com/habitat-sh/builder/assets/108087313/9c096c03-4585-4e65-b94c-caca6e58188f">
<img width="1792" alt="Screenshot 2023-12-06 at 7 46 09 PM" src="https://github.com/habitat-sh/builder/assets/108087313/97422280-39bb-4a38-98ea-15d7bb2da151">

