### PR TITLE
Address Markdown lint errors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,11 +1,13 @@
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
+
 Diversity is one of the greatest strengths a community can have and many times that strength is born from the friction that can only come through sharing of differing perspectives.
 
 In the interest of fostering an open, welcoming, and encouraging environment, we as contributors, maintainers, and community members pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
+
 Habitat is a diverse community of professionals and volunteers who come from all over the world to make Habitat better. Community members may fulfill many roles including mentoring, teaching, and connecting with other members of the community.
 
 Be careful in the words that you choose. Be kind to others. Practice empathy. Don't insult or put down others. Remember that sexist, racist, ableist and other exclusionary jokes can be offensive to those around you. If you think your conversation is making another community member uncomfortable _or_ if they tell you so, stop immediately, make amends, and move forward.
@@ -13,6 +15,7 @@ Be careful in the words that you choose. Be kind to others. Practice empathy. Do
 As you are working with other members of the community, please keep in mind the following guidelines, which apply equally to founders, mentors, those who submit new features and pull requests, and to anyone who is seeking help and guidance.
 
 The following list isn’t exhaustive; but these few examples can help all of us communicate well so that the community can work better together:
+
 * Use welcoming and inclusive language
 * Exercise patience and friendliness
 * Be respectful of differing viewpoints and experiences
@@ -23,48 +26,54 @@ The following list isn’t exhaustive; but these few examples can help all of us
 The previous list applies to all forms of communication: Slack (or any web chat), discourse, the issue tracker, and any other forum that is used by the community.
 
 Please keep in mind that:
-  * Your work will be used by other people, and you, in turn, will depend on the work of others.
-  * Decisions that you make will often affect others in the community.
-  * Disagreements happen, but should not be an excuse for poor behavior and bad manners. When disagreements do happen, let’s work together to solve them effectively and in a way that ensures that everyone understands what the disagreement was.
-  * Our community spans languages, cultures, perspectives (and continents!), and as such people may not understand jokes, sarcasm, and oblique references in the same way that you do. So remember that and be kind to the other members of the community.
-  * Sexist, racist, ableist and other prejudicial or exclusionary comments are not welcome in the community.
+
+* Your work will be used by other people, and you, in turn, will depend on the work of others.
+* Decisions that you make will often affect others in the community.
+* Disagreements happen, but should not be an excuse for poor behavior and bad manners. When disagreements do happen, let’s work together to solve them effectively and in a way that ensures that everyone understands what the disagreement was.
+* Our community spans languages, cultures, perspectives (and continents!), and as such people may not understand jokes, sarcasm, and oblique references in the same way that you do. So remember that and be kind to the other members of the community.
+* Sexist, racist, ableist and other prejudicial or exclusionary comments are not welcome in the community.
 
 ## Unacceptable Behavior
+
 Harassment comes in many forms, including but not limited to: offensive verbal or written comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, and sexual images.
 
 As a community that meets in physical public spaces, harassment also includes: stalking, persistent following, intrusive or otherwise unwanted photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
 
 Examples of other unacceptable behaviors by participants include but are not limited to:
