### PR TITLE
include quotes in config

### DIFF
--- a/components/builder-api-proxy/habitat/config/habitat.conf.js
+++ b/components/builder-api-proxy/habitat/config/habitat.conf.js
@@ -28,5 +28,5 @@ habitatConfig({
     enable_builder_events: {{ cfg.enable_builder_events }},
     enable_builder_events_saas: {{ cfg.enable_builder_events_saas }},
     enable_base: {{ cfg.enable_base }},
-    latest_base_default_channel: {{ cfg.latest_base_default_channel }},
+    latest_base_default_channel: "{{ cfg.latest_base_default_channel }}",
 });


### PR DESCRIPTION
The rendered JSON has an error because the channel name is not included in quotes.