### PR TITLE
soft delete origins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ components/builder-protocol/src/message
 
 #### Vendored test helpers
 test/test_helper
+
+#### For copilot
+builder.code-workspace

--- a/components/builder-db/src/migrations/2025-04-24-000001_hide_origins/down.sql
+++ b/components/builder-db/src/migrations/2025-04-24-000001_hide_origins/down.sql
@@ -1,0 +1,85 @@
+ALTER TABLE origins DROP COLUMN hidden;
+ALTER TABLE origin_packages DROP COLUMN hidden;
+ALTER TABLE origin_package_settings DROP COLUMN hidden;
+
+DROP VIEW origins_with_secret_key;
+CREATE OR REPLACE VIEW origins_with_secret_key AS
+  SELECT origins.name,
+     origins.owner_id,
+     origin_secret_keys.full_name AS private_key_name,
+     origins.default_package_visibility,
+     accounts.name AS owner_account
+    FROM (origins
+     LEFT JOIN origin_secret_keys ON ((origins.name = origin_secret_keys.origin))
+     LEFT JOIN accounts ON ((origins.owner_id = accounts.id)))
+   ORDER BY origins.name, origin_secret_keys.full_name DESC;
+
+CREATE OR REPLACE VIEW origins_with_stats AS
+    SELECT o.*, count(DISTINCT ops.name) as package_count
+        FROM origins o
+        LEFT OUTER JOIN origin_package_settings ops ON o.name = ops.origin
+        GROUP BY o.name
+        ORDER BY o.name;
+
+DROP VIEW origin_packages_with_version_array;
+CREATE OR REPLACE VIEW origin_packages_with_version_array AS
+    SELECT
+        id,
+        owner_id,
+        name,
+        ident,
+        ident_array,
+        checksum,
+        manifest,
+        config,
+        target,
+        deps,
+        tdeps,
+        exposes,
+        created_at,
+        updated_at,
+        visibility,
+        origin,
+        build_deps,
+        build_tdeps,
+        regexp_matches(ident_array[3], '([\d\.]*\d+)(.+)?') as version_array,
+        package_type
+FROM origin_packages;
+
+DROP VIEW packages_with_channel_platform;
+CREATE OR REPLACE VIEW packages_with_channel_platform AS
+ SELECT op.id,
+    op.owner_id,
+    op.name,
+    op.ident,
+    op.ident_array,
+    op.checksum,
+    op.manifest,
+    op.config,
+    op.target,
+    op.deps,
+    op.tdeps,
+    op.build_deps,
+    op.build_tdeps,
+    op.exposes,
+    op.visibility,
+    op.created_at,
+    op.updated_at,
+    op.origin,
+    array_agg(oc.name) OVER w AS channels,
+    array_agg(op.target) OVER w AS platforms
+   FROM origin_packages op
+     JOIN origin_channel_packages ocp ON op.id = ocp.package_id
+     JOIN origin_channels oc ON oc.id = ocp.channel_id
+  WINDOW w AS (PARTITION BY op.origin, op.name, op.ident);
+
+DROP VIEW origin_package_versions;
+CREATE OR REPLACE VIEW origin_package_versions AS
+    SELECT origin, name, visibility,
+    ident_array[3] as version,
+    COUNT(ident_array[4]) as release_count, 
+    MAX(ident_array[4]) as latest,
+    ARRAY_AGG(DISTINCT target) as platforms,
+    regexp_matches(ident_array[3], '([\d\.]*\d+)(.+)?') as version_array
+    FROM origin_packages
+    GROUP BY ident_array[3], origin, name, visibility;

