### PR TITLE
Updates deprecated 'hab sup status' commands to 'hab svc status' calls

### DIFF
--- a/.expeditor/templates/studiorc
+++ b/.expeditor/templates/studiorc
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
 cd /src || exit
 
-echo "--- Installing prerequisites" 
+echo "--- Installing prerequisites"
 hab pkg install core/openssl
 hab pkg install core/node --binlink
-hab pkg install core/coreutils 
+hab pkg install core/coreutils
 hab pkg binlink core/coreutils env -d /usr/bin
-( 
+(
   # At the point studiorc is evaluated, our cwd is /
   cd /src/test/builder-api || exit
-  npm install mocha 
+  npm install mocha
 )
 
 echo "--- Creating fake builder-github-app.pem"
 hab pkg exec core/openssl openssl genrsa \
-  -out /src/.secrets/builder-github-app.pem 2048 
+  -out /src/.secrets/builder-github-app.pem 2048
 
 echo "--- Creating log directory"
 mkdir -p logs
 echo "--- Starting the supervisor"
 env HAB_FUNC_TEST=1 hab sup run > logs/sup.log 2>&1 &
 
-until hab sup status >/dev/null 2>&1; 
+until hab svc status >/dev/null 2>&1;
   do echo "waiting for hab sup to start"
-  sleep 1 
+  sleep 1
 done
 
 echo "--- Starting builder"
@@ -31,13 +31,13 @@ start-builder
 
 while ! [ -f "/hab/svc/builder-api/files/builder-github-app.pem" ];
 do
-    echo "Waiting for builder-github-app.pem"
-    ls /hab/svc/builder-api/files
-    sleep 10
+  echo "Waiting for builder-github-app.pem"
+  ls /hab/svc/builder-api/files
+  sleep 10
 done
 
 # In most cases, these builds will be noise in the log files
-# Redirect the output into a file that is automatically uploaded 
+# Redirect the output into a file that is automatically uploaded
 # to buildkite so we can inspect if necessary
 echo "--- Building changed builder components"
 echo "--- Building builder-api"
@@ -45,7 +45,7 @@ echo "Redirecting log output; See build artifact 'builder-api.build.log'"
 build-builder api > logs/builder-api.build.log 2>&1
 
 echo "--- Waiting for services to start"
-while hab sup status | grep --quiet down;
+while hab svc status | grep --quiet down;
 do
   echo "Waiting for services to start..."
   sleep 10
@@ -54,9 +54,9 @@ done
 echo "--- Waiting for builder-github-app.pem to arrive"
 while ! [ -f "/hab/svc/builder-api/files/builder-github-app.pem" ];
 do
-    echo "Waiting for builder-github-app.pem"
-    ls /hab/svc/builder-api/files
-    sleep 10
+  echo "Waiting for builder-github-app.pem"
+  ls /hab/svc/builder-api/files
+  sleep 10
 done
 
 echo "--- :mocha: Running tests"

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -5,7 +5,7 @@ sleep 5
 
 pwfile=/hab/svc/builder-datastore/config/pwfile
 while [ ! -f $pwfile ] \
-&&  hab sup status habitat/builder-datastore > /dev/null 2>&1;
+&&  hab svc status habitat/builder-datastore > /dev/null 2>&1;
 do
   echo "Waiting for password"
   sleep 2
@@ -15,7 +15,7 @@ if [ -f $pwfile ]; then
   export PGPASSWORD
   PGPASSWORD=$(cat $pwfile)
 else
-  hab sup status
+  hab svc status
   echo "ERROR: $0: $pwfile does not exist and habitat/builder-datastore is not running"
   exit 1
 fi


### PR DESCRIPTION
While reviewing a build in buildkite I notice several messages about 'hab sup status' commands being deprecated in favor of 'hab svc status'.  This PR updates to using 'hab svc status'.