### PR TITLE
Fixes verify pipeline and a bit of hygeine

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ $BUILDKITE_ORGANIZATION_SLUG = 'chef-canary' ]]; then
+  AWS_REGION='us-west-1'
+elif [[ $BUILDKITE_ORGANIZATION_SLUG = 'chef' ]] || [[ $BUILDKITE_ORGANIZATION_SLUG = 'chef-oss' ]]; then
+  AWS_REGION='us-west-2'
+fi
+
+HAB_AUTH_TOKEN=$(aws ssm get-parameter --name 'habitat-prod-auth-token' --with-decryption --query Parameter.Value --output text --region "${AWS_REGION}")
+export HAB_AUTH_TOKEN

--- a/.expeditor/builder_seed.toml
+++ b/.expeditor/builder_seed.toml
@@ -2,7 +2,7 @@ format_version = 1
 file_descriptor = "Packages needed to run an instance of Builder"
 
 [[x86_64-linux]]
-channel = "acceptance"
+channel = "stable"
 packages = [
   # Supervisor and prerequisites
   "chef/hab-launcher",

--- a/.expeditor/builder_seed.toml
+++ b/.expeditor/builder_seed.toml
@@ -2,12 +2,12 @@ format_version = 1
 file_descriptor = "Packages needed to run an instance of Builder"
 
 [[x86_64-linux]]
-channel = "stable"
+channel = "acceptance"
 packages = [
   # Supervisor and prerequisites
-  "core/hab-launcher",
-  "core/hab",
-  "core/hab-sup",
+  "chef/hab-launcher",
+  "chef/hab",
+  "chef/hab-sup",
 ]
 
 [[x86_64-linux]]

--- a/.expeditor/scripts/verify/builder-api-functional.sh
+++ b/.expeditor/scripts/verify/builder-api-functional.sh
@@ -2,15 +2,25 @@
 
 set -euo pipefail
 
+readonly channel='acceptance'
+
 # 10/11/2024: We need to use the most recent hab binary that is not yet in stable
 # to build against LTS without conflicts with existing stable packages
-hab pkg install core/hab --channel acceptance -bf
+hab pkg install chef/hab --channel="${channel}" --binlink --force
+
+# 2025-07-16: Installing these works around a bug that exists at the
+# current time where the HAB_AUTH_TOKEN isn't read  when packages are
+# automatically installed by calls to different hab commands.
+# See https://progresssoftware.atlassian.net/browse/CHEF-23525
+hab pkg install chef/hab-studio --channel="${channel}" --binlink --force
+hab pkg install chef/hab-sup --channel="${channel}" --binlink --force
+hab pkg install chef/hab-launcher --channel="${channel}" --binlink --force
 
 echo "--- Generating signing key"
 hab origin key generate "$HAB_ORIGIN"
 
-echo "--- Updating .studiorc" 
-cat .expeditor/templates/studiorc >> .studiorc
+echo "--- Updating .studiorc"
+cat .expeditor/templates/studiorc >>.studiorc
 
 echo "--- Copying habitat-env"
 cp .secrets/habitat-env.sample .secrets/habitat-env
@@ -18,6 +28,6 @@ cp .secrets/habitat-env.sample .secrets/habitat-env
 echo "--- Entering studio"
 env HAB_NONINTERACTIVE=true \
     HAB_STUDIO_SUP=false \
-    HAB_INTERNAL_BLDR_CHANNEL=acceptance \
-    HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL=acceptance \
+    HAB_INTERNAL_BLDR_CHANNEL="${channel}" \
+    HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL="${channel}" \
     hab studio enter

--- a/.expeditor/templates/studiorc
+++ b/.expeditor/templates/studiorc
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# This file (.expeditor/templates/studiorc) is concatenated onto .studiorc when
+# .expeditor/scripts/verify/builder-api-functional.sh runs.  
+
 cd /src || exit
 
 echo "--- Installing prerequisites"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -3,18 +3,14 @@ expeditor:
     buildkite:
       timeout_in_minutes: 30
       env:
-          HAB_BLDR_CHANNEL: LTS-2024
-          HAB_REFRESH_CHANNEL: LTS-2024
-          HAB_FALLBACK_CHANNEL: LTS-2024
-          HAB_STUDIO_SECRET_HAB_BLDR_CHANNEL: LTS-2024
-          HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: LTS-2024
-          HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: LTS-2024
+        HAB_BLDR_CHANNEL: LTS-2024
+        HAB_REFRESH_CHANNEL: LTS-2024
+        HAB_FALLBACK_CHANNEL: LTS-2024
+        HAB_STUDIO_SECRET_HAB_BLDR_CHANNEL: LTS-2024
+        HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: LTS-2024
+        HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: LTS-2024
 
 steps:
-#######################################################################
-# Linting!
-#######################################################################
-
   - label: "[lint] :linux: :bash: Shellcheck"
     command:
       - ./test/shellcheck.sh
@@ -52,10 +48,6 @@ steps:
     expeditor:
       executor:
         docker:
-
-#######################################################################
-# Unit Tests - Linux!
-#######################################################################
 
   - label: "[unit] :linux: builder-api"
     command:
@@ -125,6 +117,7 @@ steps:
         docker:
           privileged: true
           environment:
+            - HAB_AUTH_TOKEN
             - HAB_ORIGIN=habitat
             - HAB_STUDIO_SECRET_NODE_OPTIONS="--dns-result-order=ipv4first"
 
@@ -141,7 +134,4 @@ steps:
           privileged: true
           environment:
             - HAB_ORIGIN=habitat
-            # The following variables are only set inside `studio` and how we enter
-            # `studio` should not matter.
-            # test test
             - HAB_STUDIO_SECRET_NODE_OPTIONS="--dns-result-order=ipv4first"


### PR DESCRIPTION
- Works around a bug in hab 2.0 for .expeditor/scripts/verify/builder-api-functional.sh by
  - now explicitly installing hab-studio, hab-sup, and hab-launcher as a workaround
  - exporting HAB_AUTH_TOKEN as appropriate for chef-oss pipelines so that it's available
- Does a s/core/chef/ in .expeditor/builder_seed.toml
- Removes #! and adds comment to .expeditor/templates/studiorc
  - this cleans up the concatenation of .expeditor/templates/studiorc and helps makes that a bit more explicit
- Removes some comments from there verify piepline that were "sectioning" as well as one that is ~base knowledge for hab team but wasn't mirrored in other pipelines so why have this extra bit.
- makes a white space change in the verify pipeline to eliminate extra indentation in the yaml comb structure.
  - I just had to fix another yaml file's comb structure after dependabot added something and it's service began choking until things where cleaned up. 