### PR TITLE
ability to restrict origin creation to authorized users

### DIFF
--- a/components/builder-api-proxy/habitat/config/habitat.conf.js
+++ b/components/builder-api-proxy/habitat/config/habitat.conf.js
@@ -2,7 +2,6 @@ habitatConfig({
     company_id: "{{cfg.analytics.company_id}}",
     company_name: "{{cfg.analytics.company_name}}",
     cookie_domain: "{{cfg.cookie_domain}}",
-    demo_app_url: "{{cfg.demo_app_url}}",
     docs_url: "{{cfg.docs_url}}",
     enable_builder: {{ cfg.enable_builder }},
     enable_visibility: {{ cfg.enable_visibility }},

--- a/components/builder-api-proxy/habitat/default.toml
+++ b/components/builder-api-proxy/habitat/default.toml
@@ -1,6 +1,5 @@
 app_url                   = "https://bldr.habitat.sh"
 cookie_domain             = ""
-demo_app_url              = "https://www.habitat.sh/demo/build-system/steps/1/"
 docs_url                  = "https://www.habitat.sh/docs"
 enable_publisher_amazon   = false
 enable_publisher_azure    = false

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -8,6 +8,7 @@ build_on_upload = true
 saas_bldr_url = "https://bldr.habitat.sh"
 suppress_autobuild_origins = []
 allowed_native_package_origins = []
+allowed_users_for_origin_create = []
 
 [http]
 listen = "0.0.0.0"

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -106,18 +106,19 @@ impl Default for S3Cfg {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct ApiCfg {
-    pub data_path:                  PathBuf,
-    pub log_path:                   PathBuf,
+    pub data_path: PathBuf,
+    pub log_path: PathBuf,
     /// Location of Builder encryption keys
-    pub key_path:                   KeyCache,
-    pub targets:                    Vec<PackageTarget>,
-    pub build_targets:              Vec<PackageTarget>,
+    pub key_path: KeyCache,
+    pub targets: Vec<PackageTarget>,
+    pub build_targets: Vec<PackageTarget>,
     #[serde(with = "deserialize_into_vec")]
-    pub features_enabled:           Vec<String>,
-    pub build_on_upload:            bool,
-    pub private_max_age:            usize,
-    pub saas_bldr_url:              String,
+    pub features_enabled: Vec<String>,
+    pub build_on_upload: bool,
+    pub private_max_age: usize,
+    pub saas_bldr_url: String,
     pub suppress_autobuild_origins: Vec<String>,
+    pub allowed_users_for_origin_create: Vec<String>,
 }
 
 mod deserialize_into_vec {
@@ -151,7 +152,8 @@ impl Default for ApiCfg {
                  build_on_upload: true,
                  private_max_age: 300,
                  saas_bldr_url: "https://bldr.habitat.sh".to_string(),
-                 suppress_autobuild_origins: vec![] }
+                 suppress_autobuild_origins: vec![],
+                 allowed_users_for_origin_create: vec![] }
     }
 }
 
@@ -412,6 +414,7 @@ mod tests {
         build_on_upload = false
         private_max_age = 400
         suppress_autobuild_origins = ["origin1", "origin2"]
+        allowed_users_for_origin_create = ["super1", "super2"]
 
         [http]
         listen = "0:0:0:0:0:0:0:1"
@@ -486,6 +489,9 @@ mod tests {
 
         assert_eq!(config.api.build_targets.len(), 1);
         assert_eq!(config.api.build_targets[0], target::X86_64_LINUX);
+
+        assert_eq!(&config.api.allowed_users_for_origin_create,
+                   &["super1".to_string(), "super2".to_string()]);
 
         assert_eq!(&config.api.features_enabled,
                    &["FOO".to_string(), "BAR".to_string()]);

--- a/components/builder-api/src/server/resources/origins.rs
+++ b/components/builder-api/src/server/resources/origins.rs
@@ -181,6 +181,14 @@ async fn create_origin(req: HttpRequest,
         Ok(session) => session,
         Err(err) => return err.into(),
     };
+    if !state.config.api.allowed_users_for_origin_create.is_empty()
+       && !state.config
+                .api
+                .allowed_users_for_origin_create
+                .contains(&session.get_name().to_string())
+    {
+        return HttpResponse::new(StatusCode::FORBIDDEN);
+    }
 
     let dpv = match body.clone().default_package_visibility {
         Some(viz) => viz,

--- a/components/builder-web/app/origin/origins-page/_origins-page.component.scss
+++ b/components/builder-web/app/origin/origins-page/_origins-page.component.scss
@@ -1,5 +1,9 @@
 .origins-page-component {
 
+  .error {
+    color: map-get($form-colors, error);
+  }
+
   .nav-list {
     font-size: $base-font-size;
 

--- a/components/builder-web/app/origin/origins-page/origins-page.component.html
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.html
@@ -11,7 +11,6 @@
         <a mat-raised-button color="primary" [routerLink]="['/origins', 'create']">Create origin</a>
       </section>
       <section *ngIf="builderEnabled">
-        <h3>Build</h3>
         <p class="error"><b>Important Notice:</b> We would like to inform you that we have disabled the creation of origins in our hosted Chef Habitat Builder (bldr.habitat.sh). However, you can still continue to install an on-prem or self-hosted habitat builder by following these instructions (<a href="https://www.chef.io/blog/chef-habitat-product-announcement-builder-on-prem-enhancements-that-extend-support-to-airgap-environments-and-simplify-set-up" target="_blank">more info here</a>).  Please <a href="https://www.chef.io/contact-us" target="_blank">contact us</a> if you would like to know more</p>
       </section>
       <div *ngIf="!ui.loading">

--- a/components/builder-web/app/origin/origins-page/origins-page.component.html
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.html
@@ -7,21 +7,17 @@
       <section *ngIf="ui.loading">
         <hab-icon symbol="loading" class="spinning"></hab-icon>
       </section>
-      <section>
+      <section *ngIf="!builderEnabled">
         <a mat-raised-button color="primary" [routerLink]="['/origins', 'create']">Create origin</a>
+      </section>
+      <section *ngIf="builderEnabled">
+        <h3>Build</h3>
+        <p class="error"><b>Important Notice:</b> We would like to inform you that we have disabled the creation of origins in our hosted Chef Habitat Builder (bldr.habitat.sh). However, you can still continue to install an on-prem or self-hosted habitat builder by following these instructions (<a href="https://www.chef.io/blog/chef-habitat-product-announcement-builder-on-prem-enhancements-that-extend-support-to-airgap-environments-and-simplify-set-up" target="_blank">more info here</a>).  Please <a href="https://www.chef.io/contact-us" target="_blank">contact us</a> if you would like to know more</p>
       </section>
       <div *ngIf="!ui.loading">
         <section *ngIf="origins.size === 0 && !ui.errorMessage">
           <p>
             <strong>You are not currently an owner or member of any origins.</strong>
-          </p>
-          <p>
-            Note: If you've already created an origin with the Habitat CLI tool, then you'll need to create it here, too, using the same
-            name.
-          </p>
-          <p>
-            <em>New to Habitat?
-              <a href="{{ config['demo_app_url'] }}">Try the demo app</a>.</em>
           </p>
         </section>
         <section *ngIf="origins.size > 0">

--- a/components/builder-web/app/origin/origins-page/origins-page.component.ts
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.ts
@@ -42,6 +42,10 @@ export class OriginsPageComponent implements OnInit {
     }
   }
 
+  get builderEnabled() {
+    return this.store.getState().features.builder;
+  }
+
   get config() {
     return config;
   }

--- a/components/builder-web/app/package/package-latest/package-latest.component.html
+++ b/components/builder-web/app/package/package-latest/package-latest.component.html
@@ -27,10 +27,6 @@
           <a [routerLink]="['/pkgs', origin, name, 'settings']">Build Settings</a> by connecting a plan file to Habitat Builder.
         </li>
       </ol>
-      <p>
-        <em>Don't have a plan file?
-        <a href="{{ config['demo_app_url'] }}">Try the demo app</a>.</em>
-      </p>
     </div>
   </ng-container>
 </div>

--- a/components/builder-web/app/sign-in-page/sign-in-page.component.html
+++ b/components/builder-web/app/sign-in-page/sign-in-page.component.html
@@ -23,7 +23,7 @@
   </div>
   <p class="footnote">
     By clicking on "Sign in with {{ providerName }}", you are agreeing to the
-    <a href="{{ wwwUrl }}/legal/terms-and-conditions/" target="_blank">Terms of Service</a> ,
+    <a href="https://www.chef.io/end-user-license-agreement" target="_blank">Terms of Service</a> ,
     <a href="https://www.progress.com/legal/privacy-policy" target="_blank">Privacy Policy</a> and
     <a href="https://www.progress.com/legal/cookie-policy" target="_blank">Cookie Policy </a>. 
     Know more about <a href="https://www.chef.io/patents" target="_blank">Chef Patents</a>

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -7,9 +7,6 @@ habitatConfig({
     // Cookie domain (optional; e.g., 'bldr.company.co')
     cookie_domain: "",
 
-    // The URL for the Builder demo app
-    demo_app_url: "https://www.habitat.sh/demo/build-system/steps/1/",
-
     // The URL for documentation
     docs_url: "https://www.habitat.sh/docs",
 

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -30,6 +30,9 @@ mkdir -p /hab/user/builder-api/config
 cat <<EOT > /hab/user/builder-api/config/user.toml
 log_level = "debug,tokio_core=error,tokio_reactor=error,zmq=error,hyper=error"
 
+[api]
+allowed_users_for_origin_create = ['bobo', 'mystique', 'wesker', 'lkennedy']
+
 [http]
 handler_count = 15
 

--- a/test/builder-api/src/origins.js
+++ b/test/builder-api/src/origins.js
@@ -111,6 +111,20 @@ describe("Origin API", function () {
     });
   });
 
+  describe("Create origin when not allowed", function () {
+    it("requires the user to be allowed", function (done) {
+      request
+        .post("/depot/origins")
+        .set("Authorization", global.hankBearer)
+        .send({ name: "hank" })
+        .expect(403)
+        .end(function (err, res) {
+          expect(res.text).to.be.empty;
+          done(err);
+        });
+    });
+  });
+
   describe("Updating origins", function () {
     it("requires authentication", function (done) {
       request


### PR DESCRIPTION
This allows a builder instance to configure a list of usernames in the builder-api user.toml:

```
[api]
allowed_users_for_origin_create = ['bobo', 'mystique', 'wesker', 'lkennedy']
```

If this list is specified and not empty, a user MUST be in this list in order to create any origin.