### PR TITLE
Support loading builder encryption key from env

### DIFF
--- a/components/builder-api/src/server/migrations.rs
+++ b/components/builder-api/src/server/migrations.rs
@@ -1,7 +1,8 @@
 use crate::{db::models::keys::OriginPrivateSigningKey,
             server::error::{Error,
                             Result}};
-use builder_core::{crypto, keys};
+use builder_core::{crypto,
+                   keys};
 use diesel::pg::PgConnection;
 use habitat_core::crypto::keys::{Key,
                                  KeyCache};

--- a/components/builder-api/src/server/migrations.rs
+++ b/components/builder-api/src/server/migrations.rs
@@ -1,7 +1,7 @@
 use crate::{db::models::keys::OriginPrivateSigningKey,
             server::error::{Error,
                             Result}};
-use builder_core::crypto;
+use builder_core::{crypto, keys};
 use diesel::pg::PgConnection;
 use habitat_core::crypto::keys::{Key,
                                  KeyCache};
@@ -16,7 +16,7 @@ pub fn migrate_to_encrypted(conn: &PgConnection, key_cache: &KeyCache) -> Result
     let start_time = Instant::now();
     let mut updated_keys = 0;
     let mut skipped_keys = 0;
-    let builder_secret_key = key_cache.latest_builder_key()?;
+    let builder_secret_key = keys::get_latest_builder_key(key_cache)?;
     let mut next_id: i64 = 0;
 
     loop {

--- a/components/builder-api/src/server/migrations/encrypt_secret_keys.rs
+++ b/components/builder-api/src/server/migrations/encrypt_secret_keys.rs
@@ -3,6 +3,7 @@
 
 use crate::server::error::{Error,
                            Result};
+use builder_core::keys;
 use diesel::{connection::Connection,
              pg::PgConnection};
 use habitat_builder_db::models::keys as db_keys;
@@ -12,7 +13,7 @@ use std::time::Instant;
 /// Perform the actual migration of data.
 pub fn run(conn: &PgConnection, key_cache: &KeyCache) -> Result<()> {
     let start_time = Instant::now();
-    let builder_encryption_key = key_cache.latest_builder_key()?;
+    let builder_encryption_key = keys::get_latest_builder_key(key_cache)?;
 
     let updated_rows = conn.transaction::<_, Error, _>(|| {
                                Ok(

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -22,7 +22,8 @@ use self::{framework::middleware::authentication_middleware,
                        user::User},
            services::{memcache::MemcacheClient,
                       s3::S3Handler}};
-use crate::{bldr_core::{keys, rpc::RpcClient},
+use crate::{bldr_core::{keys,
+                        rpc::RpcClient},
             config::{Config,
                      GatewayCfg},
             db::{migration,
@@ -133,7 +134,7 @@ pub async fn run(config: Config) -> error::Result<()> {
     let db_pool = DbPool::new(&config.datastore.clone());
 
     // Check if the builder encryption key is present; if not, panic with an appropriate error.
-    if let Err(e) = keys::get_latest_builder_key(&config.api.key_path){
+    if let Err(e) = keys::get_latest_builder_key(&config.api.key_path) {
         panic!("Failed to get the builder encryption key, error = {}", e);
     }
 

--- a/components/builder-core/src/crypto.rs
+++ b/components/builder-core/src/crypto.rs
@@ -1,7 +1,7 @@
 //! This module holds code that's common to dealing with the
 //! encrypting and decrytping data in Builder.
 
-use crate::error::Result;
+use crate::{error::Result, keys};
 use habitat_core::crypto::keys::{BuilderSecretEncryptionKey,
                                  Key,
                                  KeyCache,
@@ -24,7 +24,7 @@ use habitat_core::crypto::keys::{BuilderSecretEncryptionKey,
 pub fn encrypt<B>(key_cache: &KeyCache, bytes: B) -> Result<(String, KeyRevision)>
     where B: AsRef<[u8]>
 {
-    let key = key_cache.latest_builder_key()?;
+    let key = keys::get_latest_builder_key(key_cache)?;
     Ok(encrypt_with_key(&key, bytes))
 }
 
@@ -48,6 +48,6 @@ pub fn encrypt_with_key<B>(key: &BuilderSecretEncryptionKey, bytes: B) -> (Strin
 /// cleaning up callsites. But for now, you get bytes!
 pub fn decrypt(key_cache: &KeyCache, encrypted_message: &str) -> Result<Vec<u8>> {
     let encrypted_message = encrypted_message.parse::<SignedBox>()?;
-    let builder_key = key_cache.builder_secret_encryption_key(encrypted_message.decryptor())?;
+    let builder_key = keys::get_builder_key_for_revision(key_cache, encrypted_message.decryptor())?;
     Ok(builder_key.decrypt(&encrypted_message)?)
 }

--- a/components/builder-core/src/crypto.rs
+++ b/components/builder-core/src/crypto.rs
@@ -1,7 +1,8 @@
 //! This module holds code that's common to dealing with the
 //! encrypting and decrytping data in Builder.
 
-use crate::{error::Result, keys};
+use crate::{error::Result,
+            keys};
 use habitat_core::crypto::keys::{BuilderSecretEncryptionKey,
                                  Key,
                                  KeyCache,

--- a/components/builder-core/src/keys.rs
+++ b/components/builder-core/src/keys.rs
@@ -12,4 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use habitat_core::{crypto::keys::{BuilderSecretEncryptionKey, KeyCache, NamedRevision}, Error};
+
 pub const BUILDER_KEY_NAME: &str = "bldr";
+
+pub fn get_latest_builder_key(key_cache: &KeyCache) -> Result<BuilderSecretEncryptionKey, Error> {
+    key_cache.latest_builder_key()
+}
+
+pub fn get_builder_key_for_revision(key_cache: &KeyCache, named_revision: &NamedRevision) -> Result<BuilderSecretEncryptionKey, Error> {
+    key_cache.builder_secret_encryption_key(named_revision)
+}

--- a/components/builder-core/src/keys.rs
+++ b/components/builder-core/src/keys.rs
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use habitat_core::{crypto::keys::{BuilderSecretEncryptionKey,
+                                  Key,
+                                  KeyCache,
+                                  NamedRevision},
+                   Error};
 use std::env;
-use habitat_core::{crypto::keys::{Key, BuilderSecretEncryptionKey, KeyCache, NamedRevision}, Error};
 
 pub const BUILDER_KEY_NAME: &str = "bldr";
 
@@ -31,9 +35,10 @@ fn get_bldr_secret_key_from_env() -> Option<Result<BuilderSecretEncryptionKey, E
 }
 
 /// Retrieves the latest builder secret encryption key.
-/// 
+///
 /// First, it attempts to retrieve the key from the environment variable `BLDR_SECRET_KEY`.
-/// If the key is not set in the environment, it falls back to fetching the key from the `key_cache`.
+/// If the key is not set in the environment, it falls back to fetching the key from the
+/// `key_cache`.
 pub fn get_latest_builder_key(key_cache: &KeyCache) -> Result<BuilderSecretEncryptionKey, Error> {
     if let Some(result) = get_bldr_secret_key_from_env() {
         return result;
@@ -43,23 +48,24 @@ pub fn get_latest_builder_key(key_cache: &KeyCache) -> Result<BuilderSecretEncry
 }
 
 /// Retrieves the builder secret encryption key for a specific revision.
-/// 
+///
 /// First, it attempts to retrieve the key from the environment variable `BLDR_SECRET_KEY`.
 /// If the key is found and matches the revision, it is returned. If there is a revision mismatch,
 /// an error is returned with details about the mismatch.
-/// If the key is not found in the environment, the function falls back to fetching the key from 
+/// If the key is not found in the environment, the function falls back to fetching the key from
 /// the `key_cache` based on the provided `named_revision`.
 pub fn get_builder_key_for_revision(key_cache: &KeyCache, named_revision: &NamedRevision) -> Result<BuilderSecretEncryptionKey, Error> {
     if let Some(result) = get_bldr_secret_key_from_env() {
         let key = result?;
 
-        // Generally, this should not happen if the BLDR_SECRET_KEY is used to configure the key. 
+        // Generally, this should not happen if the BLDR_SECRET_KEY is used to configure the key.
         // This is an extra safeguard to inform that there is a mismatch in the key for some reason.
         if key.named_revision() != named_revision {
-            return Err(Error::CryptoError(format!(
-                "Revision mismatch from env BLDR_SECRET_KEY. Expected revision: {}, Found: {}",
-                named_revision, key.named_revision()
-            )));
+            return Err(Error::CryptoError(format!("Revision mismatch from env \
+                                                   BLDR_SECRET_KEY. Expected \
+                                                   revision: {}, Found: {}",
+                                                  named_revision,
+                                                  key.named_revision())));
         }
 
         return Ok(key);
@@ -68,12 +74,13 @@ pub fn get_builder_key_for_revision(key_cache: &KeyCache, named_revision: &Named
     key_cache.builder_secret_encryption_key(named_revision)
 }
 
-/// This module contains tests that interact with the process environment (via environment variables).
-/// 
-/// These tests cannot be run in parallel because they modify the `BLDR_SECRET_KEY` environment variable, 
-/// and concurrent access may cause interference or inconsistent results. 
-/// 
-/// Some tests are ignored for manual inspection when issues occur. 
+/// This module contains tests that interact with the process environment (via environment
+/// variables).
+///
+/// These tests cannot be run in parallel because they modify the `BLDR_SECRET_KEY` environment
+/// variable, and concurrent access may cause interference or inconsistent results.
+///
+/// Some tests are ignored for manual inspection when issues occur.
 /// In the future, we may use a crate like 'temp-env' to handle environment-based tests if needed.
 #[cfg(test)]
 mod tests {
@@ -81,22 +88,22 @@ mod tests {
     use std::env;
 
     // Helper function to set the env variable
-    fn set_bldr_secret_key(key_value: &str) {
-        env::set_var("BLDR_SECRET_KEY", key_value);
-    }
+    fn set_bldr_secret_key(key_value: &str) { env::set_var("BLDR_SECRET_KEY", key_value); }
 
     #[test]
     #[ignore]
     fn test_bldr_secret_key_not_set() {
         let result = get_bldr_secret_key_from_env();
 
-        assert!(result.is_none(), "Expected None when BLDR_SECRET_KEY is not set");
+        assert!(result.is_none(),
+                "Expected None when BLDR_SECRET_KEY is not set");
     }
 
     // Test case for BLDR_SECRET_KEY with escaped newlines
     #[test]
     fn test_bldr_secret_key_with_escaped_newlines() {
-        let key_with_escaped_newlines = r#"BOX-SEC-1\nbldr-20200825205529\n\nM9u8wuJmZMsmVG4tNgngYJDapjIJE1RnxJAFVN97Bxs="#;
+        let key_with_escaped_newlines =
+            r#"BOX-SEC-1\nbldr-20200825205529\n\nM9u8wuJmZMsmVG4tNgngYJDapjIJE1RnxJAFVN97Bxs="#;
 
         set_bldr_secret_key(key_with_escaped_newlines);
 

--- a/components/builder-core/src/keys.rs
+++ b/components/builder-core/src/keys.rs
@@ -12,14 +12,58 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use habitat_core::{crypto::keys::{BuilderSecretEncryptionKey, KeyCache, NamedRevision}, Error};
+use std::env;
+use habitat_core::{crypto::keys::{Key, BuilderSecretEncryptionKey, KeyCache, NamedRevision}, Error};
 
 pub const BUILDER_KEY_NAME: &str = "bldr";
 
+fn get_bldr_secret_key_from_env() -> Option<Result<BuilderSecretEncryptionKey, Error>> {
+    match env::var("BLDR_SECRET_KEY") {
+        Ok(val) => {
+            // Update the value before parsing: replace "\\n" with actual newline characters
+            let val = val.replace("\\n", "\n");
+            Some(val.parse::<BuilderSecretEncryptionKey>().map_err(|e| {
+                Error::CryptoError(format!("Failed to parse `BLDR_SECRET_KEY`: {}", e))
+            }))
+        }
+        Err(_) => None, // If not set, return None
+    }
+}
+
+/// Retrieves the latest builder secret encryption key.
+/// 
+/// First, it attempts to retrieve the key from the environment variable `BLDR_SECRET_KEY`.
+/// If the key is not set in the environment, it falls back to fetching the key from the `key_cache`.
 pub fn get_latest_builder_key(key_cache: &KeyCache) -> Result<BuilderSecretEncryptionKey, Error> {
+    if let Some(result) = get_bldr_secret_key_from_env() {
+        return result;
+    }
+
     key_cache.latest_builder_key()
 }
 
+/// Retrieves the builder secret encryption key for a specific revision.
+/// 
+/// First, it attempts to retrieve the key from the environment variable `BLDR_SECRET_KEY`.
+/// If the key is found and matches the revision, it is returned. If there is a revision mismatch,
+/// an error is returned with details about the mismatch.
+/// If the key is not found in the environment, the function falls back to fetching the key from 
+/// the `key_cache` based on the provided `named_revision`.
 pub fn get_builder_key_for_revision(key_cache: &KeyCache, named_revision: &NamedRevision) -> Result<BuilderSecretEncryptionKey, Error> {
+    if let Some(result) = get_bldr_secret_key_from_env() {
+        let key = result?;
+
+        // Generally, this should not happen if the BLDR_SECRET_KEY is used to configure the key. 
+        // This is an extra safeguard to inform that there is a mismatch in the key for some reason.
+        if key.named_revision() != named_revision {
+            return Err(Error::CryptoError(format!(
+                "Revision mismatch from env BLDR_SECRET_KEY. Expected revision: {}, Found: {}",
+                named_revision, key.named_revision()
+            )));
+        }
+
+        return Ok(key);
+    }
+
     key_cache.builder_secret_encryption_key(named_revision)
 }

--- a/components/builder-core/src/keys.rs
+++ b/components/builder-core/src/keys.rs
@@ -54,7 +54,9 @@ pub fn get_latest_builder_key(key_cache: &KeyCache) -> Result<BuilderSecretEncry
 /// an error is returned with details about the mismatch.
 /// If the key is not found in the environment, the function falls back to fetching the key from
 /// the `key_cache` based on the provided `named_revision`.
-pub fn get_builder_key_for_revision(key_cache: &KeyCache, named_revision: &NamedRevision) -> Result<BuilderSecretEncryptionKey, Error> {
+pub fn get_builder_key_for_revision(key_cache: &KeyCache,
+                                    named_revision: &NamedRevision)
+                                    -> Result<BuilderSecretEncryptionKey, Error> {
     if let Some(result) = get_bldr_secret_key_from_env() {
         let key = result?;
 


### PR DESCRIPTION
The Builder API service requires a user key named `bldr`, which is created with the following command:

```sh
hab user key generate bldr
```

The bldr keys are then used to encrypt and decrypt authentication tokens and origin secret keys. These keys are always specified through the `key_path` configuration in `config.toml`.

The command generates two keys, as shown below:

- bldr-20250324065740.pub (public key)
- bldr-20250324065740.box.key (private key)

Although both the public and private keys are generated, only the private key (bldr-20250324065740.box.key) is used during the service lifecycle. The public key is never used, and only the private key is required for the Builder API service to function.

This PR adds support for supplying the secret key via the new environment variable `BLDR_SECRET_KEY`. It also removes the automatic creation of the token when the bldr key is missing, and provides an appropriate error message during the service startup.