### PR TITLE
CHEF-25809 - Standardize - Removing SLA from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ If you are looking for on-premise installation, please visit [On-Premise Builder
 
 To learn more about Habitat, please visit the [Habitat website](https://www.habitat.sh).
 
-**Umbrella Project**: [Habitat](https://github.com/habitat-sh/habitat)
-
 ## Building
 
 See [DEVELOPING.md](dev-docs/dev-environment.md) for information on setting up a Builder Dev Environment


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.
This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025).
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).