### PR TITLE
remove restricted channel settings in default toml

### DIFF
--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -6,9 +6,9 @@ saas_bldr_url = "https://bldr.habitat.sh"
 license_server_url = "http://licensing-acceptance.chef.co"
 allowed_native_package_origins = []
 allowed_users_for_origin_create = []
-unrestricted_channels = ["LTS-2024"]
-partially_unrestricted_channels = ["stable"]
-restricted_if_present = ["base-2025"]
+unrestricted_channels = []
+partially_unrestricted_channels = []
+restricted_if_present = []
 
 [http]
 listen = "0.0.0.0"


### PR DESCRIPTION
We will manage the channels for license restrictions via user.toml for SAAS. In default.toml they should be empty so that on-prem instances are not impacted by license restrictions.