### PR TITLE
Updates diesel.rs attributes that were triggering compile warnings

### DIFF
--- a/components/builder-api/src/server/resources/reverse_dependencies.rs
+++ b/components/builder-api/src/server/resources/reverse_dependencies.rs
@@ -13,7 +13,7 @@ use crate::server::error::{Error,
 use r2d2::PooledConnection;
 #[derive(Clone, Debug, QueryableByName, Serialize, Deserialize)]
 pub(crate) struct Dependent {
-    #[sql_type = "Text"]
+    #[diesel(sql_type = Text)]
     pub short_id: String, // "origin/name"
 }
 

--- a/components/builder-db/src/models/account.rs
+++ b/components/builder-db/src/models/account.rs
@@ -23,7 +23,7 @@ pub struct Account {
 }
 
 #[derive(Identifiable, Debug, Serialize, Queryable)]
-#[table_name = "account_tokens"]
+#[diesel(table_name = account_tokens)]
 pub struct AccountToken {
     #[serde(with = "db_id_format")]
     pub id:         i64,
@@ -34,7 +34,7 @@ pub struct AccountToken {
 }
 
 #[derive(Insertable)]
-#[table_name = "accounts"]
+#[diesel(table_name = accounts)]
 pub struct NewAccount<'a> {
     pub email: &'a str,
     pub name:  &'a str,
@@ -81,7 +81,7 @@ impl Account {
 }
 
 #[derive(Insertable)]
-#[table_name = "account_tokens"]
+#[diesel(table_name = account_tokens)]
 pub struct NewAccountToken<'a> {
     pub account_id: i64,
     pub token:      &'a str,

--- a/components/builder-db/src/models/channel.rs
+++ b/components/builder-db/src/models/channel.rs
@@ -60,7 +60,7 @@ pub struct ChannelWithPromotion {
 }
 
 #[derive(Insertable)]
-#[table_name = "origin_channels"]
+#[diesel(table_name = origin_channels)]
 pub struct CreateChannel<'a> {
     // This would be ChannelIdent, but Insertable requires implementing diesel::Expression
     pub name:     &'a str,
@@ -608,7 +608,7 @@ impl From<Channel> for ChannelWithPromotion {
 }
 
 #[derive(Debug, Serialize, Deserialize, Insertable)]
-#[table_name = "audit_package"]
+#[diesel(table_name = audit_package)]
 pub struct PackageChannelAudit<'a> {
     pub package_ident:  BuilderPackageIdent,
     // This would be ChannelIdent, but Insertable requires implementing diesel::Expression
@@ -629,7 +629,7 @@ impl PackageChannelAudit<'_> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Insertable)]
-#[table_name = "audit_package_group"]
+#[diesel(table_name = audit_package_group)]
 pub struct PackageGroupChannelAudit<'a> {
     pub origin:         &'a str,
     // This would be ChannelIdent, but Insertable requires implementing diesel::Expression

--- a/components/builder-db/src/models/integration.rs
+++ b/components/builder-db/src/models/integration.rs
@@ -25,7 +25,7 @@ pub struct OriginIntegration {
 }
 
 #[derive(Insertable)]
-#[table_name = "origin_integrations"]
+#[diesel(table_name = origin_integrations)]
 pub struct NewOriginIntegration<'a> {
     pub origin:      &'a str,
     pub integration: &'a str,

--- a/components/builder-db/src/models/invitations.rs
+++ b/components/builder-db/src/models/invitations.rs
@@ -29,7 +29,7 @@ pub struct OriginInvitation {
 }
 
 #[derive(Insertable)]
-#[table_name = "origin_invitations"]
+#[diesel(table_name = origin_invitations)]
 pub struct NewOriginInvitation<'a> {
     pub origin:       &'a str,
     pub account_id:   i64,

--- a/components/builder-db/src/models/keys.rs
+++ b/components/builder-db/src/models/keys.rs
@@ -11,7 +11,7 @@ use diesel::{self,
              RunQueryDsl};
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
-#[table_name = "origin_public_encryption_keys"]
+#[diesel(table_name = origin_public_encryption_keys)]
 pub struct OriginPublicEncryptionKey {
     #[serde(with = "db_id_format")]
     pub id:         i64,
@@ -27,7 +27,7 @@ pub struct OriginPublicEncryptionKey {
 }
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
-#[table_name = "origin_private_encryption_keys"]
+#[diesel(table_name = origin_private_encryption_keys)]
 pub struct OriginPrivateEncryptionKey {
     #[serde(with = "db_id_format")]
     pub id:         i64,
@@ -43,7 +43,7 @@ pub struct OriginPrivateEncryptionKey {
 }
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
-#[table_name = "origin_secret_keys"]
+#[diesel(table_name = origin_secret_keys)]
 pub struct OriginPrivateSigningKey {
     #[serde(with = "db_id_format")]
     pub id:                 i64,
@@ -60,7 +60,7 @@ pub struct OriginPrivateSigningKey {
 }
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
-#[table_name = "origin_public_keys"]
+#[diesel(table_name = origin_public_keys)]
 pub struct OriginPublicSigningKey {
     #[serde(with = "db_id_format")]
     pub id:         i64,
@@ -76,7 +76,7 @@ pub struct OriginPublicSigningKey {
 }
 
 #[derive(Insertable)]
-#[table_name = "origin_public_encryption_keys"]
+#[diesel(table_name = origin_public_encryption_keys)]
 pub struct NewOriginPublicEncryptionKey<'a> {
     pub owner_id:  i64,
     pub name:      &'a str,
@@ -87,7 +87,7 @@ pub struct NewOriginPublicEncryptionKey<'a> {
 }
 
 #[derive(Insertable)]
-#[table_name = "origin_private_encryption_keys"]
+#[diesel(table_name = origin_private_encryption_keys)]
 pub struct NewOriginPrivateEncryptionKey<'a> {
     pub owner_id:  i64,
     pub name:      &'a str,
@@ -98,7 +98,7 @@ pub struct NewOriginPrivateEncryptionKey<'a> {
 }
 
 #[derive(Insertable)]
-#[table_name = "origin_secret_keys"]
+#[diesel(table_name = origin_secret_keys)]
 pub struct NewOriginPrivateSigningKey<'a> {
     pub owner_id:           i64,
     pub name:               &'a str,
@@ -110,7 +110,7 @@ pub struct NewOriginPrivateSigningKey<'a> {
 }
 
 #[derive(Insertable)]
-#[table_name = "origin_public_keys"]
+#[diesel(table_name = origin_public_keys)]
 pub struct NewOriginPublicSigningKey<'a> {
     pub owner_id:  i64,
     pub name:      &'a str,

--- a/components/builder-db/src/models/origin.rs
+++ b/components/builder-db/src/models/origin.rs
@@ -44,7 +44,7 @@ use std::{fmt,
 use diesel_derive_enum::DbEnum;
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
-#[table_name = "origins"]
+#[diesel(table_name = origins)]
 pub struct Origin {
     #[serde(with = "db_id_format")]
     pub owner_id: i64,
@@ -136,7 +136,7 @@ impl FromStr for OriginMemberRole {
 }
 
 #[derive(Debug, Serialize, Deserialize, Queryable, QueryableByName, Insertable)]
-#[table_name = "origin_members"]
+#[diesel(table_name = origin_members)]
 pub struct OriginMember {
     #[serde(with = "db_id_format")]
     pub account_id:  i64,
@@ -147,7 +147,7 @@ pub struct OriginMember {
 }
 
 #[derive(Insertable)]
-#[table_name = "origins"]
+#[diesel(table_name = origins)]
 pub struct NewOrigin<'a> {
     pub name: &'a str,
     pub owner_id: i64,
@@ -164,7 +164,7 @@ pub enum OriginOperation {
 }
 
 #[derive(Debug, Serialize, Deserialize, Insertable)]
-#[table_name = "audit_origin"]
+#[diesel(table_name = audit_origin)]
 struct OriginAudit<'a> {
     operation:      OriginOperation,
     origin:         &'a str,

--- a/components/builder-db/src/models/package.rs
+++ b/components/builder-db/src/models/package.rs
@@ -72,7 +72,7 @@ use diesel_derive_enum::DbEnum;
          Queryable,
          Clone,
          Identifiable)]
-#[table_name = "origin_packages"]
+#[diesel(table_name = origin_packages)]
 pub struct Package {
     #[serde(with = "db_id_format")]
     pub id:           i64,
@@ -104,7 +104,7 @@ pub struct Package {
          Queryable,
          Clone,
          Identifiable)]
-#[table_name = "origin_packages_with_version_array"]
+#[diesel(table_name = origin_packages_with_version_array)]
 pub struct PackageWithVersionArray {
     #[serde(with = "db_id_format")]
     pub id:            i64,
@@ -138,7 +138,7 @@ pub struct PackageWithVersionArray {
          Clone,
          Identifiable,
          Eq)]
-#[table_name = "packages_with_channel_platform"]
+#[diesel(table_name = packages_with_channel_platform)]
 pub struct PackageWithChannelPlatform {
     #[serde(with = "db_id_format")]
     pub id:          i64,
@@ -287,7 +287,7 @@ type AllWithVersion =
     diesel::dsl::Select<origin_packages_with_version_array::table, AllColumnsWithVersion>;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable)]
-#[table_name = "origin_packages"]
+#[diesel(table_name = origin_packages)]
 pub struct NewPackage {
     pub origin:       String,
     #[serde(with = "db_id_format")]

--- a/components/builder-db/src/models/project_integration.rs
+++ b/components/builder-db/src/models/project_integration.rs
@@ -22,7 +22,7 @@ use crate::{bldr_core::metrics::CounterMetric,
          QueryableByName,
          Queryable,
          Identifiable)]
-#[table_name = "origin_project_integrations"]
+#[diesel(table_name = origin_project_integrations)]
 pub struct ProjectIntegration {
     #[serde(with = "db_id_format")]
     pub id:             i64,

--- a/components/builder-db/src/models/projects.rs
+++ b/components/builder-db/src/models/projects.rs
@@ -15,7 +15,7 @@ use crate::{bldr_core::metrics::CounterMetric,
             metrics::Counter};
 
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Queryable)]
-#[table_name = "origin_projects"]
+#[diesel(table_name = origin_projects)]
 pub struct Project {
     #[serde(with = "db_id_format")]
     pub id:                  i64,
@@ -36,7 +36,7 @@ pub struct Project {
 }
 
 #[derive(Insertable)]
-#[table_name = "origin_projects"]
+#[diesel(table_name = origin_projects)]
 pub struct NewProject<'a> {
     pub owner_id:            i64,
     pub origin:              &'a str,
@@ -51,7 +51,7 @@ pub struct NewProject<'a> {
 }
 
 #[derive(AsChangeset)]
-#[table_name = "origin_projects"]
+#[diesel(table_name = origin_projects)]
 pub struct UpdateProject<'a> {
     pub id:                  i64,
     pub owner_id:            i64,

--- a/components/builder-db/src/models/secrets.rs
+++ b/components/builder-db/src/models/secrets.rs
@@ -35,7 +35,7 @@ pub struct OriginSecretWithOriginId {
 }
 
 #[derive(Insertable)]
-#[table_name = "origin_secrets"]
+#[diesel(table_name = origin_secrets)]
 pub struct NewOriginSecret<'a> {
     pub owner_id: i64,
     pub origin:   &'a str,

--- a/components/builder-db/src/models/settings.rs
+++ b/components/builder-db/src/models/settings.rs
@@ -24,7 +24,7 @@ use crate::{bldr_core::metrics::CounterMetric,
          Clone,
          PartialEq,
          Identifiable)]
-#[table_name = "origin_package_settings"]
+#[diesel(table_name = origin_package_settings)]
 pub struct OriginPackageSettings {
     #[serde(with = "db_id_format")]
     pub id:         i64,
@@ -39,7 +39,7 @@ pub struct OriginPackageSettings {
 }
 
 #[derive(Debug, Insertable)]
-#[table_name = "origin_package_settings"]
+#[diesel(table_name = origin_package_settings)]
 pub struct NewOriginPackageSettings<'a> {
     pub origin:     &'a str,
     pub name:       &'a str,
@@ -48,7 +48,7 @@ pub struct NewOriginPackageSettings<'a> {
 }
 
 #[derive(AsChangeset, Debug)]
-#[table_name = "origin_package_settings"]
+#[diesel(table_name = origin_package_settings)]
 pub struct UpdateOriginPackageSettings<'a> {
     pub origin:     &'a str,
     pub name:       &'a str,


### PR DESCRIPTION
In [this comment](https://github.com/habitat-sh/builder/pull/1892#issuecomment-3007153413) @agadgil-progress pointed out some compile time warnings from diesel.rs attributes that I didn't want to fix because it was another thing on an already extremely noisy branch.  I double checked and they were still there after merging so this PR addresses them.