-  * The use of sexualized language or imagery and unwelcome sexual attention or
-advances.
-  * Threats or violent language directed against another person.
-  * Posting sexually explicit or violent material.
-  * Sexist, racist, homophobic, transphobic, ableist, or otherwise discriminatory jokes and language.
-  * Trolling, insulting/derogatory comments, and personal or political attacks particulary those related to gender, sexual orientation, race, religion or disability.
-  * Public or private harassment.
-  * Publishing others' private information, such as a physical or electronic address, without explicit permission ("doxing")
-  * Other conduct which could reasonably be considered inappropriate in a professional setting
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances.
+* Threats or violent language directed against another person.
+* Posting sexually explicit or violent material.
+* Sexist, racist, homophobic, transphobic, ableist, or otherwise discriminatory jokes and language.
+* Trolling, insulting/derogatory comments, and personal or political attacks particulary those related to gender, sexual orientation, race, religion or disability.
+* Public or private harassment.
+* Publishing others' private information, such as a physical or electronic address, without explicit permission ("doxing")
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
 If you have any lack of clarity about behaviors we include in the definition of "harassment", please read the [Citizen Code of Conduct](http://citizencodeofconduct.org/). In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
 
 ## Enforcement/Getting Help
+
 Instances of abusive, harassing, or otherwise unacceptable should be reported by contacting any of the Community Advocates or the Community Manager directly. Each person's contact information and role is listed below. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Community Organizers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
 ## Roles
-The following are the various roles of our <b>Community Organizers</b> and the person(s) assigned to each role:
-  * The <b>Decider</b> has final say on community guidelines and final authority on correct actions and appeals. The top-level decider is [Adam Jacob](mailto:adam@habitat.sh), [@adamhjk](https://twitter.com/adamhjk)
-  * The <b>Community Manager</b> guides and meets regularly with community advocates, helps enforce corrective actions, hears appeals, is responsible for maintaining a list of incidents, and ensures incident responders have support in incident documentation as outlined below. The Community Manager is [Ian Henry](mailto:ian@habitat.sh), [@eeyun___](https://twitter.com/eeyun___).
-  * <b>Community Advocates</b> may be assigned for each area where the community convenes online (IRC, email list, GitHub, etc.). Community Advocates are volunteers who have the best interests of our community in mind. They act in good faith to help enforce our community guidelines and respond to incidents when they occur. Our Community Advocates are
-    - [Tasha Drew](mailto:tasha@habitat.sh), [@tashadrew](https://twitter.com/tashadrew)
-    - [Nell Shamrell-Harrington](mailto:nshamrell@habitat.sh), [@nellshamrell](https://twitter.com/nellshamrell)
-    - [Ben Dang](mailto:me@bdang.it), [@bdangit](https://twitter.com/bdangit)
-  * The <b>Project Maintainers</b> are likewise expected to conduct their behavior in line with the Code of Conduct and are individually responsible for both escalating to a <b>Community Advocate</b> in case of witnessing an incident and helping to foster the community and it's members.
-  * A <b>Community Member</b> is anyone who participates with the community whether in-person or via online channels. Community members are responsible for following the community guidelines, suggesting updates to the guidelines when warranted, and helping enforce community guidelines.
+
+The following are the various roles of our **Community Organizers** and the person(s) assigned to each role:
+
+* The **Decider** has final say on community guidelines and final authority on correct actions and appeals. The top-level decider is [Adam Jacob](mailto:adam@habitat.sh), [@adamhjk](https://twitter.com/adamhjk)
+* The **Community Manager** guides and meets regularly with community advocates, helps enforce corrective actions, hears appeals, is responsible for maintaining a list of incidents, and ensures incident responders have support in incident documentation as outlined below. The Community Manager is [Ian Henry](mailto:ian@habitat.sh), [@eeyun___](https://twitter.com/eeyun___).
+* **Community Advocates** may be assigned for each area where the community convenes online (IRC, email list, GitHub, etc.). Community Advocates are volunteers who have the best interests of our community in mind. They act in good faith to help enforce our community guidelines and respond to incidents when they occur. Our Community Advocates are
+  * [Tasha Drew](mailto:tasha@habitat.sh), [@tashadrew](https://twitter.com/tashadrew)
+  * [Nell Shamrell-Harrington](mailto:nshamrell@habitat.sh), [@nellshamrell](https://twitter.com/nellshamrell)
+  * [Ben Dang](mailto:me@bdang.it), [@bdangit](https://twitter.com/bdangit)
+* The **Project Maintainers** are likewise expected to conduct their behavior in line with the Code of Conduct and are individually responsible for both escalating to a **Community Advocate** in case of witnessing an incident and helping to foster the community and it's members.
+* A **Community Member** is anyone who participates with the community whether in-person or via online channels. Community members are responsible for following the community guidelines, suggesting updates to the guidelines when warranted, and helping enforce community guidelines.
 
 ## Consequences of Unacceptable Behavior
-Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will *not* be tolerated.
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will _not_ be tolerated.
 
 Anyone asked to stop unacceptable behavior is expected to comply immediately.
 
@@ -73,6 +82,7 @@ If a community member engages in unacceptable behavior, the community organizers
 Any physical violence _or_ intimidation, threatened or acted on, is a serious offense and will result in immediate exclusion from the community and appropriate follow up with law enforcement (no, we're not kidding).
 
 ## Procedure for Handling Disagreements and Incidents
+
 Disagreements are inherent to a group of impassioned people. When they occur, we seek to resolve disagreements and differing views constructively and with the help of the community and community processes. When disagreements escalate, we ask our community advocates to step in to moderate, mediate, and help resolve tense situations.
 
 The Habitat Community advocates are well informed on how to deal with incidents. Report the incident (preferably in writing) to one of the community advocates listed above. See the "Roles" section for details on each role.
@@ -81,35 +91,35 @@ The Habitat Community advocates are well informed on how to deal with incidents.
 
 When a Community Organizer or Project Maintainer notices someone behaving in a way that is outside of our guidelines (a violator) the Advocate should make every reasonable attempt to help curtail that behavior.  The Advocate may:
 
-  * Remind the violator about our Community Code of Conduct and provide a link to this document.
-  * Ask the violator to stop the unacceptable behavior.
-  * Raise the issue with a maintainer, the community manager, or any member of the core project team.
-  * Allow time for the violator to correct the behavior.
+* Remind the violator about our Community Code of Conduct and provide a link to this document.
+* Ask the violator to stop the unacceptable behavior.
+* Raise the issue with a maintainer, the community manager, or any member of the core project team.
+* Allow time for the violator to correct the behavior.
 
 The Advocate should take the following steps if the behavior is not brought inline with our guidelines or the incident is not resolved.
 
-  * Consult with another Community Organizer to make a judgement call about what reasonable corrective actions are warranted.
-  * In the case that no conclusion can be made, escalate to include the next level of Community Organizer
-  * If still no conclusion can be made, report the incident to the <b>Decider</b> listed above.
-  * Apply the corrective action.
-  * Document the incident as described below.
+* Consult with another Community Organizer to make a judgement call about what reasonable corrective actions are warranted.
+* In the case that no conclusion can be made, escalate to include the next level of Community Organizer
+* If still no conclusion can be made, report the incident to the **Decider** listed above.
+* Apply the corrective action.
+* Document the incident as described below.
 
 #### Documenting Incidents
-All incident reports will be kept in a private repository that is shared with the aforementioned Community Advocates, Community Manager and Decider under the *Roles* section. No other individuals or project contributors will be given access to these incident reports. <b>This repo will hold no personal information on the victim of an incident</b>. On the displacement of any Community Organizer in the *Roles* list above, that individual will immediately lose access to this repository and will terminate any local copies of the repository.
+
+All incident reports will be kept in a private repository that is shared with the aforementioned Community Advocates, Community Manager and Decider under the _Roles_ section. No other individuals or project contributors will be given access to these incident reports. **This repo will hold no personal information on the victim of an incident**. On the displacement of any Community Organizer in the _Roles_ list above, that individual will immediately lose access to this repository and will terminate any local copies of the repository.
 
 The important information to report consists of:
 
-  * Identifying information (name, email address, Slack nick, etc.) of the person doing the harassing
-  * The behavior that was in violation
-  * The approximate time of the behavior
-  * The circumstances surrounding the incident
-  * Where applicaple, contextual information/proof (email body, chat log, GH Issue)
-  * Contact information for witnesses to the incident
+* Identifying information (name, email address, Slack nick, etc.) of the person doing the harassing
+* The behavior that was in violation
+* The approximate time of the behavior
+* The circumstances surrounding the incident
+* Where applicaple, contextual information/proof (email body, chat log, GH Issue)
+* Contact information for witnesses to the incident
 
 If you feel your safety is in jeopardy please do not hesitate to contact local law enforcement.
 
 **Note**: Incidents that violate the Community Code of Conduct are extremely damaging to the community. The silver lining is that, in many cases, these incidents present a chance for the community as a whole to grow, learn, and become better.
-
 
 ## Our Responsibilities
 
@@ -118,6 +128,7 @@ Community Organizers are responsible for clarifying the standards of acceptable 
 Community Organizers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, messages, tweets and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
+
 Our community will convene in both physical and virtual spaces and this Code of Conduct applies within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers and community organizers.
 
 ## Attribution

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -15,9 +15,9 @@ In order to run Builder on MacOS, it required that the builder services run in a
 To configure multipass to work for our standalone Builder, we need to ensure we can forward content from our MacOS workstation to the builder instance running in the multipass VM.  
 In order to do that, use these steps to enable NAT forwarding:
 
-1)  Add the following line to the file /etc/pf.conf  
+1) Add the following line to the file /etc/pf.conf  
     `nat on utun1 from bridge100:network to any -> (utun1)`  
-2)  Save the file and run the following command  
+2) Save the file and run the following command  
     `sudo pfctl -f /etc/pf.conf`  
 
 In addition, if running Builder UI, we will need to ensure port 9636 is forwarded to your VM.  Add these entries to /etc/pf.anchors/com.apple to enable port forwarding for builder:
@@ -26,7 +26,7 @@ In addition, if running Builder UI, we will need to ensure port 9636 is forwarde
 
 `rdr pass on en0 inet proto tcp from any to self port 9636 -> <YOUR VM IP ADDRESS> 9636`
 
-If using wireless connection, the network value in the second line is likely en0.  Check by running ifconfig at the terminal and update this value if necessary. 
+If using wireless connection, the network value in the second line is likely en0.  Check by running ifconfig at the terminal and update this value if necessary.
 
 Multipass assigns a static IP address for you when you create a virtual machine.  It can be found by running `multipass list`
 from a MacOS terminal under the IPv4 column, noting that the instance must be running (`multipass start <VM instance>`).  For convenience, adding a line to /etc/hosts will enable referring to this VM by its name rather than its IP address:
@@ -36,9 +36,10 @@ from a MacOS terminal under the IPv4 column, noting that the instance must be ru
 NOTE:  If you are doing active Web UI development, then you will likely want to run the UI on your Host (Mac OS). If so, there are some extra steps and configuration changes that will be needed, and those are called out below. See the [Web UI README](https://github.com/habitat-sh/builder/blob/master/components/builder-web/README.md) for more info.  As port forwarding is required to run in this setup, you will need to ensure that the Builder API port (9636) is forwarded from your VM to your host.
 
 ## Builder Status Check
+
 You can test the API port access from your Host OS after starting Builder services (steps below) by issuing the following from the command line:
 
-```
+```shell
 curl -v http://localhost:9636/v1/status
 ```
 
@@ -60,9 +61,10 @@ Before you can successfully build, you need to provision the OS with some basic 
 The sections below will walk through the steps for getting the source and configuration ready.
 
 ### Builder repo clone
+
 Select a location to clone the Builder repo on your Linux VM, eg, `~/Workspace` (this directory will be referred to as ${BUILDER_SRC_ROOT} in the sections below)
 
-```
+```shell
 cd ${BUILDER_SRC_ROOT}
 git clone https://github.com/habitat-sh/builder.git
 ```
@@ -88,7 +90,7 @@ However, if you are going to be doing Web UI development, and running the Web UI
 
 ### Builder configuration
 
-1. Copy the GitHub application private key (from section above) to the following location (_Important: name it exactly as shown_) `${BUILDER_SRC_ROOT}/.secrets/builder-github-app.pem`
+1. Copy the GitHub application private key (from section above) to the following location (*Important: name it exactly as shown*) `${BUILDER_SRC_ROOT}/.secrets/builder-github-app.pem`
 1. Make a copy of the sample env file: `cp ${BUILDER_SRC_ROOT}/.secrets/habitat-env.sample ${BUILDER_SRC_ROOT}/.secrets/habitat-env`
 1. Edit the env file with your favorite editor `${BUILDER_SRC_ROOT}/.secrets/habitat-env` and populate the variables appropriately
 1. Save and close the env file
@@ -96,6 +98,7 @@ However, if you are going to be doing Web UI development, and running the Web UI
 ## Builder Services Setup
 
 ### Starting Builder services
+
 Once the Builder Repo is configured, Builder services can be started inside the Habitat Studio.
 
 * `cd ${BUILDER_SRC_ROOT}`
@@ -128,7 +131,6 @@ If there are recent UI changes not yet promoted to stable that you wish to try o
 
 In the event that you *ARE* developing the UI then you will need to follow the instructions in the [Web UI README](https://github.com/habitat-sh/builder/blob/master/components/builder-web/README.md) to get the Web UI running on your Host OS.
 
-
 ### Personal Access Token generation
 
 Once the Builder services are up, you should generate a Personal Access Token. Currently, this can only be done via the Web UI.
@@ -158,20 +160,20 @@ In order to do package builds locally, at a minimum you will need to seed the yo
 
 From within your Studio, do the following (for example, using the 0.64.1 version of hab-backline):
 
-```
+```shell
 load_package /hab/cache/artifacts/core-hab-backline-0.64.1-20180928012546-x86_64-linux.hart
 ```
 
-Alternatively, you can use the `on-prem-archive.sh` script from the on-prem repo to do the initial hydration (and sync) of base packages - see the [Synchronizing Packages](#Synchronizing_Packages) section below.
+Alternatively, you can use the `on-prem-archive.sh` script from the on-prem repo to do the initial hydration (and sync) of base packages - see the [Synchronizing Packages](#synchronizing-packages) section below.
 
 ### Plan file connection
 
 Currently, connecting a plan file is only available from within the Web UI.
 
 1. Go the Builder Web UI
-2. Click on _My Origins_, and then select your origin
-3. Click on the _Connect a plan file_ button
-4. Click on the _Install Github App_ button to install the Builder Dev app on your github account
+2. Click on *My Origins*, and then select your origin
+3. Click on the *Connect a plan file* button
+4. Click on the *Install Github App* button to install the Builder Dev app on your github account
 5. Go back to the Packages page (from Step 3), and follow the instructions to link the plan you want to build
 
 Note: your GitHub app must have access to the repo containing the plan file you are testing. Forking `habitat-sh/core-plans` is an easy way to test, or feel free to create your own repo with a test plan.
@@ -181,6 +183,7 @@ Note: your GitHub app must have access to the repo containing the plan file you 
 You can test that the plan file you just connected actually builds by issuing a build command. You can do that either via the Builder Web UI, or via the `hab` cli.
 
 ### Option A: From the Web UI
+
 * Navigate to http://${APP_HOSTNAME}/#/pkgs
 * If you are not already logged in, log in.
 * Click on "My origins"
@@ -195,7 +198,7 @@ You can test that the plan file you just connected actually builds by issuing a 
 
 Issue the following command (replace `origin/package` with your origin and package names):
 
-```
+```shell
 hab bldr job start origin/package
 ```
 
@@ -213,7 +216,7 @@ Before building Builder you must ensure that your Personal Access Token is set t
 
 If the `HAB_AUTH_TOKEN` is not set correctly, you will likely see an error similar to the following when trying to build.
 
-```
+```shell
 Unloading builder-api
 Unloading habitat/builder-api
    : Loading /src/components/builder-api/habitat-dev/plan.sh
@@ -265,20 +268,23 @@ In some scenarios, it's valuable to test against `core` packages that haven't be
 
 #### Build Habitat components
 
-First, you will need to clone https://github.com/habitat-sh/habitat and build a subset of the components. It is important they are built in the correct order so that dependencies are correct at install time. You can use the below snippet to build them, replacing the channel as necessary.
-```
+First, you will need to clone <https://github.com/habitat-sh/habitat> and build a subset of the components. It is important they are built in the correct order so that dependencies are correct at install time. You can use the below snippet to build them, replacing the channel as necessary.
+
+```shell
 git clone https://github.com/habitat-sh/habitat
 cd habitat
 env HAB_BLDR_CHANNEL=stable HAB_ORIGIN=core hab studio run "for component in hab plan-build backline studio pkg-export-docker; do build components/\$component; done"
 ```
 
 Next, copy the hart files produced to the `results` directory in your copy of the Builder repository. Assuming your `habitat` and `builder` checkout share the same parent directory:
-```
+
+```shell
 cp habitat/results/core-hab*.hart builder/results/
 ```
 
 Next, you will need to enter the studio inside the builder directory, install the Habitat harts, and rebuild Builder against them. Once this is complete, you can follow the testing instructions detailed in [the testing readme](test/builder-api/README.md). It is safe to skip the `build-builder` step in that document.  You can also use the `test-builder` helper function, shown below.
-```
+
+```shell
 hab studio enter
 hab pkg install results/core-hab*.hart
 for component in builder-api builder-api-proxy builder-datastore builder-graph builder-jobsrv builder-minio builder-worker; do
@@ -296,7 +302,7 @@ Some services like builder-api and builder-jobsrv send statsd metrics. These are
 
 The below assumes node and npm is already installed and available.
 
-```
+```shell
 npm install -g statsd-logger
 statsd-logger
 ```

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,6 @@ Please review the Project Members section in the link above for details on how t
 
 ---
 
-# Maintainers
+## Maintainers
 
 Please refer to the [Habitat Project](https://github.com/chef/chef-oss-practices/blob/master/projects/habitat.md) for the up-to-date list of owners, approvers and reviewers.

--- a/ON_CALL.md
+++ b/ON_CALL.md
@@ -1,1 +1,3 @@
+# On Call Instructions
+
 For the latest On Call instructions, please see [On Call Engineering Duties](https://github.com/habitat-sh/habitat/wiki/On-Call-Engineering-Duties) in the Habitat Wiki.

--- a/components/builder-web/README.md
+++ b/components/builder-web/README.md
@@ -22,7 +22,7 @@ You will need the Github app id and client id for configuration below.  Your Git
 
 Select a location to clone the Builder repo on your Host OS, eg, `~/Workspace` (this directory will be referred to as ${BUILDER_SRC_ROOT} in the sections below)
 
-```
+```shell
 cd ${BUILDER_SRC_ROOT}
 git clone https://github.com/habitat-sh/builder.git
 ```
@@ -35,13 +35,13 @@ We suggest using [NVM](https://github.com/creationix/nvm) (Node Version Manager)
 
 Once NVM is installed (you can verify with `nvm --version`), `cd` into `${BUILDER_SRC_ROOT}/components/builder-web` and run:
 
-```
+```shell
 nvm install
 ```
 
 When that completes, verify the installation:
 
-```
+```shell
 node --version
 ```
 
@@ -57,16 +57,16 @@ Update the *github_app_id* and *oauth_client_id* fields with the values from you
 
 To start the node web server on your local machine:
 
-```
+```shell
 npm install
 npm start
 ```
 
 You should now be able to browse to the UI at `http://localhost:3000/#/pkgs`.
 
-Note that browsing to `http://localhost:3000/` (i.e., at the root level) will activate the application's default route, which is configured to redirect signed-out users to the Habitat home page (http://habitat.sh), and various navigation links will operate similarly. If you plan on developing for both the Builder UI and the [Web site](../../www), consider changing some of your configuration entries to allow for easier navigation between the two:
+Note that browsing to `http://localhost:3000/` (i.e., at the root level) will activate the application's default route, which is configured to redirect signed-out users to the Habitat home page <http://habitat.sh>, and various navigation links will operate similarly. If you plan on developing for both the Builder UI and the [Web site](../../www), consider changing some of your configuration entries to allow for easier navigation between the two:
 
-```
+```shell
 ...
 docs_url: "http://localhost:4567/docs",
 tutorials_url: "http://localhost:4567/learn",

--- a/docs/Migrations.md
+++ b/docs/Migrations.md
@@ -4,7 +4,7 @@ All builder migrations are run with [Diesel](http://diesel.rs). This document de
 
 ## Install the Diesel client
 
-```
+```shell
 cargo install diesel_cli --no-default-features --features postgres
 ```
 
@@ -25,7 +25,7 @@ The migration name should describe what you are doing. Ex:
 
 This will generate something like
 
-```
+```shell
 Creating migrations/20160815133237_create_posts/up.sql
 Creating migrations/20160815133237_create_posts/down.sql
 ```

--- a/tools/bldr_toml_create/README.md
+++ b/tools/bldr_toml_create/README.md
@@ -1,4 +1,4 @@
-## Builder TOML Creation Tool
+# Builder TOML Creation Tool
 
 This is a development tool that can be used to create a ```bldr.toml``` file for
 a given repo. This tool is targeted to creating a toml file for the core plans
@@ -7,11 +7,12 @@ repo.
 It takes as input parameters a local path to the core-plans repo, and a
 destination directory for the ```bldr.toml``` file.
 
-### Usage
+## Usage
 
 You need to have a recent Ruby installed.
 
 To run:
-```
+
+```shell
 ruby toml_create.rb <core-plans-dir> <destination-dir>
 ```

--- a/tools/hab-channel-list-pkgs/README.md
+++ b/tools/hab-channel-list-pkgs/README.md
@@ -1,8 +1,8 @@
-## List All Packages in a Channel
+# List All Packages in a Channel
 
 This is a a tool which will fetch all packages that are in an origin's channel across multiple paged API responses.
 
-### Usage
+## Usage
 
 The following command line tools are required and will be checked before running:
 

--- a/tools/hab_token/Usage.md
+++ b/tools/hab_token/Usage.md
@@ -10,7 +10,7 @@ It makes is easier to switch between tokens during development / acceptance test
 
 The `.tokens` file should have the following format:
 
-```
+```shell
 #!/bin/bash
 TOKEN_LIVE=<your prod token>
 TOKEN_ACCEPTANCE=<your acceptance token>
@@ -21,12 +21,12 @@ TOKEN_DEV=<your dev token>
 
 When you want to switch to a specific token, issue a command like the following in your shell:
 
-```
+```shell
 eval $(hab-token live)
 ```
 
 This should set and export the `HAB_AUTH_TOKEN` env variable appropriately.  You can confirm that the token is set by doing the following:
 
-```
+```shell
 echo $HAB_AUTH_TOKEN
 ```

--- a/tools/project_create/README.md
+++ b/tools/project_create/README.md
@@ -1,4 +1,4 @@
-## Bulk Project Creation Tool
+# Bulk Project Creation Tool
 
 This is a development tool that can be used to bulk create projects for builder
 services. Project creation is a key pre-requisite that needs to be done for the
@@ -9,20 +9,21 @@ input parameters a local path to the core-plans repo, an API endpoint URL,
 an installation id (for an installed Habitat Builder app), and a Github auth
 token.
 
-### Usage
+## Usage
 
 You need to have a recent Ruby installed.
 
 To run:
-```
+
+```shell
 ruby project_create.rb <core-plans-dir> <projects-url> <installation-id> [<auth-token>]
 ```
 
 The projects-url should be in this form (replace the URL appropriately):
-https://bldr.acceptance.habitat.sh
+<https://bldr.acceptance.habitat.sh>
 
 For a development environment, the URL will be:
-http://localhost:9636
+<http://localhost:9636>
 
 If `<auth-token>` is not specified, the script will default to looking for
 the `HAB_AUTH_TOKEN` environment variable.
@@ -34,6 +35,7 @@ and repositories from Github using Github App authentication. These
 require nodejs to be installed (any recent version should be fine).
 
 The tools are:
+
 * app.js - gets basic app info (for sanity validation)
 * installations.js - get a list of installation ids and names
 * repos.js - gets a list of repo ids and repo names
@@ -43,7 +45,8 @@ the PEM file available on the machine. For reference, the Habitat Builder
 Dev app id is 5629.
 
 Example usage (assumes the pem file is in the current folder):
-```
+
+```shell
 node app.js 5629 builder-github-app.pem
 node installations.js 5629 builder-github-app.pem
 node repos.js 5629 56940 builder-github-app.pem

--- a/tools/ssh_helpers/Usage.md
+++ b/tools/ssh_helpers/Usage.md
@@ -1,4 +1,6 @@
-# Prerequisites
+# Usage
+
+## Prerequisites
 
 These scripts make it easy to connect to running Habitat instances. To use them, you'll need to set up a few things first:
 
@@ -10,7 +12,7 @@ These scripts make it easy to connect to running Habitat instances. To use them,
 * Install [tmux](https://github.com/tmux/tmux/wiki). (e.g., `brew install tmux`)
 * Install [tmuxinator](https://github.com/tmuxinator/tmuxinator). (`gem install tmuxinator`)
 
-# Testing AWS CLI
+## Testing AWS CLI
 
 Since we typically use `okta_aws` and you may have multiple profiles, you will likely need to specify the following environment variable: `AWS_PROFILE`.
 Otherwise, you may receive this error: `An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity operation: The security token included in the request is invalid.`
@@ -22,18 +24,18 @@ export AWS_PROFILE=habitat
 aws sts get-caller-identity
 ```
 
-# Generating and Updating Configuration
+## Generating and Updating Configuration
 
 Once you're set up with the prerequisites listed above, you should be able to generate SSH and tmuxinator configurations using the following commands (executed from within this directory):
 
-```
+```shell
 ./update-habitat-ssh acceptance
 ./update-habitat-ssh live
 ```
 
 And with that, connect to running environments:
 
-```
+```shell
 ./hab-env acceptance
 ./hab-env live
 ```


### PR DESCRIPTION
This set of documents for review was selected via the following command

```shell
code $(find -name "*md" -! -path "*test*" -! -path "*node_modules*" -! -path "*.github*" -! -path "*target*" | grep -v -e builder-jobsrv -e builder-graph -e builder-protocol -e CHANGELOG.md | xargs)
```

The documents were then review with markdown lint and the code spell checker extensions active. Ultimately the spell checker just detected technical things like "passwordless" and different command line programs that didn't need to be corrected.

NOTE: This PR isn't about correcting content. That will be a future PR.