### PR TITLE
Fixes adhoc workflow

### DIFF
--- a/.github/actions/hab-pkg-build-and-upload-linux/action.yaml
+++ b/.github/actions/hab-pkg-build-and-upload-linux/action.yaml
@@ -16,6 +16,7 @@ runs:
       env:
         BLDR_COMPONENT: ${{ inputs.bldr-component }}
         HAB_BLDR_CHANNEL: LTS-2024
+        HAB_REFRESH_CHANNEL: LTS-2024
         HAB_FALLBACK_CHANNEL: LTS-2024
       run: |
         hab pkg build $BLDR_COMPONENT


### PR DESCRIPTION
Set the HAB_REFRESH_CHANNEL to LTS-2024 to fix the failing workflow.