### PR TITLE
CHEF-23586: Update license handling for SaaS users

### DIFF
--- a/components/builder-web/app/actions/users.ts
+++ b/components/builder-web/app/actions/users.ts
@@ -286,6 +286,11 @@ export function fetchLicenseKey(token: string) {
         if (typeof msg === 'string' && msg.length > 1 && msg[0] === '"' && msg[msg.length - 1] === '"') {
           msg = msg.substring(1, msg.length - 1);
         }
+        // Handle 404 errors specifically for license API
+        if (msg.includes('404') || msg.includes('Not Found')) {
+          // For 404s, we don't need to show an error message to user
+          msg = null;
+        }
         dispatch({
           type: FETCH_LICENSE_KEY_FAILED,
           payload: { errorMessage: msg }

--- a/components/builder-web/app/events/events-routing.module.ts
+++ b/components/builder-web/app/events/events-routing.module.ts
@@ -18,17 +18,18 @@ import { Routes, RouterModule } from '@angular/router';
 import { EventsComponent } from './events/events.component';
 import { EventsSaaSComponent } from './events-saas/events-saas.component';
 import { LicenseRequiredGuard } from '../shared/guards/license-required.guard';
+import { SignedInGuard } from '../shared/guards/signed-in.guard';
 
 const routes: Routes = [
   {
     path: 'events',
     component: EventsComponent,
-    canActivate: [LicenseRequiredGuard]
+    canActivate: [SignedInGuard, LicenseRequiredGuard]
   },
   {
     path: 'events/saas',
     component: EventsSaaSComponent,
-    canActivate: [LicenseRequiredGuard]
+    canActivate: [SignedInGuard, LicenseRequiredGuard]
   }
 ];
 

--- a/components/builder-web/app/origin/origin-page/origin-page-routing.module.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page-routing.module.ts
@@ -26,53 +26,59 @@ import { BuilderEnabledGuard } from '../../shared/guards/builder-enabled.guard';
 import { VisibilityEnabledGuard } from '../../shared/guards/visibility-enabled.guard';
 import { OriginMemberGuard } from '../../shared/guards/origin-member.guard';
 import { SignedInGuard } from '../../shared/guards/signed-in.guard';
+import { LicenseRequiredGuard } from '../../shared/guards/license-required.guard';
 
 const routes: Routes = [
   {
     path: 'origins/:origin',
     component: OriginPageComponent,
+    canActivate: [SignedInGuard, LicenseRequiredGuard],
     children: [
       {
         path: '',
         redirectTo: 'packages',
-        pathMatch: 'full'
+        pathMatch: 'full',
+        canActivate: [SignedInGuard, LicenseRequiredGuard]
       },
       {
         path: 'packages',
-        component: OriginPackagesTabComponent
+        component: OriginPackagesTabComponent,
+        canActivate: [SignedInGuard, LicenseRequiredGuard]
       },
       {
         path: 'keys',
-        component: OriginKeysTabComponent
+        component: OriginKeysTabComponent,
+        canActivate: [SignedInGuard, LicenseRequiredGuard]
       },
       {
         path: 'members',
         component: OriginMembersTabComponent,
-        canActivate: [SignedInGuard, OriginMemberGuard],
+        canActivate: [SignedInGuard, OriginMemberGuard, LicenseRequiredGuard],
       },
       {
         path: 'settings',
         component: OriginSettingsTabComponent,
-        canActivate: [VisibilityEnabledGuard, SignedInGuard, OriginMemberGuard],
+        canActivate: [VisibilityEnabledGuard, SignedInGuard, OriginMemberGuard, LicenseRequiredGuard],
       },
       {
         path: 'integrations',
         component: OriginIntegrationsTabComponent,
-        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard, LicenseRequiredGuard]
       },
       {
         path: 'jobs',
         component: OriginJobsTabComponent,
-        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard, LicenseRequiredGuard]
       },
       {
         path: 'jobs/:id',
         component: OriginJobDetailComponent,
-        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard]
+        canActivate: [BuilderEnabledGuard, SignedInGuard, OriginMemberGuard, LicenseRequiredGuard]
       },
       {
         path: '**',
-        redirectTo: 'packages'
+        redirectTo: 'packages',
+        canActivate: [SignedInGuard, LicenseRequiredGuard]
       }
     ]
   }

--- a/components/builder-web/app/package/package-routing.module.ts
+++ b/components/builder-web/app/package/package-routing.module.ts
@@ -32,22 +32,22 @@ const routes: Routes = [
   {
     path: 'pkgs/:origin/:name',
     component: PackageComponent,
-    canActivate: [LicenseRequiredGuard],
+    canActivate: [SignedInGuard, LicenseRequiredGuard],
     children: [
       {
         path: '',
         component: PackageVersionsComponent,
-        canActivate: [LicenseRequiredGuard]
+        canActivate: [SignedInGuard, LicenseRequiredGuard]
       },
       {
         path: 'latest',
         component: PackageLatestComponent,
-        canActivate: [LicenseRequiredGuard]
+        canActivate: [SignedInGuard, LicenseRequiredGuard]
       },
       {
         path: 'latest/:target',
         component: PackageLatestComponent,
-        canActivate: [LicenseRequiredGuard]
+        canActivate: [SignedInGuard, LicenseRequiredGuard]
       },
       {
         path: 'jobs',
@@ -72,12 +72,12 @@ const routes: Routes = [
       {
         path: ':version',
         component: PackageVersionsComponent,
-        canActivate: [LicenseRequiredGuard]
+        canActivate: [SignedInGuard, LicenseRequiredGuard]
       },
       {
         path: ':version/:release',
         component: PackageReleaseComponent,
-        canActivate: [LicenseRequiredGuard]
+        canActivate: [SignedInGuard, LicenseRequiredGuard]
       },
       {
         path: ':version/:release/settings',

--- a/components/builder-web/app/reducers/users.ts
+++ b/components/builder-web/app/reducers/users.ts
@@ -90,7 +90,7 @@ export default function users(state = initialState['users'], action) {
         .setIn(['current', 'license', 'licenseKey'], null)
         .setIn(['current', 'license', 'expirationDate'], null)
         .setIn(['current', 'license', 'fetchedLicenseMessage'], action.payload.errorMessage || null)
-        .setIn(['current', 'license', 'isValid'], null);
+        .setIn(['current', 'license', 'isValid'], false); // Set to false instead of null to prevent refetch
 
     default:
       return state;

--- a/components/builder-web/app/routes.ts
+++ b/components/builder-web/app/routes.ts
@@ -14,12 +14,15 @@
 
 import { Routes, RouterModule } from '@angular/router';
 import { SignInPageComponent } from './sign-in-page/sign-in-page.component';
+import { SignedInGuard } from './shared/guards/signed-in.guard';
+import { LicenseRequiredGuard } from './shared/guards/license-required.guard';
 
 export const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
-    redirectTo: 'origins'
+    redirectTo: 'origins',
+    canActivate: [SignedInGuard, LicenseRequiredGuard]
   },
   {
     path: 'sign-in',
@@ -27,7 +30,8 @@ export const routes: Routes = [
   },
   {
     path: '*',
-    redirectTo: '/pkgs/core'
+    redirectTo: '/pkgs/core',
+    canActivate: [SignedInGuard, LicenseRequiredGuard]
   }
 ];
 

--- a/components/builder-web/app/search/search-routing.module.ts
+++ b/components/builder-web/app/search/search-routing.module.ts
@@ -16,22 +16,23 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { SearchComponent } from './search/search.component';
 import { LicenseRequiredGuard } from '../shared/guards/license-required.guard';
+import { SignedInGuard } from '../shared/guards/signed-in.guard';
 
 const routes: Routes = [
   {
     path: 'search',
     component: SearchComponent,
-    canActivate: [LicenseRequiredGuard]
+    canActivate: [SignedInGuard, LicenseRequiredGuard]
   },
   {
     path: 'pkgs/:origin',
     component: SearchComponent,
-    canActivate: [LicenseRequiredGuard]
+    canActivate: [SignedInGuard, LicenseRequiredGuard]
   },
   {
     path: 'pkgs',
     redirectTo: '/pkgs/core',
-    canActivate: [LicenseRequiredGuard]
+    canActivate: [SignedInGuard, LicenseRequiredGuard]
   }
 ];
 

--- a/components/builder-web/app/shared/guards/license-required.guard.ts
+++ b/components/builder-web/app/shared/guards/license-required.guard.ts
@@ -1,29 +1,130 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { AppStore } from '../../app.store';
+import { fetchLicenseKey } from '../../actions/index';
 import config from '../../config';
 
 @Injectable()
 export class LicenseRequiredGuard implements CanActivate {
+  private fetchAttempted = false;
+  private licenseFetchPromise: Promise<void> = null;
 
   constructor(private store: AppStore, private router: Router) {}
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
     // Allow all navigation if not SaaS mode
     if (!config.is_saas) {
-      return true;
+      return Promise.resolve(true);
     }
-    const licenseValid = this.store.getState().users.current.license.isValid;
+    const appState = this.store.getState();
+    const isSignedIn = !!appState.session.token;
+    // If user is not signed in, deny navigation (SignedInGuard will handle sign-in)
+    if (!isSignedIn) {
+      return Promise.resolve(false);
+    }
+    // Allow access to profile page even without valid license (for SaaS users to add license)
+    if (state.url === '/profile') {
+      return Promise.resolve(true);
+    }
+    // For all other routes, check license validity
+    return new Promise((resolve) => {
+      this.handleLicenseValidation(resolve, state.url);
+    });
+  }
 
-    // If license is invalid, redirect to profile page
-    if (!licenseValid) {
-      if (this.router.url !== '/profile') {
-        this.router.navigate(['/profile']);
+  private handleLicenseValidation(resolve, requestedUrl?: string) {
+    const appState = this.store.getState();
+    const license = appState.users.current.license;
+    const isValid = license && (license.get ? license.get('isValid') : license.isValid);
+    const licenseFetchInProgress = license && (license.get ? license.get('licenseFetchInProgress') : license.licenseFetchInProgress);
+    const isSigningIn = appState.users.current.isSigningIn;
+    // If license fetch is in progress or user is signing in, wait for completion
+    if (licenseFetchInProgress || isSigningIn) {
+      const unsub = this.store.subscribe(newState => {
+        const newLicense = newState.users.current.license;
+        const newLicenseFetchInProgress = newLicense && (newLicense.get ? newLicense.get('licenseFetchInProgress') : newLicense.licenseFetchInProgress);
+        const newIsSigningIn = newState.users.current.isSigningIn;
+        if (!newLicenseFetchInProgress && !newIsSigningIn) {
+          unsub();
+          setTimeout(() => {
+            this.handleLicenseValidation(resolve, requestedUrl);
+          }, 0);
+        }
+      });
+      return;
+    }
+    // If license validity is unknown, fetch it
+    if (isValid === null) {
+      // If license fetch promise already exists, wait for it
+      if (this.licenseFetchPromise) {
+        this.licenseFetchPromise.then(() => {
+          setTimeout(() => {
+            this.handleLicenseValidation(resolve, requestedUrl);
+          }, 0);
+        }).catch(() => {
+          // If license fetch failed, redirect to profile
+          this.router.navigate(['/profile']);
+          resolve(true);
+        });
+        return;
       }
-      return false;
+      if (!this.fetchAttempted) {
+        // Starting license fetch
+        this.fetchAttempted = true;
+        // Create promise to track license fetch and prevent multiple calls
+        this.licenseFetchPromise = new Promise<void>((resolveFetch, rejectFetch) => {
+          this.store.dispatch(fetchLicenseKey(appState.session.token));
+          // Set timeout to prevent infinite waiting
+          const timeout = setTimeout(() => {
+            this.licenseFetchPromise = null;
+            this.fetchAttempted = false; // Reset to allow retry
+            rejectFetch(new Error('License fetch timeout'));
+          }, 10000);
+          // Wait for license fetch to complete
+          const unsub = this.store.subscribe(newState => {
+            const newLicense = newState.users.current.license;
+            const newLicenseFetchInProgress = newLicense && (newLicense.get ? newLicense.get('licenseFetchInProgress') : newLicense.licenseFetchInProgress);
+            if (!newLicenseFetchInProgress) {
+              clearTimeout(timeout);
+              unsub();
+              this.licenseFetchPromise = null;
+              // Check if fetch failed (404 case)
+              const fetchedMessage = newLicense && (newLicense.get ? newLicense.get('fetchedLicenseMessage') : newLicense.fetchedLicenseMessage);
+              if (fetchedMessage) {
+                // License fetch failed (e.g., 404 - user has no license)
+                rejectFetch(new Error(fetchedMessage));
+              } else {
+                // License fetch completed successfully
+                resolveFetch();
+              }
+            }
+          });
+        });
+        // Wait for fetch completion then re-validate
+        this.licenseFetchPromise.then(() => {
+          setTimeout(() => {
+            this.handleLicenseValidation(resolve, requestedUrl);
+          }, 0);
+        }).catch(() => {
+          // If license fetch failed (e.g., 404), redirect to profile
+          this.router.navigate(['/profile']);
+          resolve(true);
+        });
+        return;
+      } else {
+        // License fetch was already attempted but still null - redirect to profile
+        this.router.navigate(['/profile']);
+        resolve(true);
+        return;
+      }
     }
-
     // If license is valid, allow navigation
-    return true;
+    if (isValid === true) {
+      resolve(true);
+    } else {
+      // License is invalid/expired, redirect to profile
+      this.router.navigate(['/profile']);
+      resolve(true);
+    }
   }
 }


### PR DESCRIPTION
## Description:
1) On-prem (non SaaS) users may not be signed or have valid license to access any routes.
2) SaaS users with valid license are allowed to access all routes after signing in and are by default moved to /origins page.
3) SaaS users without license get 404 code and after signed-in has to stay on /profile page till license is provided.
4) SaaS users with expired license should also stay on /profile page after sign-in till valid license is provided.
5) On refresh the users should remain on same page, if still signed-in.

## Issues:
https://progresssoftware.atlassian.net/browse/CHEF-23586

## Recordings:
On-prem (hosted=false)

https://github.com/user-attachments/assets/bfd6a78b-675d-427e-ab85-d897f4bb4963

SaaS (hosted=true)

https://github.com/user-attachments/assets/2190eec6-082a-47d0-acbe-5c15754c04e9