--- a/components/builder-db/src/migrations/2025-04-24-000001_hide_origins/up.sql
+++ b/components/builder-db/src/migrations/2025-04-24-000001_hide_origins/up.sql
@@ -1,0 +1,90 @@
+ALTER TABLE origins ADD COLUMN hidden boolean DEFAULT false;
+ALTER TABLE origin_packages ADD COLUMN hidden boolean DEFAULT false;
+ALTER TABLE origin_package_settings ADD COLUMN hidden boolean DEFAULT false;
+
+DROP VIEW origins_with_secret_key;
+CREATE OR REPLACE VIEW origins_with_secret_key AS
+  SELECT origins.name,
+     origins.owner_id,
+     origin_secret_keys.full_name AS private_key_name,
+     origins.default_package_visibility,
+     accounts.name AS owner_account
+    FROM (origins
+     LEFT JOIN origin_secret_keys ON ((origins.name = origin_secret_keys.origin AND origins.hidden = false))
+     LEFT JOIN accounts ON ((origins.owner_id = accounts.id)))
+   ORDER BY origins.name, origin_secret_keys.full_name DESC;
+
+DROP VIEW origins_with_stats;
+CREATE OR REPLACE VIEW origins_with_stats AS
+    SELECT o.*, count(DISTINCT ops.name) as package_count
+        FROM origins o
+        LEFT OUTER JOIN origin_package_settings ops ON o.name = ops.origin
+        WHERE o.hidden = false
+        GROUP BY o.name
+        ORDER BY o.name;
+
+DROP VIEW origin_packages_with_version_array;
+CREATE OR REPLACE VIEW origin_packages_with_version_array AS
+    SELECT
+        id,
+        owner_id,
+        name,
+        ident,
+        ident_array,
+        checksum,
+        manifest,
+        config,
+        target,
+        deps,
+        tdeps,
+        exposes,
+        created_at,
+        updated_at,
+        visibility,
+        origin,
+        build_deps,
+        build_tdeps,
+        regexp_matches(ident_array[3], '([\d\.]*\d+)(.+)?') as version_array,
+        package_type
+FROM origin_packages
+WHERE hidden = false;
+
+DROP VIEW packages_with_channel_platform;
+CREATE OR REPLACE VIEW packages_with_channel_platform AS
+ SELECT op.id,
+    op.owner_id,
+    op.name,
+    op.ident,
+    op.ident_array,
+    op.checksum,
+    op.manifest,
+    op.config,
+    op.target,
+    op.deps,
+    op.tdeps,
+    op.build_deps,
+    op.build_tdeps,
+    op.exposes,
+    op.visibility,
+    op.created_at,
+    op.updated_at,
+    op.origin,
+    array_agg(oc.name) OVER w AS channels,
+    array_agg(op.target) OVER w AS platforms
+   FROM origin_packages op
+     JOIN origin_channel_packages ocp ON op.id = ocp.package_id
+     JOIN origin_channels oc ON oc.id = ocp.channel_id
+   WHERE op.hidden = false
+  WINDOW w AS (PARTITION BY op.origin, op.name, op.ident);
+
+DROP VIEW origin_package_versions;
+CREATE OR REPLACE VIEW origin_package_versions AS
+    SELECT origin, name, visibility,
+    ident_array[3] as version,
+    COUNT(ident_array[4]) as release_count, 
+    MAX(ident_array[4]) as latest,
+    ARRAY_AGG(DISTINCT target) as platforms,
+    regexp_matches(ident_array[3], '([\d\.]*\d+)(.+)?') as version_array
+    FROM origin_packages
+    WHERE hidden = false
+    GROUP BY ident_array[3], origin, name, visibility;

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -1189,7 +1189,7 @@ impl FromArchive for NewPackage {
                         owner_id: 999_999_999_999,
                         visibility: PackageVisibility::Public,
                         package_type: BuilderPackageType(archive.package_type()?),
-                        hidden: false,})
+                        hidden: false })
     }
 }
 

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -305,6 +305,7 @@ pub struct NewPackage {
     pub exposes:      Vec<i32>,
     pub visibility:   PackageVisibility,
     pub package_type: BuilderPackageType,
+    pub hidden:       bool,
 }
 
 #[derive(Debug)]
