### PR TITLE
do not swallow oauth provider errors. let their light shine

### DIFF
--- a/components/builder-api/src/server/resources/authenticate.rs
+++ b/components/builder-api/src/server/resources/authenticate.rs
@@ -49,11 +49,12 @@ async fn authenticate(path: Path<String>, state: Data<AppState>) -> HttpResponse
 
     match do_authenticate(&code, &state).await {
         Ok(session) => HttpResponse::Ok().json(session),
-        Err(Error::OAuth(OAuthError::HttpResponse(_code, _response))) => {
-            HttpResponse::new(StatusCode::UNAUTHORIZED)
+        Err(Error::OAuth(OAuthError::HttpResponse(_code, response))) => {
+            // Include the oauth provider error response in the HTTP response
+            HttpResponse::build(StatusCode::UNAUTHORIZED).body(response)
         }
         Err(e) => {
-            warn!("Oauth client error, {:?}", e);
+            warn!("OAuth client error, {:?}", e);
             e.into()
         }
     }


### PR DESCRIPTION
If an oauth provider like github returns an error due to some obsure downstream issue with token provisioning, these errors are lost to us. This should help us debug scenarios like the one we had with a customer who had azureAD integrated as a SSO provider for their github accounts that was not configured to provide tokens. 