### PR TITLE
sync habitat_core commit with habitat_win_users to e7e37ab8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/habitat.git#aff457eb48ae3894c83dca2afbbe3a886296a92c"
+source = "git+https://github.com/habitat-sh/habitat.git#e7e37ab822f15799cee603ae2087bc3944ce6601"
 dependencies = [
  "cc",
  "log",


### PR DESCRIPTION
This updates habitat_core to include the aarch64-windows target