### PR TITLE
remove phantomjs

### DIFF
--- a/components/builder-api-proxy/habitat/plan.sh
+++ b/components/builder-api-proxy/habitat/plan.sh
@@ -11,7 +11,6 @@ pkg_build_deps=(
   core/gcc
   core/git
   core/tar
-  core/phantomjs
   core/python2
   core/make
 )


### PR DESCRIPTION
Removed the unneeded package `phantomjs` from build dependencies.