@@ -438,6 +439,7 @@ impl Package {
 
         let result = Self::all().filter(origin_packages::ident.eq(ident))
                                 .filter(origin_packages::visibility.eq(any(visibility)))
+                                .filter(origin_packages::hidden.eq(false))
                                 .get_result(conn);
 
         let duration_millis = start_time.elapsed().as_millis();
@@ -455,6 +457,7 @@ impl Package {
         let result = Self::all().filter(origin_packages::ident.eq(req.ident))
                                 .filter(origin_packages::visibility.eq(any(req.visibility)))
                                 .filter(origin_packages::target.eq(req.target))
+                                .filter(origin_packages::hidden.eq(false))
                                 .get_result(conn);
 
         let duration_millis = start_time.elapsed().as_millis();
@@ -480,6 +483,7 @@ impl Package {
 
         let result = Self::all().filter(origin_packages::ident.eq(any(req.pkgs)))
                                 .filter(origin_packages::visibility.eq(any(req.visibility)))
+                                .filter(origin_packages::hidden.eq(false))
                                 .get_results(conn);
 
         let duration_millis = start_time.elapsed().as_millis();
@@ -499,6 +503,7 @@ impl Package {
             Self::all().filter(origin_packages::origin.eq(&req_ident.origin))
                        .filter(origin_packages::name.eq(&req_ident.name))
                        .filter(origin_packages::ident_array.contains(req_ident.clone().parts()))
+                       .filter(origin_packages::hidden.eq(false))
                        .get_results(conn);
 
         let duration_millis = start_time.elapsed().as_millis();
@@ -693,6 +698,7 @@ impl Package {
         let query = query
             .filter(origin_packages::ident_array.contains(pl.ident.clone().parts()))
             .filter(origin_packages::visibility.eq(any(pl.visibility)))
+            .filter(origin_packages::hidden.eq(false))
             // This is because diesel doesn't yet support group_by
             // see: https://github.com/diesel-rs/diesel/issues/210
             .filter(sql("TRUE GROUP BY ident_array[2], ident_array[1]"))
@@ -730,6 +736,7 @@ impl Package {
             .select(origin_package_settings::all_columns)
             .filter(origin_package_settings::origin.eq(&pl.ident.origin))
             .filter(origin_package_settings::visibility.eq(any(pl.visibility)))
+            .filter(origin_package_settings::hidden.eq(false))
             .order(origin_package_settings::origin.asc())
             .order(origin_package_settings::name.asc())
             .paginate(pl.page)
@@ -765,6 +772,7 @@ impl Package {
             .filter(origin_packages::ident.eq(ident))
             .filter(origin_packages::target.eq(target.to_string()))
             .filter(origin_packages::visibility.eq(any(visibility)))
+            .filter(origin_packages::hidden.eq(false))
             .order(origin_channels::name.desc())
             .get_results(conn);
 
@@ -806,6 +814,7 @@ impl Package {
 
         let result = origin_packages::table.select(count(origin_packages::id))
                                            .filter(origin_packages::origin.eq(&origin))
+                                           .filter(origin_packages::hidden.eq(false))
                                            .first(conn);
 
         let duration_millis = start_time.elapsed().as_millis();
@@ -825,6 +834,7 @@ impl Package {
         let mut query = origin_packages::table
             .select(origin_packages::ident)
             .filter(to_tsquery(format!("{}:*", sp.query)).matches(origin_packages::ident_vector))
+            .filter(origin_packages::hidden.eq(false))
             .order(origin_packages::ident.asc())
             .into_boxed();
 
@@ -863,6 +873,7 @@ impl Package {
             .inner_join(origins::table)
             .select(sql("concat_ws('/', origins.name, origin_packages.name)"))
             .filter(to_tsquery(format!("{}:*", sp.query)).matches(origin_packages::ident_vector))
+            .filter(origin_packages::hidden.eq(false))
             .order(origin_packages::name.asc())
             .into_boxed();
 
@@ -906,6 +917,7 @@ impl Package {
             .filter(origin_packages::name.eq(&ident.name))
             .filter(origin_packages::ident_array.contains(&searchable_ident(ident)))
             .filter(origin_packages::visibility.eq(any(visibilities)))
+            .filter(origin_packages::hidden.eq(false))
             .get_results(conn);
 
         let duration_millis = start_time.elapsed().as_millis();
@@ -1176,7 +1188,8 @@ impl FromArchive for NewPackage {
                         name: ident.name.to_string(),
                         owner_id: 999_999_999_999,
                         visibility: PackageVisibility::Public,
-                        package_type: BuilderPackageType(archive.package_type()?) })
+                        package_type: BuilderPackageType(archive.package_type()?),
+                        hidden: false,})
     }
 }
 

--- a/components/builder-db/src/models/settings.rs
+++ b/components/builder-db/src/models/settings.rs
@@ -34,6 +34,7 @@ pub struct OriginPackageSettings {
     pub visibility: PackageVisibility,
     #[serde(with = "db_id_format")]
     pub owner_id:   i64,
+    pub hidden: bool,
     pub created_at: Option<NaiveDateTime>,
     pub updated_at: Option<NaiveDateTime>,
 }

--- a/components/builder-db/src/models/settings.rs
+++ b/components/builder-db/src/models/settings.rs
@@ -34,7 +34,7 @@ pub struct OriginPackageSettings {
     pub visibility: PackageVisibility,
     #[serde(with = "db_id_format")]
     pub owner_id:   i64,
-    pub hidden: bool,
+    pub hidden:     bool,
     pub created_at: Option<NaiveDateTime>,
     pub updated_at: Option<NaiveDateTime>,
 }

--- a/components/builder-db/src/schema/package.rs
+++ b/components/builder-db/src/schema/package.rs
@@ -54,7 +54,7 @@ table! {
 
 table! {
     use crate::models::package::PackageVisibilityMapping;
-    use diesel::sql_types::{Array, BigInt, Integer, Text, Nullable, Timestamptz};
+    use diesel::sql_types::{Array, BigInt, Bool, Integer, Text, Nullable, Timestamptz};
     use diesel_full_text_search::TsVector;
     origin_packages {
         id -> BigInt,
@@ -77,6 +77,7 @@ table! {
         origin -> Text,
         ident_vector -> TsVector,
         package_type -> Text,
+        hidden -> Bool,
     }
 }
 

--- a/components/builder-db/src/schema/settings.rs
+++ b/components/builder-db/src/schema/settings.rs
@@ -1,6 +1,6 @@
 table! {
     use crate::models::package::PackageVisibilityMapping;
-    use diesel::sql_types::{BigInt, Nullable, Text, Timestamptz};
+    use diesel::sql_types::{BigInt, Bool, Nullable, Text, Timestamptz};
 
     origin_package_settings {
         id -> BigInt,
@@ -8,6 +8,7 @@ table! {
         name -> Text,
         visibility -> PackageVisibilityMapping,
         owner_id -> BigInt,
+        hidden -> Bool,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
     }


### PR DESCRIPTION
This hides origins and packages with `hidden=true` in ui, cli, and api. I think this captures all the key scenarios. There may be some edge cases like listing the keys of a hidden origin is possible. But adding yet another hidden column or adding a join did not seem worth it.