### PR TITLE
Terraform Cleanup and Review

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -162,7 +162,7 @@ resource "aws_instance" "api" {
       "echo \"Supervisor is up. Sleeping 120s to allow for auto upgrade.\"",
       "sleep 120",
       "sudo hab svc load habitat/builder-memcached --group ${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
-      "sudo hab svc load habitat/builder-api --group ${var.env} --bind memcached:builder-memcached.${var.env} --bind jobsrv:builder-jobsrv.${var.env} --binding-mode relaxed --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load habitat/builder-api --group ${var.env} --bind memcached:builder-memcached.${var.env} --binding-mode relaxed --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
       "sudo hab svc load habitat/builder-api-proxy --group ${var.env} --bind http:builder-api.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]
   }
@@ -342,7 +342,7 @@ resource "aws_instance" "worker" {
     aws_security_group.jobsrv_client.id,
     aws_security_group.worker.id,
   ]
-  
+
   connection {
     type = "ssh"
     // JW TODO: switch to private ip after VPN is ready
@@ -377,7 +377,7 @@ resource "aws_instance" "worker" {
       "${path.module}/scripts/worker_bootstrap.sh",
     ]
   }
-  
+
   provisioner "file" {
     source      = "${path.module}/files/builder.logrotate"
     destination = "/tmp/builder.logrotate"
@@ -611,7 +611,7 @@ resource "aws_instance" "linux2-worker" {
 }
 
 resource "aws_instance" "windows-worker" {
-  // Windows Server 2019 English Core with Containers 2021-05-12 
+  // Windows Server 2019 English Core with Containers 2021-05-12
   ami           = "ami-0613a489ef66dc885"
   instance_type = var.instance_size_windows_worker
   key_name      = var.aws_key_pair


### PR DESCRIPTION
The acceptance environment broke after merging the removal of the graph, jobsrv, and worker components.  This was traced to a a binding against jobserv for builder-api.  This removes that binding but the issue prompted a deeper review of our terraform.

- Removes builder-api jobsrv binding
- whitespace hygiene