### PR TITLE
Taking cargo machete to our crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,26 +346,19 @@ dependencies = [
  "chrono",
  "dogstatsd",
  "env_proxy",
- "futures",
- "futures-util",
  "glob",
  "habitat-builder-protocol",
  "habitat_core",
  "lazy_static",
- "libarchive",
  "log",
- "petgraph",
  "protobuf",
- "rand",
  "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
  "tempfile",
- "tokio",
  "toml",
  "url",
- "walkdir",
  "zmq",
 ]
 
@@ -913,12 +906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,17 +1063,14 @@ version = "0.0.0"
 dependencies = [
  "base64 0.21.0",
  "builder_core",
- "env_proxy",
  "frank_jwt",
  "habitat_core",
  "log",
- "regex",
  "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
  "tokio",
- "url",
 ]
 
 [[package]]
@@ -1118,17 +1102,10 @@ dependencies = [
 name = "habitat-builder-protocol"
 version = "0.0.0"
 dependencies = [
- "fnv",
  "habitat_core",
- "lazy_static",
- "pkg-config",
  "protobuf",
- "protobuf-codegen",
- "protoc",
  "protoc-rust",
- "regex",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -1138,15 +1115,12 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "artifactory-client",
- "base64 0.21.0",
  "bitflags 1.3.2",
  "builder_core",
  "bytes",
  "chrono",
  "clap",
  "diesel",
- "diesel-derive-enum",
- "diesel_full_text_search",
  "env_logger",
  "features",
  "futures",
@@ -1154,7 +1128,6 @@ dependencies = [
  "habitat-builder-protocol",
  "habitat_builder_db",
  "habitat_core",
- "hex 0.4.3",
  "lazy_static",
  "log",
  "memcache",
@@ -1174,10 +1147,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "tempfile",
- "toml",
- "url",
  "uuid",
- "zmq",
 ]
 
 [[package]]
@@ -1191,13 +1161,11 @@ dependencies = [
  "diesel_full_text_search",
  "diesel_migrations",
  "fallible-iterator 0.2.0",
- "fnv",
  "habitat-builder-protocol",
  "habitat_core",
  "itertools",
  "log",
  "num_cpus",
- "paste",
  "percent-encoding",
  "postgres",
  "postgres-shared",
@@ -1205,11 +1173,8 @@ dependencies = [
  "protobuf",
  "r2d2",
  "r2d2_postgres",
- "rand",
  "serde",
  "serde_derive",
- "threadpool",
- "url",
 ]
 
 [[package]]
@@ -1563,26 +1528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libarchive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da06b22cd19af338a40f5d44a0aa6352ae43839d0855a049881cbc7e1b9c914"
-dependencies = [
- "libarchive3-sys",
- "libc",
-]
-
-[[package]]
-name = "libarchive3-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd3beae8f59a4c7a806523269b5392037577c150446e88d684dfa6de6031ca7"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,7 +1777,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "url",
 ]
 
 [[package]]
@@ -1991,16 +1935,6 @@ checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
 dependencies = [
  "thiserror",
  "ucd-trie",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
-dependencies = [
- "fixedbitset",
- "indexmap 1.9.2",
 ]
 
 [[package]]
@@ -2926,15 +2860,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]

--- a/components/artifactory-client/Cargo.toml
+++ b/components/artifactory-client/Cargo.toml
@@ -24,3 +24,6 @@ features = ["fs"]
 [dependencies.reqwest]
 version = "*"
 features = ["stream"]
+
+[package.metadata.cargo-machete]
+ignored = ["serde"]

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -15,16 +15,12 @@ doc = false
 [dependencies]
 actix-rt = "*"
 bytes = "*"
-base64 = "*"
 bitflags = "*"
 chrono = { version = "*", features = ["serde"] }
 diesel = { version = "*", features = ["postgres", "chrono", "serde_json", "r2d2"] }
-diesel-derive-enum = { version = "*", features = ["postgres"] }
-diesel_full_text_search = "*"
 env_logger = "*"
 features = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
-hex = "*"
 lazy_static = "*"
 log = "*"
 memcache = "*"
@@ -37,7 +33,6 @@ serde = "*"
 serde_derive = "*"
 serde_json = "*"
 sha2 = "*"
-toml = { version = "*", default-features = false }
 futures = "*"
 rand = "*"
 r2d2 = "*"
@@ -45,9 +40,7 @@ regex = "*"
 rusoto_core = "*"
 rusoto_s3 = "*"
 tempfile = "*"
-url = "*"
 uuid = { version = "*", features = ["v4"] }
-zmq = "*"
 
 [dependencies.actix-web]
 version = "*"

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -11,21 +11,15 @@ bitflags = "*"
 chrono = { version = "*", features = ["serde"] }
 dogstatsd = "*"
 env_proxy = "*"
-futures = "*"
-futures-util = "*"
 glob = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
 lazy_static = "*"
-libarchive = "*"
 log = "*"
-petgraph = "*"
 protobuf = "*"
-rand = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"
 toml = { version = "*", default-features = false }
-walkdir = "*"
 url = "*"
 zmq = "*"
 
@@ -36,9 +30,8 @@ git = "https://github.com/habitat-sh/habitat.git"
 version = "*"
 features = ["stream"]
 
-[dependencies.tokio]
-version = "*"
-features = ["fs", "io-util"]
-
 [dev-dependencies]
 tempfile = "*"
+
+[package.metadata.cargo-machete]
+ignored = ["zmq"]

--- a/components/builder-db/Cargo.toml
+++ b/components/builder-db/Cargo.toml
@@ -15,25 +15,23 @@ diesel_full_text_search = "*"
 diesel_migrations = "*"
 itertools = "*"
 r2d2 = "*"
-rand = "*"
 serde = "*"
 chrono = { version = "*", features = ["serde"] }
 serde_derive = "*"
 num_cpus = "*"
 protobuf = "*"
-fnv = "*"
-fallible-iterator = "*"
-paste = "*"
+fallible-iterator = "*" # TODO: Do we need this? Machete says we don't.
 percent-encoding = "*"
 postgres = "*"
 postgres-types = { version = "*", features = ["derive"] }
 postgres-shared = "*"
 r2d2_postgres = "*"
-threadpool = "*"
-url = "*"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
 
 [dependencies.builder_core]
 path = "../builder-core"
+
+[package.metadata.cargo-machete]
+ignored = ["fallible-iterator", "r2d2_postgres"]

--- a/components/builder-protocol/Cargo.toml
+++ b/components/builder-protocol/Cargo.toml
@@ -8,18 +8,14 @@ workspace = "../../"
 edition = "2018"
 
 [dependencies]
-fnv = "*"
 protobuf = "*"
 serde = "*"
-serde_derive = "*"
-regex = "*"
-lazy_static = "*"
 
 [dependencies.habitat_core]
 git = "https://github.com/habitat-sh/habitat.git"
 
 [build-dependencies]
-pkg-config = "*"
-protoc = "*"
 protoc-rust = "*"
-protobuf-codegen = "*"
+
+[package.metadata.cargo-machete]
+ignored = ["protoc-rust"]

--- a/components/github-api-client/Cargo.toml
+++ b/components/github-api-client/Cargo.toml
@@ -7,15 +7,12 @@ edition = "2018"
 
 [dependencies]
 base64 = "*"
-env_proxy = "*"
 frank_jwt = "*"
 log = "*"
-regex = "*"
 reqwest = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"
-url = "*"
 
 [dependencies.builder_core]
 path = "../builder-core"
@@ -25,4 +22,7 @@ git = "https://github.com/habitat-sh/habitat.git"
 
 [dependencies.tokio]
 version = "*"
-features = ["macros","rt-multi-thread"]
+features = ["macros", "rt-multi-thread"]
+
+[package.metadata.cargo-machete]
+ignored = ["serde"]

--- a/components/oauth-client/Cargo.toml
+++ b/components/oauth-client/Cargo.toml
@@ -13,8 +13,9 @@ reqwest = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"
-url = "*"
 
 [dependencies.builder_core]
 path = "../builder-core"
 
+[package.metadata.cargo-machete]
+ignored = ["serde"]


### PR DESCRIPTION
I found a couple of tools (machete, shears) when I was shrinking the builder code base that can be use to find unnecessary dependencies in a rust project. I took another look at those and decided they were fairly close and chose machete over shears. They seem roughly equivalent and I think that if we ever wanted to switch it should be rather easy.

Reasons that dependencies were removed include
- The dependency was already available as a transitive dependency
- The shrinking of the code base eliminated the need for the dependency

Serde was added to the ignore list because the parent crate is needed for the macros. Interestingly shears might be able to detect that in the future but that feature doesn’t seem to be done baking just yet and I liked the --with-metadata option in machete