### PR TITLE
Aligns rustfmt between Makefile and verify pipeline

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -22,7 +22,7 @@ steps:
 
   - label: "[lint] :linux: :bash: rustfmt"
     command:
-      - ./support/ci/rustfmt.sh
+      - make fmt
     timeout_in_minutes: 20
     retry:
       automatic:

--- a/Makefile
+++ b/Makefile
@@ -70,18 +70,9 @@ clean-lib: $(addprefix clean-,$(LIB)) ## cleans the library components' project 
 clean-srv: $(addprefix clean-,$(SRV)) ## cleans the service components' project trees
 .PHONY: clean-srv
 
-fmt: fmt-bin fmt-lib fmt-srv ## formats all the components' codebases
-fmt-all: fmt
-.PHONY: fmt fmt-all
-
-fmt-bin: $(addprefix fmt-,$(BIN)) ## formats the binary components' codebases
-.PHONY: clean-bin
-
-fmt-lib: $(addprefix fmt-,$(LIB)) ## formats the library components' codebases
-.PHONY: clean-lib
-
-fmt-srv: $(addprefix fmt-,$(SRV)) ## formats the service components' codebases
-.PHONY: clean-srv
+fmt: 
+	bash ./support/ci/rustfmt.sh
+.PHONY: fmt 
 
 help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -125,11 +116,3 @@ clean-$1: linux ## cleans the $1 component's project tree
 
 endef
 $(foreach component,$(ALL),$(eval $(call CLEAN,$(component))))
-
-define FMT
-fmt-$1: linux ## formats the $1 component
-	sh -c 'cd components/$1 && cargo fmt'
-.PHONY: fmt-$1
-
-endef
-$(foreach component,$(ALL),$(eval $(call FMT,$(component))))


### PR DESCRIPTION
The fmt targets of the Makefile were inconsistent with our expeditor pipeline.  The verify expeditor pipeline directly called the script support/ci/rustfmt.sh while the Makefile had its own rule where cargo fmt was called within each component directory.  Also, a lot of the .PHONY targets that should have been fmt-SOMETHING where still clean-SOMETHING from a copy and paste error.

In this PR all fmt targets are removed from the Makefile except for fmt which now calls the support/ci/rustfmt.sh directly.

Also, the verify pipeline now calls make fmt as opposed to calling the script directly. This mirrors the practice whereby clippy is executed via make lint.